### PR TITLE
feat(supabase): add core schema migration, cloud CLI docs, and CI db push workflow

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -1,0 +1,66 @@
+# Apply pending SQL migrations from supabase/migrations/ to the linked Supabase Cloud project.
+# Requires repository secrets (see docs/DEV_SETUP.md §4).
+#
+# - push to main: applies migrations (supabase db push)
+# - pull_request: dry-run only (supabase db push --dry-run) when migration files change
+# - workflow_dispatch: manual deploy
+
+name: Supabase migrations
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'supabase/migrations/**'
+      - '.github/workflows/supabase-migrations.yml'
+  pull_request:
+    paths:
+      - 'supabase/migrations/**'
+      - '.github/workflows/supabase-migrations.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # Validate that migrations apply cleanly without mutating the remote DB.
+  dry-run:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link project (non-interactive)
+        run: supabase link --project-ref "$SUPABASE_PROJECT_ID"
+
+      - name: Dry-run migrations
+        run: supabase db push --dry-run --yes
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link project (non-interactive)
+        run: supabase link --project-ref "$SUPABASE_PROJECT_ID"
+
+      - name: Push migrations to Supabase Cloud
+        run: supabase db push --yes

--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -4,6 +4,8 @@
 # - push to main: applies migrations (supabase db push)
 # - pull_request: dry-run only (supabase db push --dry-run) when migration files change
 # - workflow_dispatch: manual deploy
+# Concurrency: one run at a time per branch/ref so overlapping supabase db push jobs do not
+# contend on the remote migration history (especially main → cloud).
 
 name: Supabase migrations
 
@@ -26,6 +28,10 @@ env:
 
 permissions:
   contents: read
+
+concurrency:
+  group: supabase-migrations-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   # Validate that migrations apply cleanly without mutating the remote DB.

--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -20,6 +20,10 @@ on:
       - '.github/workflows/supabase-migrations.yml'
   workflow_dispatch:
 
+# Pin CLI for reproducible db push / dry-run; bump when you intentionally adopt a new CLI.
+env:
+  SUPABASE_CLI_VERSION: 2.84.4
+
 permissions:
   contents: read
 
@@ -37,7 +41,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: latest
+          version: ${{ env.SUPABASE_CLI_VERSION }}
 
       - name: Link project (non-interactive)
         run: supabase link --project-ref "$SUPABASE_PROJECT_ID"
@@ -57,7 +61,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: latest
+          version: ${{ env.SUPABASE_CLI_VERSION }}
 
       - name: Link project (non-interactive)
         run: supabase link --project-ref "$SUPABASE_PROJECT_ID"

--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -3,7 +3,8 @@
 #
 # - push to main: applies migrations (supabase db push)
 # - pull_request: dry-run only (supabase db push --dry-run) when migration files change
-# - workflow_dispatch: manual deploy
+# - workflow_dispatch: manual deploy (deploy job only runs on refs/heads/main so a mistaken
+#   dispatch from a feature branch cannot push unmerged migrations to the linked project).
 # Concurrency: one run at a time per branch/ref so overlapping supabase db push jobs do not
 # contend on the remote migration history (especially main → cloud).
 
@@ -56,7 +57,7 @@ jobs:
         run: supabase db push --dry-run --yes
 
   deploy:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -163,7 +163,74 @@ Get URLs and keys from the [Supabase dashboard](https://supabase.com/dashboard):
 
 ---
 
-## 4. Verify the workspace
+## 4. Supabase database migrations (cloud CLI and CI)
+
+App environment variables (`NEXT_PUBLIC_SUPABASE_URL`, keys) let clients call the **Data API**; they do **not** apply SQL from the repo. Schema changes live in [`supabase/migrations/`](../supabase/migrations/) and must be applied to your hosted Postgres with the **Supabase CLI** (or an equivalent process).
+
+Official reference: [Managing Environments](https://supabase.com/docs/guides/cli/managing-environments) (CLI + GitHub Actions).
+
+### Install and sign in to the CLI
+
+From the repo root (or install the CLI globally per [Supabase CLI docs](https://supabase.com/docs/guides/cli)):
+
+```bash
+pnpm dlx supabase --version
+pnpm dlx supabase login
+```
+
+`supabase login` opens a browser or accepts a **personal access token** from the dashboard: [Account → Access Tokens](https://supabase.com/dashboard/account/tokens). The CLI stores credentials for local use; it is not the same key as your app’s publishable/anon key.
+
+### Link this repo to your Supabase project
+
+You need your **project ref** (the id in the dashboard URL: `https://supabase.com/dashboard/project/<project-ref>`).
+
+```bash
+pnpm dlx supabase link --project-ref <project-ref>
+```
+
+The CLI will prompt for the **database password** unless you set it in the environment (useful for scripts and CI):
+
+```bash
+export SUPABASE_DB_PASSWORD='<database-password>'
+pnpm dlx supabase link --project-ref <project-ref>
+```
+
+Find or reset the database password under **Project Settings → Database** in the [Supabase dashboard](https://supabase.com/dashboard) (not the API keys screen).
+
+Linking writes local metadata (under `supabase/`, gitignored where appropriate) so commands like `db push` know which remote database to target.
+
+### Push pending migrations to Supabase Cloud
+
+After new files exist in `supabase/migrations/`, apply them to the linked project:
+
+```bash
+pnpm dlx supabase db push
+```
+
+Useful variants:
+
+- **`pnpm dlx supabase db push --dry-run`** — prints which migrations would run without applying them (good for checks before merge).
+- **`pnpm dlx supabase migration list`** — compare local and remote migration history.
+
+`supabase db reset` (recreate local DB + run migrations + `seed.sql`) is for **local** development with Docker and the Supabase stack; it does not run against your online project. **`seed.sql`** is not applied to production unless you intentionally use a seeding path (the default cloud workflow is migrations only).
+
+### GitHub Actions (this repository)
+
+The workflow [`.github/workflows/supabase-migrations.yml`](../.github/workflows/supabase-migrations.yml) uses the same non-interactive variables as the [Supabase managing environments](https://supabase.com/docs/guides/cli/managing-environments) guide:
+
+| Secret | Purpose |
+|--------|--------|
+| `SUPABASE_ACCESS_TOKEN` | Personal access token for the CLI (`supabase login` equivalent). |
+| `SUPABASE_PROJECT_ID` | Project ref string (same as `supabase link --project-ref`). |
+| `SUPABASE_DB_PASSWORD` | Postgres password from **Project Settings → Database**. |
+
+Add these under **Repository → Settings → Secrets and variables → Actions**. The workflow runs **`supabase db push --dry-run`** on pull requests that change migration files (same-repo branches only; **fork PRs do not receive secrets**, so migrate checks are skipped there), and **`supabase db push`** on pushes to `main` when migration paths change. You can also run the workflow manually (**Actions → Supabase migrations → Run workflow**).
+
+If you later use **separate staging and production** projects, duplicate the pattern with different secrets (for example `STAGING_PROJECT_ID` / `PRODUCTION_PROJECT_ID`) as in the [demo workflow](https://supabase.com/docs/guides/cli/managing-environments#configure-github-actions).
+
+---
+
+## 5. Verify the workspace
 
 From the repo root, align with CI:
 
@@ -178,7 +245,7 @@ Env vars are **not** required for these tasks unless code reads them at import t
 
 ---
 
-## 5. Run applications locally
+## 6. Run applications locally
 
 Run from the **repository root** unless noted.
 
@@ -198,7 +265,7 @@ Useful references:
 
 ---
 
-## 6. Upgrading React (e.g. to 19.2+)
+## 7. Upgrading React (e.g. to 19.2+)
 
 The workspace pins **React 19.1.x** to match **Expo SDK 54** and to stay aligned with **`react-dom`**, **`react-test-renderer`**, and **`@types/react` / `@types/react-dom`**. If you move to a newer React minor (for example **19.2+**), update **everything below in one commit** so you do not get peer warnings or type/runtime skew.
 
@@ -221,7 +288,7 @@ The workspace pins **React 19.1.x** to match **Expo SDK 54** and to stay aligned
 
 ---
 
-## 7. Optional tooling
+## 8. Optional tooling
 
 | Area | Notes |
 |------|--------|
@@ -231,7 +298,7 @@ The workspace pins **React 19.1.x** to match **Expo SDK 54** and to stay aligned
 
 ---
 
-## 8. Troubleshooting
+## 9. Troubleshooting
 
 | Symptom | Things to try |
 |---------|----------------|
@@ -239,18 +306,22 @@ The workspace pins **React 19.1.x** to match **Expo SDK 54** and to stay aligned
 | Wrong Node version | Switch to Node 20 with your version manager; confirm with `node -v`. |
 | Next.js cannot see Supabase env | Confirm variables are in **`apps/<app>/.env.local`**, not only the repo root. Restart the dev server after changes. |
 | Expo cannot see variables | Use `EXPO_PUBLIC_*` names in **`apps/mobile/.env`**; restart Metro / clear cache if needed (`pnpm exec nx start mobile` with Expo’s cache clear options if documented for your setup). |
+| `supabase link` / `db push` fails in CI | Confirm **Actions secrets** match [§4](#4-supabase-database-migrations-cloud-cli-and-ci) (`SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_ID`, `SUPABASE_DB_PASSWORD`). The database password is from **Project Settings → Database**, not the API key screen. |
+| Fork PR: migration workflow skipped | Expected: GitHub does not expose repository secrets to workflows from forks. Run checks on a branch in the main repo or apply migrations manually after merge. |
 | `pnpm install` fails on Windows | Run shell as admin once if permission errors; check antivirus locking `node_modules`; try deleting `node_modules` and reinstalling. |
 | Path errors on Windows | Use forward slashes in copied commands where supported, or use the `copy` / `Copy-Item` examples above with backslashes in `cmd`. |
 
 ---
 
-## 9. Checklist
+## 10. Checklist
 
 - [ ] Node.js 20 and pnpm 10.29.2 installed
 - [ ] Repository cloned
 - [ ] `pnpm install --frozen-lockfile` succeeded
 - [ ] `apps/web/.env.local` and `apps/practitioner/.env.local` created from `.env.example` and filled with project credentials
 - [ ] `apps/mobile/.env` created from `.env.example`, **trimmed** to `EXPO_PUBLIC_*` only, and filled with real values
+- [ ] Supabase CLI can talk to your cloud project: `pnpm dlx supabase login`, `pnpm dlx supabase link --project-ref <ref>`, then `pnpm dlx supabase db push` when you have pending migrations ([§4](#4-supabase-database-migrations-cloud-cli-and-ci))
+- [ ] If using GitHub Actions for migrations: repository secrets set (`SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_ID`, `SUPABASE_DB_PASSWORD`) per [§4](#4-supabase-database-migrations-cloud-cli-and-ci)
 - [ ] `pnpm exec nx run-many -t lint test typecheck` (and build excluding mobile if you match CI) passes
 - [ ] `pnpm exec nx dev web` (and/or other apps) runs as expected
 

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -195,7 +195,7 @@ export SUPABASE_DB_PASSWORD='<database-password>'
 pnpm dlx supabase link --project-ref <project-ref>
 ```
 
-Find or reset the database password under **Project Settings → Database** in the [Supabase dashboard](https://supabase.com/dashboard) (not the API keys screen).
+Find or reset the database password in the [Supabase dashboard](https://supabase.com/dashboard) under **Database → Settings** for your project, or open **Connect** at the top of the project page to view connection strings and the `postgres` password. It is **not** the same as **API Keys** or **JWT Keys** under Project Settings.
 
 Linking writes local metadata (under `supabase/`, gitignored where appropriate) so commands like `db push` know which remote database to target.
 
@@ -222,7 +222,7 @@ The workflow [`.github/workflows/supabase-migrations.yml`](../.github/workflows/
 |--------|--------|
 | `SUPABASE_ACCESS_TOKEN` | Personal access token for the CLI (`supabase login` equivalent). |
 | `SUPABASE_PROJECT_ID` | Project ref string (same as `supabase link --project-ref`). |
-| `SUPABASE_DB_PASSWORD` | Postgres password from **Project Settings → Database**. |
+| `SUPABASE_DB_PASSWORD` | Postgres password for the `postgres` role (from **Connect** or **Database → Settings**; see §4 above). |
 
 Add these under **Repository → Settings → Secrets and variables → Actions**. The workflow runs **`supabase db push --dry-run`** on pull requests that change migration files (same-repo branches only; **fork PRs do not receive secrets**, so migrate checks are skipped there), and **`supabase db push`** on pushes to `main` when migration paths change. You can also run the workflow manually (**Actions → Supabase migrations → Run workflow**).
 
@@ -306,7 +306,7 @@ The workspace pins **React 19.1.x** to match **Expo SDK 54** and to stay aligned
 | Wrong Node version | Switch to Node 20 with your version manager; confirm with `node -v`. |
 | Next.js cannot see Supabase env | Confirm variables are in **`apps/<app>/.env.local`**, not only the repo root. Restart the dev server after changes. |
 | Expo cannot see variables | Use `EXPO_PUBLIC_*` names in **`apps/mobile/.env`**; restart Metro / clear cache if needed (`pnpm exec nx start mobile` with Expo’s cache clear options if documented for your setup). |
-| `supabase link` / `db push` fails in CI | Confirm **Actions secrets** match [§4](#4-supabase-database-migrations-cloud-cli-and-ci) (`SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_ID`, `SUPABASE_DB_PASSWORD`). The database password is from **Project Settings → Database**, not the API key screen. |
+| `supabase link` / `db push` fails in CI | Confirm **Actions secrets** match [§4](#4-supabase-database-migrations-cloud-cli-and-ci) (`SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_ID`, `SUPABASE_DB_PASSWORD`). The database password is the **Postgres** password from **Connect** or **Database → Settings**, not the Data API / anon keys. |
 | Fork PR: migration workflow skipped | Expected: GitHub does not expose repository secrets to workflows from forks. Run checks on a branch in the main repo or apply migrations manually after merge. |
 | `pnpm install` fails on Windows | Run shell as admin once if permission errors; check antivirus locking `node_modules`; try deleting `node_modules` and reinstalling. |
 | Path errors on Windows | Use forward slashes in copied commands where supported, or use the `copy` / `Copy-Item` examples above with backslashes in `cmd`. |

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,396 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "ABStrack"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+# This feature is only available on the hosted platform.
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# [experimental.pgdelta]
+# When enabled, pg-delta becomes the active engine for supported schema flows.
+# enabled = false
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./declarative"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/migrations/20260327120000_abstrack_core_schema.sql
+++ b/supabase/migrations/20260327120000_abstrack_core_schema.sql
@@ -79,8 +79,7 @@ CREATE TABLE public.health_marker_presets (
   user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
   name text NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now (),
-  updated_at timestamptz NOT NULL DEFAULT now (),
-  CONSTRAINT health_marker_presets_user_id_id_key UNIQUE (user_id, id)
+  updated_at timestamptz NOT NULL DEFAULT now ()
 );
 
 CREATE INDEX health_marker_presets_user_idx ON public.health_marker_presets (user_id);
@@ -138,7 +137,8 @@ CREATE TABLE public.episodes (
   CONSTRAINT episodes_ended_after_started CHECK (
     ended_at IS NULL
     OR ended_at >= started_at
-  )
+  ),
+  CONSTRAINT episodes_user_id_id_key UNIQUE (user_id, id)
 );
 
 CREATE INDEX episodes_user_started_idx ON public.episodes (user_id, started_at DESC);
@@ -153,7 +153,7 @@ COMMENT ON COLUMN public.episodes.episode_type IS 'Filtering/metadata: ABS vs Ot
 CREATE TABLE public.episode_symptoms (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
   user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
-  episode_id uuid REFERENCES public.episodes (id) ON DELETE CASCADE,
+  episode_id uuid,
   preset_symptom_id uuid REFERENCES public.preset_symptoms (id) ON DELETE SET NULL,
   symptom_name text NOT NULL,
   response_type text NOT NULL
@@ -196,7 +196,11 @@ CREATE TABLE public.episode_symptoms (
       AND response_boolean IS NULL
       AND response_severity IS NULL
     )
-  )
+  ),
+  CONSTRAINT episode_symptoms_episode_fk FOREIGN KEY (user_id, episode_id)
+    REFERENCES public.episodes (user_id, id)
+    ON DELETE CASCADE,
+  CONSTRAINT episode_symptoms_episode_id_id_key UNIQUE (episode_id, id)
 );
 
 CREATE INDEX episode_symptoms_episode_idx ON public.episode_symptoms (episode_id);
@@ -212,7 +216,7 @@ COMMENT ON COLUMN public.episode_symptoms.episode_id IS 'Null for standalone / w
 CREATE TABLE public.health_markers (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
   user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
-  episode_id uuid REFERENCES public.episodes (id) ON DELETE CASCADE,
+  episode_id uuid,
   marker_kind text NOT NULL
     CHECK (
       marker_kind IN (
@@ -233,7 +237,10 @@ CREATE TABLE public.health_markers (
   recorded_at timestamptz NOT NULL,
   notes text,
   created_at timestamptz NOT NULL DEFAULT now (),
-  updated_at timestamptz NOT NULL DEFAULT now ()
+  updated_at timestamptz NOT NULL DEFAULT now (),
+  CONSTRAINT health_markers_episode_fk FOREIGN KEY (user_id, episode_id)
+    REFERENCES public.episodes (user_id, id)
+    ON DELETE CASCADE
 );
 
 CREATE INDEX health_markers_user_recorded_idx ON public.health_markers (user_id, recorded_at DESC);
@@ -248,7 +255,7 @@ COMMENT ON COLUMN public.health_markers.marker_kind IS 'Includes wellness_mood f
 CREATE TABLE public.food_diary_entries (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
   user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
-  episode_id uuid REFERENCES public.episodes (id) ON DELETE SET NULL,
+  episode_id uuid,
   meal_tag text NOT NULL
     CHECK (
       meal_tag IN ('Breakfast', 'Lunch', 'Dinner', 'Snack', 'Other')
@@ -256,7 +263,10 @@ CREATE TABLE public.food_diary_entries (
   food_note text NOT NULL,
   logged_at timestamptz NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now (),
-  updated_at timestamptz NOT NULL DEFAULT now ()
+  updated_at timestamptz NOT NULL DEFAULT now (),
+  CONSTRAINT food_diary_episode_fk FOREIGN KEY (user_id, episode_id)
+    REFERENCES public.episodes (user_id, id)
+    ON DELETE SET NULL
 );
 
 CREATE INDEX food_diary_user_logged_idx ON public.food_diary_entries (user_id, logged_at DESC);
@@ -313,8 +323,8 @@ COMMENT ON TABLE public.caretaker_access IS 'Caretaker grant; partial unique ind
 CREATE TABLE public.episode_media (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
   user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
-  episode_id uuid NOT NULL REFERENCES public.episodes (id) ON DELETE CASCADE,
-  episode_symptom_id uuid REFERENCES public.episode_symptoms (id) ON DELETE SET NULL,
+  episode_id uuid NOT NULL,
+  episode_symptom_id uuid,
   storage_object_key text NOT NULL,
   thumbnail_storage_key text,
   media_type text NOT NULL CHECK (media_type IN ('photo', 'video')),
@@ -324,7 +334,13 @@ CREATE TABLE public.episode_media (
   ),
   upload_completed_at timestamptz,
   created_at timestamptz NOT NULL DEFAULT now (),
-  updated_at timestamptz NOT NULL DEFAULT now ()
+  updated_at timestamptz NOT NULL DEFAULT now (),
+  CONSTRAINT episode_media_episode_fk FOREIGN KEY (user_id, episode_id)
+    REFERENCES public.episodes (user_id, id)
+    ON DELETE CASCADE,
+  CONSTRAINT episode_media_symptom_step_fk FOREIGN KEY (episode_id, episode_symptom_id)
+    REFERENCES public.episode_symptoms (episode_id, id)
+    ON DELETE CASCADE
 );
 
 CREATE INDEX episode_media_episode_idx ON public.episode_media (episode_id);
@@ -333,6 +349,7 @@ CREATE INDEX episode_media_symptom_step_idx ON public.episode_media (episode_sym
 
 COMMENT ON TABLE public.episode_media IS 'Metadata for private bucket objects; confidentiality via Storage RLS + TLS + platform encryption (PRD §10), not ciphertext columns here.';
 COMMENT ON COLUMN public.episode_media.storage_object_key IS 'Path/key within the episode-media bucket; no encryption_iv or ciphertext columns in Postgres per PRD.';
+COMMENT ON CONSTRAINT episode_media_symptom_step_fk ON public.episode_media IS 'Links media to a symptom step in the same episode; ON DELETE CASCADE removes metadata if the symptom row is deleted (composite SET NULL would null episode_id, which is NOT NULL).';
 
 -- ---------------------------------------------------------------------------
 -- access_log — append-only audit metadata (no PHI in rows)

--- a/supabase/migrations/20260327120000_abstrack_core_schema.sql
+++ b/supabase/migrations/20260327120000_abstrack_core_schema.sql
@@ -33,8 +33,7 @@ CREATE TABLE public.symptom_presets (
   user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
   name text NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now (),
-  updated_at timestamptz NOT NULL DEFAULT now (),
-  CONSTRAINT symptom_presets_user_id_id_key UNIQUE (user_id, id)
+  updated_at timestamptz NOT NULL DEFAULT now ()
 );
 
 CREATE INDEX symptom_presets_user_idx ON public.symptom_presets (user_id);
@@ -131,8 +130,8 @@ CREATE TABLE public.episodes (
   ended_at timestamptz,
   created_at timestamptz NOT NULL DEFAULT now (),
   updated_at timestamptz NOT NULL DEFAULT now (),
-  CONSTRAINT episodes_symptom_preset_fk FOREIGN KEY (user_id, symptom_preset_id)
-    REFERENCES public.symptom_presets (user_id, id)
+  CONSTRAINT episodes_symptom_preset_id_fk FOREIGN KEY (symptom_preset_id)
+    REFERENCES public.symptom_presets (id)
     ON DELETE SET NULL,
   CONSTRAINT episodes_ended_after_started CHECK (
     ended_at IS NULL
@@ -144,8 +143,33 @@ CREATE TABLE public.episodes (
 CREATE INDEX episodes_user_started_idx ON public.episodes (user_id, started_at DESC);
 CREATE INDEX episodes_user_type_idx ON public.episodes (user_id, episode_type);
 
-COMMENT ON COLUMN public.episodes.symptom_preset_id IS 'Optional FK to symptom_presets.id; composite (user_id, symptom_preset_id) ensures the preset belongs to the episode owner.';
+COMMENT ON COLUMN public.episodes.symptom_preset_id IS 'Optional FK to symptom_presets.id; ON DELETE SET NULL clears only this column. Same-owner vs user_id is enforced by trigger episode_symptom_preset_owner (composite FK SET NULL would null user_id).';
+
 COMMENT ON COLUMN public.episodes.episode_type IS 'Filtering/metadata: ABS vs Other per PRD §4.';
+
+CREATE OR REPLACE FUNCTION public.enforce_episode_symptom_preset_owner ()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql
+  AS $$
+BEGIN
+  IF NEW.symptom_preset_id IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM public.symptom_presets s
+      WHERE s.id = NEW.symptom_preset_id
+        AND s.user_id = NEW.user_id
+    ) THEN
+      RAISE EXCEPTION 'episodes.symptom_preset_id must reference a preset owned by user_id';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER episode_symptom_preset_owner
+  BEFORE INSERT OR UPDATE OF symptom_preset_id, user_id ON public.episodes
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_episode_symptom_preset_owner ();
 
 -- ---------------------------------------------------------------------------
 -- episode_symptoms — one row per logged symptom (nullable episode_id for ad-hoc logs)
@@ -195,6 +219,7 @@ CREATE TABLE public.episode_symptoms (
       response_type IN ('photo', 'video')
       AND response_boolean IS NULL
       AND response_severity IS NULL
+      AND response_text IS NULL
     )
   ),
   CONSTRAINT episode_symptoms_episode_fk FOREIGN KEY (user_id, episode_id)
@@ -264,8 +289,8 @@ CREATE TABLE public.food_diary_entries (
   logged_at timestamptz NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now (),
   updated_at timestamptz NOT NULL DEFAULT now (),
-  CONSTRAINT food_diary_episode_fk FOREIGN KEY (user_id, episode_id)
-    REFERENCES public.episodes (user_id, id)
+  CONSTRAINT food_diary_episode_id_fk FOREIGN KEY (episode_id)
+    REFERENCES public.episodes (id)
     ON DELETE SET NULL
 );
 
@@ -274,6 +299,31 @@ CREATE INDEX food_diary_episode_idx ON public.food_diary_entries (episode_id);
 
 COMMENT ON COLUMN public.food_diary_entries.food_note IS 'Free-text meal description; plaintext under RLS per PRD §6.';
 COMMENT ON COLUMN public.food_diary_entries.meal_tag IS 'Filtering metadata: Breakfast / Lunch / Dinner / Snack / Other per PRD §6.';
+COMMENT ON COLUMN public.food_diary_entries.episode_id IS 'Optional link; ON DELETE SET NULL only clears episode_id. Same-owner vs user_id is enforced by trigger food_diary_episode_owner (composite FK would SET NULL both columns and break NOT NULL on user_id).';
+
+CREATE OR REPLACE FUNCTION public.enforce_food_diary_episode_owner ()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql
+  AS $$
+BEGIN
+  IF NEW.episode_id IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM public.episodes e
+      WHERE e.id = NEW.episode_id
+        AND e.user_id = NEW.user_id
+    ) THEN
+      RAISE EXCEPTION 'food_diary_entries.episode_id must reference an episode owned by user_id';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER food_diary_episode_owner
+  BEFORE INSERT OR UPDATE OF episode_id, user_id ON public.food_diary_entries
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_food_diary_episode_owner ();
 
 -- ---------------------------------------------------------------------------
 -- practitioner_access — patient-initiated grants (no shared DEK columns)

--- a/supabase/migrations/20260327120000_abstrack_core_schema.sql
+++ b/supabase/migrations/20260327120000_abstrack_core_schema.sql
@@ -26,14 +26,28 @@ CREATE INDEX profiles_app_role_idx ON public.profiles (app_role);
 COMMENT ON TABLE public.profiles IS 'App profile keyed to auth.users; display_name may be identifying. Role used for routing; RLS in later migrations.';
 
 -- ---------------------------------------------------------------------------
--- preset_symptoms — ordered symptom lines within a named preset (rows, not columns)
+-- symptom_presets — named symptom preset (header row); lines live in preset_symptoms
+-- ---------------------------------------------------------------------------
+CREATE TABLE public.symptom_presets (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
+  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  name text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now (),
+  updated_at timestamptz NOT NULL DEFAULT now (),
+  CONSTRAINT symptom_presets_user_id_id_key UNIQUE (user_id, id)
+);
+
+CREATE INDEX symptom_presets_user_idx ON public.symptom_presets (user_id);
+
+COMMENT ON TABLE public.symptom_presets IS 'One named symptom preset per row (PRD §2); preset_symptoms.preset_id FKs here.';
+
+-- ---------------------------------------------------------------------------
+-- preset_symptoms — ordered symptom lines within a preset (rows, not columns)
 -- ---------------------------------------------------------------------------
 CREATE TABLE public.preset_symptoms (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
-  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
-  preset_id uuid NOT NULL,
-  preset_name text NOT NULL,
-  sort_order integer NOT NULL,
+  preset_id uuid NOT NULL REFERENCES public.symptom_presets (id) ON DELETE CASCADE,
+  sort_order integer NOT NULL CHECK (sort_order >= 0),
   symptom_name text NOT NULL,
   response_type text NOT NULL
     CHECK (
@@ -48,25 +62,38 @@ CREATE TABLE public.preset_symptoms (
   prompt_instruction text,
   created_at timestamptz NOT NULL DEFAULT now (),
   updated_at timestamptz NOT NULL DEFAULT now (),
-  UNIQUE (user_id, preset_id, sort_order)
+  UNIQUE (preset_id, sort_order)
 );
 
-CREATE INDEX preset_symptoms_user_preset_idx ON public.preset_symptoms (user_id, preset_id);
-CREATE INDEX preset_symptoms_user_idx ON public.preset_symptoms (user_id);
+CREATE INDEX preset_symptoms_preset_idx ON public.preset_symptoms (preset_id);
+CREATE INDEX preset_symptoms_preset_sort_idx ON public.preset_symptoms (preset_id, sort_order);
 
-COMMENT ON COLUMN public.preset_symptoms.preset_id IS 'Stable id for one named preset; groups rows without a separate preset header table.';
-COMMENT ON COLUMN public.preset_symptoms.sort_order IS 'Explicit per-row order within a preset; no default so UNIQUE (user_id, preset_id, sort_order) cannot collide on 0.';
+COMMENT ON COLUMN public.preset_symptoms.sort_order IS 'Explicit per-row order within a preset; UNIQUE (preset_id, sort_order).';
 COMMENT ON COLUMN public.preset_symptoms.response_type IS 'Symptom capture UI: yes/no, 1–5 scale, text, or media per PRD §2.';
 
 -- ---------------------------------------------------------------------------
--- preset_health_markers — ordered health marker lines within a named preset
+-- health_marker_presets — named health-marker preset (header); lines live in preset_health_markers
+-- ---------------------------------------------------------------------------
+CREATE TABLE public.health_marker_presets (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
+  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  name text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now (),
+  updated_at timestamptz NOT NULL DEFAULT now (),
+  CONSTRAINT health_marker_presets_user_id_id_key UNIQUE (user_id, id)
+);
+
+CREATE INDEX health_marker_presets_user_idx ON public.health_marker_presets (user_id);
+
+COMMENT ON TABLE public.health_marker_presets IS 'One named health-marker preset per row (PRD §3); preset_health_markers.preset_id FKs here.';
+
+-- ---------------------------------------------------------------------------
+-- preset_health_markers — ordered health marker lines within a preset
 -- ---------------------------------------------------------------------------
 CREATE TABLE public.preset_health_markers (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
-  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
-  preset_id uuid NOT NULL,
-  preset_name text NOT NULL,
-  sort_order integer NOT NULL,
+  preset_id uuid NOT NULL REFERENCES public.health_marker_presets (id) ON DELETE CASCADE,
+  sort_order integer NOT NULL CHECK (sort_order >= 0),
   marker_kind text NOT NULL
     CHECK (
       marker_kind IN (
@@ -82,13 +109,13 @@ CREATE TABLE public.preset_health_markers (
   custom_unit text,
   created_at timestamptz NOT NULL DEFAULT now (),
   updated_at timestamptz NOT NULL DEFAULT now (),
-  UNIQUE (user_id, preset_id, sort_order)
+  UNIQUE (preset_id, sort_order)
 );
 
-CREATE INDEX preset_health_markers_user_preset_idx ON public.preset_health_markers (user_id, preset_id);
-CREATE INDEX preset_health_markers_user_idx ON public.preset_health_markers (user_id);
+CREATE INDEX preset_health_markers_preset_idx ON public.preset_health_markers (preset_id);
+CREATE INDEX preset_health_markers_preset_sort_idx ON public.preset_health_markers (preset_id, sort_order);
 
-COMMENT ON COLUMN public.preset_health_markers.sort_order IS 'Explicit per-row order within a preset; no default so UNIQUE (user_id, preset_id, sort_order) cannot collide on 0.';
+COMMENT ON COLUMN public.preset_health_markers.sort_order IS 'Explicit per-row order within a preset; UNIQUE (preset_id, sort_order).';
 
 -- ---------------------------------------------------------------------------
 -- episodes — discrete ABS / other flare events
@@ -104,13 +131,20 @@ CREATE TABLE public.episodes (
   started_at timestamptz NOT NULL,
   ended_at timestamptz,
   created_at timestamptz NOT NULL DEFAULT now (),
-  updated_at timestamptz NOT NULL DEFAULT now ()
+  updated_at timestamptz NOT NULL DEFAULT now (),
+  CONSTRAINT episodes_symptom_preset_fk FOREIGN KEY (user_id, symptom_preset_id)
+    REFERENCES public.symptom_presets (user_id, id)
+    ON DELETE SET NULL,
+  CONSTRAINT episodes_ended_after_started CHECK (
+    ended_at IS NULL
+    OR ended_at >= started_at
+  )
 );
 
 CREATE INDEX episodes_user_started_idx ON public.episodes (user_id, started_at DESC);
 CREATE INDEX episodes_user_type_idx ON public.episodes (user_id, episode_type);
 
-COMMENT ON COLUMN public.episodes.symptom_preset_id IS 'Optional reference to preset_symptoms.preset_id used when starting the episode.';
+COMMENT ON COLUMN public.episodes.symptom_preset_id IS 'Optional FK to symptom_presets.id; composite (user_id, symptom_preset_id) ensures the preset belongs to the episode owner.';
 COMMENT ON COLUMN public.episodes.episode_type IS 'Filtering/metadata: ABS vs Other per PRD §4.';
 
 -- ---------------------------------------------------------------------------
@@ -138,9 +172,31 @@ CREATE TABLE public.episode_symptoms (
     OR (response_severity >= 1 AND response_severity <= 5)
   ),
   response_text text,
-  sort_order integer NOT NULL DEFAULT 0,
+  sort_order integer NOT NULL DEFAULT 0 CHECK (sort_order >= 0),
   created_at timestamptz NOT NULL DEFAULT now (),
-  updated_at timestamptz NOT NULL DEFAULT now ()
+  updated_at timestamptz NOT NULL DEFAULT now (),
+  CONSTRAINT episode_symptoms_response_matches_type CHECK (
+    (
+      response_type = 'yes_no'
+      AND response_severity IS NULL
+      AND response_text IS NULL
+    )
+    OR (
+      response_type = 'severity_scale'
+      AND response_boolean IS NULL
+      AND response_text IS NULL
+    )
+    OR (
+      response_type = 'free_text'
+      AND response_boolean IS NULL
+      AND response_severity IS NULL
+    )
+    OR (
+      response_type IN ('photo', 'video')
+      AND response_boolean IS NULL
+      AND response_severity IS NULL
+    )
+  )
 );
 
 CREATE INDEX episode_symptoms_episode_idx ON public.episode_symptoms (episode_id);
@@ -218,7 +274,8 @@ CREATE TABLE public.practitioner_access (
   practitioner_user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
   created_at timestamptz NOT NULL DEFAULT now (),
   revoked_at timestamptz,
-  UNIQUE (patient_user_id, practitioner_user_id)
+  UNIQUE (patient_user_id, practitioner_user_id),
+  CHECK (patient_user_id <> practitioner_user_id)
 );
 
 CREATE INDEX practitioner_access_patient_idx ON public.practitioner_access (patient_user_id);
@@ -238,7 +295,8 @@ CREATE TABLE public.caretaker_access (
   caretaker_user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
   created_at timestamptz NOT NULL DEFAULT now (),
   revoked_at timestamptz,
-  UNIQUE (patient_user_id, caretaker_user_id)
+  UNIQUE (patient_user_id, caretaker_user_id),
+  CHECK (patient_user_id <> caretaker_user_id)
 );
 
 CREATE INDEX caretaker_access_caretaker_idx ON public.caretaker_access (caretaker_user_id);
@@ -302,3 +360,66 @@ CREATE INDEX access_log_resource_idx ON public.access_log (resource_type, resour
 COMMENT ON TABLE public.access_log IS 'Append-only audit trail; no PHI or clinical free text. Privileges and triggers in issue #8.';
 COMMENT ON COLUMN public.access_log.action IS 'e.g. read, write, auth_failure per PRD § Access logging.';
 COMMENT ON COLUMN public.access_log.resource_type IS 'e.g. episode, storage_object; resource_id is opaque UUID.';
+
+-- ---------------------------------------------------------------------------
+-- updated_at: bump on row UPDATE (DEFAULT only covers INSERT)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.set_updated_at ()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql
+  AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER set_updated_at
+  BEFORE UPDATE ON public.profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_updated_at ();
+
+CREATE TRIGGER set_updated_at
+  BEFORE UPDATE ON public.symptom_presets
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_updated_at ();
+
+CREATE TRIGGER set_updated_at
+  BEFORE UPDATE ON public.health_marker_presets
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_updated_at ();
+
+CREATE TRIGGER set_updated_at
+  BEFORE UPDATE ON public.preset_symptoms
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_updated_at ();
+
+CREATE TRIGGER set_updated_at
+  BEFORE UPDATE ON public.preset_health_markers
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_updated_at ();
+
+CREATE TRIGGER set_updated_at
+  BEFORE UPDATE ON public.episodes
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_updated_at ();
+
+CREATE TRIGGER set_updated_at
+  BEFORE UPDATE ON public.episode_symptoms
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_updated_at ();
+
+CREATE TRIGGER set_updated_at
+  BEFORE UPDATE ON public.health_markers
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_updated_at ();
+
+CREATE TRIGGER set_updated_at
+  BEFORE UPDATE ON public.food_diary_entries
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_updated_at ();
+
+CREATE TRIGGER set_updated_at
+  BEFORE UPDATE ON public.episode_media
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_updated_at ();

--- a/supabase/migrations/20260327120000_abstrack_core_schema.sql
+++ b/supabase/migrations/20260327120000_abstrack_core_schema.sql
@@ -8,6 +8,9 @@
 --
 -- Append-only audit semantics for public.access_log (privileges / triggers / RLS) are defined
 -- in issue #8; this migration only creates the table shape (no PHI columns in log rows).
+--
+-- UUID defaults use gen_random_uuid(), which is built into PostgreSQL 13+ (not the pgcrypto
+-- extension). Supabase managed Postgres satisfies this; self-hosted Postgres should use 13+.
 
 -- ---------------------------------------------------------------------------
 -- profiles — app metadata keyed to Supabase Auth

--- a/supabase/migrations/20260327120000_abstrack_core_schema.sql
+++ b/supabase/migrations/20260327120000_abstrack_core_schema.sql
@@ -33,7 +33,7 @@ CREATE TABLE public.preset_symptoms (
   user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
   preset_id uuid NOT NULL,
   preset_name text NOT NULL,
-  sort_order integer NOT NULL DEFAULT 0,
+  sort_order integer NOT NULL,
   symptom_name text NOT NULL,
   response_type text NOT NULL
     CHECK (
@@ -55,6 +55,7 @@ CREATE INDEX preset_symptoms_user_preset_idx ON public.preset_symptoms (user_id,
 CREATE INDEX preset_symptoms_user_idx ON public.preset_symptoms (user_id);
 
 COMMENT ON COLUMN public.preset_symptoms.preset_id IS 'Stable id for one named preset; groups rows without a separate preset header table.';
+COMMENT ON COLUMN public.preset_symptoms.sort_order IS 'Explicit per-row order within a preset; no default so UNIQUE (user_id, preset_id, sort_order) cannot collide on 0.';
 COMMENT ON COLUMN public.preset_symptoms.response_type IS 'Symptom capture UI: yes/no, 1–5 scale, text, or media per PRD §2.';
 
 -- ---------------------------------------------------------------------------
@@ -65,7 +66,7 @@ CREATE TABLE public.preset_health_markers (
   user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
   preset_id uuid NOT NULL,
   preset_name text NOT NULL,
-  sort_order integer NOT NULL DEFAULT 0,
+  sort_order integer NOT NULL,
   marker_kind text NOT NULL
     CHECK (
       marker_kind IN (
@@ -86,6 +87,8 @@ CREATE TABLE public.preset_health_markers (
 
 CREATE INDEX preset_health_markers_user_preset_idx ON public.preset_health_markers (user_id, preset_id);
 CREATE INDEX preset_health_markers_user_idx ON public.preset_health_markers (user_id);
+
+COMMENT ON COLUMN public.preset_health_markers.sort_order IS 'Explicit per-row order within a preset; no default so UNIQUE (user_id, preset_id, sort_order) cannot collide on 0.';
 
 -- ---------------------------------------------------------------------------
 -- episodes — discrete ABS / other flare events
@@ -299,8 +302,3 @@ CREATE INDEX access_log_resource_idx ON public.access_log (resource_type, resour
 COMMENT ON TABLE public.access_log IS 'Append-only audit trail; no PHI or clinical free text. Privileges and triggers in issue #8.';
 COMMENT ON COLUMN public.access_log.action IS 'e.g. read, write, auth_failure per PRD § Access logging.';
 COMMENT ON COLUMN public.access_log.resource_type IS 'e.g. episode, storage_object; resource_id is opaque UUID.';
-</think>
-Removing an incorrect CHECK constraint and fixing the episode_symptoms design.
-
-<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
-StrReplace

--- a/supabase/migrations/20260327120000_abstrack_core_schema.sql
+++ b/supabase/migrations/20260327120000_abstrack_core_schema.sql
@@ -1,0 +1,306 @@
+-- ABStrack — core schema (Week 2)
+--
+-- PHI model: Postgres stores health fields as normal columns (plaintext at the application
+-- layer). Protection is RLS (enforced in later migrations), TLS, and platform / managed
+-- encryption at rest — not application-layer ciphertext columns or per-user DEKs shared
+-- across patient, caretaker, and practitioner. See docs/PRD.md (“Data model: plaintext PHI
+-- in Supabase under RLS”, “Authorized access: practitioners and caretakers (no DEK sharing)”).
+--
+-- Append-only audit semantics for public.access_log (privileges / triggers / RLS) are defined
+-- in issue #8; this migration only creates the table shape (no PHI columns in log rows).
+
+-- ---------------------------------------------------------------------------
+-- profiles — app metadata keyed to Supabase Auth
+-- ---------------------------------------------------------------------------
+CREATE TABLE public.profiles (
+  id uuid PRIMARY KEY REFERENCES auth.users (id) ON DELETE CASCADE,
+  display_name text,
+  app_role text NOT NULL
+    CHECK (app_role IN ('patient', 'caretaker', 'practitioner')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX profiles_app_role_idx ON public.profiles (app_role);
+
+COMMENT ON TABLE public.profiles IS 'App profile keyed to auth.users; display_name may be identifying. Role used for routing; RLS in later migrations.';
+
+-- ---------------------------------------------------------------------------
+-- preset_symptoms — ordered symptom lines within a named preset (rows, not columns)
+-- ---------------------------------------------------------------------------
+CREATE TABLE public.preset_symptoms (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
+  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  preset_id uuid NOT NULL,
+  preset_name text NOT NULL,
+  sort_order integer NOT NULL DEFAULT 0,
+  symptom_name text NOT NULL,
+  response_type text NOT NULL
+    CHECK (
+      response_type IN (
+        'yes_no',
+        'severity_scale',
+        'free_text',
+        'photo',
+        'video'
+      )
+    ),
+  prompt_instruction text,
+  created_at timestamptz NOT NULL DEFAULT now (),
+  updated_at timestamptz NOT NULL DEFAULT now (),
+  UNIQUE (user_id, preset_id, sort_order)
+);
+
+CREATE INDEX preset_symptoms_user_preset_idx ON public.preset_symptoms (user_id, preset_id);
+CREATE INDEX preset_symptoms_user_idx ON public.preset_symptoms (user_id);
+
+COMMENT ON COLUMN public.preset_symptoms.preset_id IS 'Stable id for one named preset; groups rows without a separate preset header table.';
+COMMENT ON COLUMN public.preset_symptoms.response_type IS 'Symptom capture UI: yes/no, 1–5 scale, text, or media per PRD §2.';
+
+-- ---------------------------------------------------------------------------
+-- preset_health_markers — ordered health marker lines within a named preset
+-- ---------------------------------------------------------------------------
+CREATE TABLE public.preset_health_markers (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
+  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  preset_id uuid NOT NULL,
+  preset_name text NOT NULL,
+  sort_order integer NOT NULL DEFAULT 0,
+  marker_kind text NOT NULL
+    CHECK (
+      marker_kind IN (
+        'bac',
+        'blood_glucose',
+        'blood_pressure',
+        'heart_rate',
+        'weight',
+        'custom'
+      )
+    ),
+  custom_name text,
+  custom_unit text,
+  created_at timestamptz NOT NULL DEFAULT now (),
+  updated_at timestamptz NOT NULL DEFAULT now (),
+  UNIQUE (user_id, preset_id, sort_order)
+);
+
+CREATE INDEX preset_health_markers_user_preset_idx ON public.preset_health_markers (user_id, preset_id);
+CREATE INDEX preset_health_markers_user_idx ON public.preset_health_markers (user_id);
+
+-- ---------------------------------------------------------------------------
+-- episodes — discrete ABS / other flare events
+-- ---------------------------------------------------------------------------
+CREATE TABLE public.episodes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
+  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  symptom_preset_id uuid,
+  episode_type text NOT NULL DEFAULT 'Other'
+    CHECK (episode_type IN ('ABS', 'Other')),
+  episode_label text,
+  note text,
+  started_at timestamptz NOT NULL,
+  ended_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now (),
+  updated_at timestamptz NOT NULL DEFAULT now ()
+);
+
+CREATE INDEX episodes_user_started_idx ON public.episodes (user_id, started_at DESC);
+CREATE INDEX episodes_user_type_idx ON public.episodes (user_id, episode_type);
+
+COMMENT ON COLUMN public.episodes.symptom_preset_id IS 'Optional reference to preset_symptoms.preset_id used when starting the episode.';
+COMMENT ON COLUMN public.episodes.episode_type IS 'Filtering/metadata: ABS vs Other per PRD §4.';
+
+-- ---------------------------------------------------------------------------
+-- episode_symptoms — one row per logged symptom (nullable episode_id for ad-hoc logs)
+-- ---------------------------------------------------------------------------
+CREATE TABLE public.episode_symptoms (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
+  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  episode_id uuid REFERENCES public.episodes (id) ON DELETE CASCADE,
+  preset_symptom_id uuid REFERENCES public.preset_symptoms (id) ON DELETE SET NULL,
+  symptom_name text NOT NULL,
+  response_type text NOT NULL
+    CHECK (
+      response_type IN (
+        'yes_no',
+        'severity_scale',
+        'free_text',
+        'photo',
+        'video'
+      )
+    ),
+  response_boolean boolean,
+  response_severity smallint CHECK (
+    response_severity IS NULL
+    OR (response_severity >= 1 AND response_severity <= 5)
+  ),
+  response_text text,
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now (),
+  updated_at timestamptz NOT NULL DEFAULT now ()
+);
+
+CREATE INDEX episode_symptoms_episode_idx ON public.episode_symptoms (episode_id);
+CREATE INDEX episode_symptoms_user_idx ON public.episode_symptoms (user_id);
+CREATE INDEX episode_symptoms_episode_sort_idx ON public.episode_symptoms (episode_id, sort_order);
+
+COMMENT ON TABLE public.episode_symptoms IS 'Symptom answers as rows; episode_id NULL allows ad-hoc symptom logs without a full episode (PRD §5).';
+COMMENT ON COLUMN public.episode_symptoms.episode_id IS 'Null for standalone / wellness symptom entries; set when part of an episode flow.';
+
+-- ---------------------------------------------------------------------------
+-- health_markers — measurements (episode, wellness, or ad-hoc) as rows
+-- ---------------------------------------------------------------------------
+CREATE TABLE public.health_markers (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
+  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  episode_id uuid REFERENCES public.episodes (id) ON DELETE CASCADE,
+  marker_kind text NOT NULL
+    CHECK (
+      marker_kind IN (
+        'bac',
+        'blood_glucose',
+        'blood_pressure',
+        'heart_rate',
+        'weight',
+        'custom',
+        'wellness_mood'
+      )
+    ),
+  custom_name text,
+  custom_unit text,
+  value_numeric numeric,
+  systolic_numeric numeric,
+  diastolic_numeric numeric,
+  recorded_at timestamptz NOT NULL,
+  notes text,
+  created_at timestamptz NOT NULL DEFAULT now (),
+  updated_at timestamptz NOT NULL DEFAULT now ()
+);
+
+CREATE INDEX health_markers_user_recorded_idx ON public.health_markers (user_id, recorded_at DESC);
+CREATE INDEX health_markers_episode_idx ON public.health_markers (episode_id);
+
+COMMENT ON TABLE public.health_markers IS 'Manual marker entries; episode_id NULL for wellness / non-episode capture (PRD §3, §5).';
+COMMENT ON COLUMN public.health_markers.marker_kind IS 'Includes wellness_mood for “how are you feeling” style logs per PRD §5.';
+
+-- ---------------------------------------------------------------------------
+-- food_diary_entries — meal notes and tags (plaintext PHI columns)
+-- ---------------------------------------------------------------------------
+CREATE TABLE public.food_diary_entries (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
+  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  episode_id uuid REFERENCES public.episodes (id) ON DELETE SET NULL,
+  meal_tag text NOT NULL
+    CHECK (
+      meal_tag IN ('Breakfast', 'Lunch', 'Dinner', 'Snack', 'Other')
+    ),
+  food_note text NOT NULL,
+  logged_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now (),
+  updated_at timestamptz NOT NULL DEFAULT now ()
+);
+
+CREATE INDEX food_diary_user_logged_idx ON public.food_diary_entries (user_id, logged_at DESC);
+CREATE INDEX food_diary_episode_idx ON public.food_diary_entries (episode_id);
+
+COMMENT ON COLUMN public.food_diary_entries.food_note IS 'Free-text meal description; plaintext under RLS per PRD §6.';
+COMMENT ON COLUMN public.food_diary_entries.meal_tag IS 'Filtering metadata: Breakfast / Lunch / Dinner / Snack / Other per PRD §6.';
+
+-- ---------------------------------------------------------------------------
+-- practitioner_access — patient-initiated grants (no shared DEK columns)
+-- ---------------------------------------------------------------------------
+CREATE TABLE public.practitioner_access (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
+  patient_user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  practitioner_user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  created_at timestamptz NOT NULL DEFAULT now (),
+  revoked_at timestamptz,
+  UNIQUE (patient_user_id, practitioner_user_id)
+);
+
+CREATE INDEX practitioner_access_patient_idx ON public.practitioner_access (patient_user_id);
+CREATE INDEX practitioner_access_practitioner_idx ON public.practitioner_access (practitioner_user_id);
+CREATE INDEX practitioner_access_active_idx ON public.practitioner_access (practitioner_user_id)
+WHERE
+  revoked_at IS NULL;
+
+COMMENT ON TABLE public.practitioner_access IS 'Grant rows for practitioner read access; enforced by RLS in later migrations.';
+
+-- ---------------------------------------------------------------------------
+-- caretaker_access — patient-initiated caretaker links (MVP: one active caretaker)
+-- ---------------------------------------------------------------------------
+CREATE TABLE public.caretaker_access (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
+  patient_user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  caretaker_user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  created_at timestamptz NOT NULL DEFAULT now (),
+  revoked_at timestamptz,
+  UNIQUE (patient_user_id, caretaker_user_id)
+);
+
+CREATE INDEX caretaker_access_caretaker_idx ON public.caretaker_access (caretaker_user_id);
+
+CREATE UNIQUE INDEX caretaker_access_one_active_per_patient_idx ON public.caretaker_access (patient_user_id)
+WHERE
+  revoked_at IS NULL;
+
+COMMENT ON TABLE public.caretaker_access IS 'Caretaker grant; partial unique index enforces one active caretaker per patient for MVP (PRD §7).';
+
+-- ---------------------------------------------------------------------------
+-- episode_media — Storage object keys and linkage to episode / symptom step
+-- ---------------------------------------------------------------------------
+CREATE TABLE public.episode_media (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
+  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  episode_id uuid NOT NULL REFERENCES public.episodes (id) ON DELETE CASCADE,
+  episode_symptom_id uuid REFERENCES public.episode_symptoms (id) ON DELETE SET NULL,
+  storage_object_key text NOT NULL,
+  thumbnail_storage_key text,
+  media_type text NOT NULL CHECK (media_type IN ('photo', 'video')),
+  duration_seconds smallint CHECK (
+    duration_seconds IS NULL
+    OR (duration_seconds >= 1 AND duration_seconds <= 15)
+  ),
+  upload_completed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now (),
+  updated_at timestamptz NOT NULL DEFAULT now ()
+);
+
+CREATE INDEX episode_media_episode_idx ON public.episode_media (episode_id);
+CREATE INDEX episode_media_user_idx ON public.episode_media (user_id);
+CREATE INDEX episode_media_symptom_step_idx ON public.episode_media (episode_symptom_id);
+
+COMMENT ON TABLE public.episode_media IS 'Metadata for private bucket objects; confidentiality via Storage RLS + TLS + platform encryption (PRD §10), not ciphertext columns here.';
+COMMENT ON COLUMN public.episode_media.storage_object_key IS 'Path/key within the episode-media bucket; no encryption_iv or ciphertext columns in Postgres per PRD.';
+
+-- ---------------------------------------------------------------------------
+-- access_log — append-only audit metadata (no PHI in rows)
+-- ---------------------------------------------------------------------------
+CREATE TABLE public.access_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
+  occurred_at timestamptz NOT NULL DEFAULT now (),
+  actor_user_id uuid REFERENCES auth.users (id) ON DELETE SET NULL,
+  actor_role text NOT NULL
+    CHECK (
+      actor_role IN ('patient', 'caretaker', 'practitioner', 'system', 'service')
+    ),
+  patient_user_id uuid REFERENCES auth.users (id) ON DELETE SET NULL,
+  action text NOT NULL,
+  resource_type text NOT NULL,
+  resource_id uuid,
+  request_id text,
+  ip_hash text
+);
+
+CREATE INDEX access_log_patient_time_idx ON public.access_log (patient_user_id, occurred_at DESC);
+CREATE INDEX access_log_actor_time_idx ON public.access_log (actor_user_id, occurred_at DESC);
+CREATE INDEX access_log_resource_idx ON public.access_log (resource_type, resource_id);
+
+COMMENT ON TABLE public.access_log IS 'Append-only audit trail; no PHI or clinical free text. Privileges and triggers in issue #8.';
+COMMENT ON COLUMN public.access_log.action IS 'e.g. read, write, auth_failure per PRD § Access logging.';
+COMMENT ON COLUMN public.access_log.resource_type IS 'e.g. episode, storage_object; resource_id is opaque UUID.';
+</think>
+Removing an incorrect CHECK constraint and fixing the episode_symptoms design.
+
+<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
+StrReplace

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,2 @@
+-- Optional seed data for local development (`supabase db reset`).
+-- Add INSERTs here when you need fixtures; keep empty for a clean reset.


### PR DESCRIPTION
Closes #7

## Summary

Adds versioned SQL for Week 2 tables under `supabase/migrations/`, documents linking the Supabase CLI to a hosted project and pushing migrations manually, and introduces a GitHub Actions workflow to dry-run migrations on PRs and apply them on `main`.

## Changes

- **Schema:** Initial migration creating `profiles`, presets, episodes, symptoms, markers, food diary, grant tables, `episode_media`, and `access_log` (plaintext PHI columns per PRD; RLS/audit enforcement deferred to follow-up work).
- **Docs:** New §4 in `docs/DEV_SETUP.md` (CLI login, link, `db push`, seed vs cloud, required Action secrets, fork caveat).
- **CI:** `.github/workflows/supabase-migrations.yml` — `db push --dry-run` on same-repo PRs when migration paths change; `db push` on pushes to `main` (path-filtered) and `workflow_dispatch`.
- **Supabase CLI layout:** `supabase/config.toml` from `supabase init`, plus `supabase/seed.sql` for local `db reset`.

## Checklist

- [ ] Repository secrets configured: `SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_ID`, `SUPABASE_DB_PASSWORD` (see `docs/DEV_SETUP.md` §4).