### PR TITLE
feat(db): add RLS policies and append-only access_log enforcement

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,9 +25,9 @@
 **Tasks:**
 
 - [x] Create Supabase project and configure environment variables (project + Email provider in [Supabase dashboard](https://supabase.com/dashboard); vars documented in [`.env.example`](../.env.example))
-- [ ] Design and apply database migrations for all tables: `profiles`, `episodes`, `episode_symptoms`, `health_markers`, `food_diary_entries`, `preset_symptoms`, `preset_health_markers`, `practitioner_access`, `caretaker_access`, `episode_media`, `access_log` (append-only audit; no PHI in log rows)
-- [ ] Write RLS policies for all PHI tables (patient owns data; caretaker and practitioner per grant tables; practitioner MFA rules per [PRD](PRD.md))
-- [ ] Append-only `access_log`: privilege/RLS/trigger pattern so clients cannot forge or mutate log rows (trusted insert path only)
+- [x] Design and apply database migrations for all tables: `profiles`, `episodes`, `episode_symptoms`, `health_markers`, `food_diary_entries`, `preset_symptoms`, `preset_health_markers`, `practitioner_access`, `caretaker_access`, `episode_media`, `access_log` (append-only audit; no PHI in log rows)
+- [x] Write RLS policies for all PHI tables (patient owns data; caretaker and practitioner per grant tables; practitioner MFA rules per [PRD](PRD.md))
+- [x] Append-only `access_log`: privilege/RLS/trigger pattern so clients cannot forge or mutate log rows (trusted insert path only)
 - [ ] Create the private `episode-media` storage bucket with RLS on `storage.objects`
 - [ ] Implement `@abstrack/types` -- all shared TypeScript interfaces and enums (episode types, meal tags, symptom response types, user roles, etc.)
 - [ ] Implement `@abstrack/supabase` -- Supabase client factory, auth helpers, typed query wrappers

--- a/supabase/migrations/20260327130000_rls_policies.sql
+++ b/supabase/migrations/20260327130000_rls_policies.sql
@@ -6,14 +6,15 @@
 -- matching app_role for the current user (fail-closed PHI reads/writes).
 
 -- ---------------------------------------------------------------------------
--- Helpers (SECURITY DEFINER; Week 5: add JWT/aal predicate on practitioner path)
+-- Helpers (SECURITY INVOKER: only own profile + own-visible grant rows; RLS applies.
+-- Week 5: add JWT/aal predicate on practitioner path.)
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION public.user_has_practitioner_access (p_patient_user_id uuid)
   RETURNS boolean
   LANGUAGE sql
   STABLE
-  SECURITY DEFINER
-  SET search_path = public
+  SECURITY INVOKER
+  SET search_path = pg_catalog, public
   AS $$
     SELECT
       EXISTS (
@@ -36,8 +37,8 @@ CREATE OR REPLACE FUNCTION public.user_is_caretaker_for_patient (p_patient_user_
   RETURNS boolean
   LANGUAGE sql
   STABLE
-  SECURITY DEFINER
-  SET search_path = public
+  SECURITY INVOKER
+  SET search_path = pg_catalog, public
   AS $$
     SELECT
       EXISTS (
@@ -56,6 +57,12 @@ $$;
 
 COMMENT ON FUNCTION public.user_is_caretaker_for_patient (uuid) IS 'True when the current user has profiles.app_role caretaker and an active caretaker_access link to this patient.';
 
+REVOKE ALL ON FUNCTION public.user_has_practitioner_access (uuid)
+  FROM PUBLIC;
+
+REVOKE ALL ON FUNCTION public.user_is_caretaker_for_patient (uuid)
+  FROM PUBLIC;
+
 GRANT EXECUTE ON FUNCTION public.user_has_practitioner_access (uuid) TO authenticated;
 
 GRANT EXECUTE ON FUNCTION public.user_is_caretaker_for_patient (uuid) TO authenticated;
@@ -67,7 +74,7 @@ CREATE OR REPLACE FUNCTION public.enforce_practitioner_access_profile_roles ()
   RETURNS TRIGGER
   LANGUAGE plpgsql
   SECURITY DEFINER
-  SET search_path = public
+  SET search_path = pg_catalog, public, pg_temp
   AS $$
 BEGIN
   IF NOT EXISTS (
@@ -103,7 +110,7 @@ CREATE OR REPLACE FUNCTION public.enforce_caretaker_access_profile_roles ()
   RETURNS TRIGGER
   LANGUAGE plpgsql
   SECURITY DEFINER
-  SET search_path = public
+  SET search_path = pg_catalog, public, pg_temp
   AS $$
 BEGIN
   IF NOT EXISTS (
@@ -139,6 +146,20 @@ COMMENT ON FUNCTION public.enforce_practitioner_access_profile_roles () IS 'Ensu
 
 COMMENT ON FUNCTION public.enforce_caretaker_access_profile_roles () IS 'Ensures caretaker grants only link patient + caretaker profiles per PRD; runs under definer to read profiles despite RLS.';
 
+REVOKE ALL ON FUNCTION public.enforce_practitioner_access_profile_roles ()
+  FROM PUBLIC;
+
+REVOKE ALL ON FUNCTION public.enforce_caretaker_access_profile_roles ()
+  FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.enforce_practitioner_access_profile_roles () TO authenticated;
+
+GRANT EXECUTE ON FUNCTION public.enforce_caretaker_access_profile_roles () TO authenticated;
+
+GRANT EXECUTE ON FUNCTION public.enforce_practitioner_access_profile_roles () TO service_role;
+
+GRANT EXECUTE ON FUNCTION public.enforce_caretaker_access_profile_roles () TO service_role;
+
 -- ---------------------------------------------------------------------------
 -- Append-only access_log: privileges + trigger (RLS policies below)
 -- ---------------------------------------------------------------------------
@@ -165,6 +186,8 @@ CREATE OR REPLACE FUNCTION public.access_log_prevent_update_or_delete ()
   AS $$
 BEGIN
   RAISE EXCEPTION 'access_log is append-only';
+  RETURN NULL;
+  -- Unreachable today; documents BEFORE UPDATE/DELETE trigger contract if RAISE is ever relaxed.
 END;
 $$;
 

--- a/supabase/migrations/20260327130000_rls_policies.sql
+++ b/supabase/migrations/20260327130000_rls_policies.sql
@@ -268,6 +268,65 @@ ALTER TABLE public.caretaker_access
 ALTER TABLE public.access_log
   ENABLE ROW LEVEL SECURITY;
 
+-- profiles: own row only; app_role is not self-service for practitioner (PRD: invitation path).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.profiles_trusted_session_for_app_role ()
+  RETURNS boolean
+  LANGUAGE sql
+  STABLE
+  SECURITY DEFINER
+  SET search_path = pg_catalog, public
+  AS $$
+    SELECT
+      COALESCE((auth.jwt() ->> 'role') = 'service_role', FALSE)
+      OR session_user = 'postgres';
+
+$$;
+
+COMMENT ON FUNCTION public.profiles_trusted_session_for_app_role () IS 'True for service_role JWT or direct postgres session (migrations / trusted role assignment).';
+
+REVOKE ALL ON FUNCTION public.profiles_trusted_session_for_app_role ()
+  FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.profiles_enforce_app_role ()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = pg_catalog, public, pg_temp
+  AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.app_role = 'practitioner'
+      AND NOT public.profiles_trusted_session_for_app_role () THEN
+      RAISE EXCEPTION 'profiles.app_role practitioner requires a trusted path';
+    END IF;
+    RETURN NEW;
+  END IF;
+  IF TG_OP = 'UPDATE' THEN
+    IF OLD.app_role IS DISTINCT FROM NEW.app_role
+      AND NOT public.profiles_trusted_session_for_app_role () THEN
+      RAISE EXCEPTION 'profiles.app_role cannot be changed without a trusted path';
+    END IF;
+    RETURN NEW;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER profiles_enforce_app_role
+  BEFORE INSERT OR UPDATE ON public.profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.profiles_enforce_app_role ();
+
+COMMENT ON FUNCTION public.profiles_enforce_app_role () IS 'Blocks practitioner self-signup and arbitrary app_role changes unless session is trusted (service_role / postgres).';
+
+REVOKE ALL ON FUNCTION public.profiles_enforce_app_role ()
+  FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.profiles_enforce_app_role () TO authenticated;
+
+GRANT EXECUTE ON FUNCTION public.profiles_enforce_app_role () TO service_role;
+
 -- profiles: own row only (routing metadata; not caretaker-as-patient proxy)
 CREATE POLICY profiles_select_own ON public.profiles
   FOR SELECT
@@ -277,7 +336,8 @@ CREATE POLICY profiles_select_own ON public.profiles
 CREATE POLICY profiles_insert_own ON public.profiles
   FOR INSERT
   TO authenticated
-  WITH CHECK (id = (SELECT auth.uid()));
+  WITH CHECK (id = (SELECT auth.uid())
+    AND app_role IN ('patient', 'caretaker'));
 
 CREATE POLICY profiles_update_own ON public.profiles
   FOR UPDATE
@@ -289,6 +349,12 @@ CREATE POLICY profiles_delete_own ON public.profiles
   FOR DELETE
   TO authenticated
   USING (id = (SELECT auth.uid()));
+
+CREATE POLICY profiles_service_role_all ON public.profiles
+  FOR ALL
+  TO service_role
+  USING (TRUE)
+  WITH CHECK (TRUE);
 
 -- symptom_presets
 CREATE POLICY symptom_presets_select ON public.symptom_presets

--- a/supabase/migrations/20260327130000_rls_policies.sql
+++ b/supabase/migrations/20260327130000_rls_policies.sql
@@ -2,9 +2,11 @@
 --
 -- PRD: Authorized access, RLS requirements table, Access logging (append-only).
 -- Practitioner MFA (aal2) is centralized in user_has_practitioner_access() for Week 5.
+-- Grant tables: triggers enforce profiles.app_role on grant endpoints; helpers require
+-- matching app_role for the current user (fail-closed PHI reads/writes).
 
 -- ---------------------------------------------------------------------------
--- Helpers (SECURITY DEFINER: stable join to grant tables; Week 5: add JWT/aal predicate here)
+-- Helpers (SECURITY DEFINER; Week 5: add JWT/aal predicate on practitioner path)
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION public.user_has_practitioner_access (p_patient_user_id uuid)
   RETURNS boolean
@@ -19,14 +21,16 @@ CREATE OR REPLACE FUNCTION public.user_has_practitioner_access (p_patient_user_i
           1
         FROM
           public.practitioner_access pa
+          INNER JOIN public.profiles pr ON pr.id = (SELECT auth.uid())
         WHERE
           pa.patient_user_id = p_patient_user_id
           AND pa.practitioner_user_id = (SELECT auth.uid())
-          AND pa.revoked_at IS NULL);
+          AND pa.revoked_at IS NULL
+          AND pr.app_role = 'practitioner');
 
 $$;
 
-COMMENT ON FUNCTION public.user_has_practitioner_access (uuid) IS 'True when the current user is the granted practitioner for this patient (active grant). Extend in Week 5 with fail-closed MFA (e.g. aal2) in one place.';
+COMMENT ON FUNCTION public.user_has_practitioner_access (uuid) IS 'True when the current user has profiles.app_role practitioner and an active practitioner_access grant for this patient. Fail-closed; extend in Week 5 with MFA (e.g. aal2).';
 
 CREATE OR REPLACE FUNCTION public.user_is_caretaker_for_patient (p_patient_user_id uuid)
   RETURNS boolean
@@ -41,18 +45,99 @@ CREATE OR REPLACE FUNCTION public.user_is_caretaker_for_patient (p_patient_user_
           1
         FROM
           public.caretaker_access ca
+          INNER JOIN public.profiles pr ON pr.id = (SELECT auth.uid())
         WHERE
           ca.patient_user_id = p_patient_user_id
           AND ca.caretaker_user_id = (SELECT auth.uid())
-          AND ca.revoked_at IS NULL);
+          AND ca.revoked_at IS NULL
+          AND pr.app_role = 'caretaker');
 
 $$;
 
-COMMENT ON FUNCTION public.user_is_caretaker_for_patient (uuid) IS 'True when the current user is the active caretaker linked to this patient.';
+COMMENT ON FUNCTION public.user_is_caretaker_for_patient (uuid) IS 'True when the current user has profiles.app_role caretaker and an active caretaker_access link to this patient.';
 
 GRANT EXECUTE ON FUNCTION public.user_has_practitioner_access (uuid) TO authenticated;
 
 GRANT EXECUTE ON FUNCTION public.user_is_caretaker_for_patient (uuid) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Grant tables: require profile roles on insert/update (RLS hides other users' profiles)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.enforce_practitioner_access_profile_roles ()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public
+  AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT
+      1
+    FROM
+      public.profiles p
+    WHERE
+      p.id = NEW.patient_user_id
+      AND p.app_role = 'patient') THEN
+    RAISE EXCEPTION 'practitioner_access.patient_user_id must reference a profile with app_role patient';
+  END IF;
+  IF NOT EXISTS (
+    SELECT
+      1
+    FROM
+      public.profiles p
+    WHERE
+      p.id = NEW.practitioner_user_id
+      AND p.app_role = 'practitioner') THEN
+    RAISE EXCEPTION 'practitioner_access.practitioner_user_id must reference a profile with app_role practitioner';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER practitioner_access_profile_roles
+  BEFORE INSERT OR UPDATE ON public.practitioner_access
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_practitioner_access_profile_roles ();
+
+CREATE OR REPLACE FUNCTION public.enforce_caretaker_access_profile_roles ()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public
+  AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT
+      1
+    FROM
+      public.profiles p
+    WHERE
+      p.id = NEW.patient_user_id
+      AND p.app_role = 'patient') THEN
+    RAISE EXCEPTION 'caretaker_access.patient_user_id must reference a profile with app_role patient';
+  END IF;
+  IF NOT EXISTS (
+    SELECT
+      1
+    FROM
+      public.profiles p
+    WHERE
+      p.id = NEW.caretaker_user_id
+      AND p.app_role = 'caretaker') THEN
+    RAISE EXCEPTION 'caretaker_access.caretaker_user_id must reference a profile with app_role caretaker';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER caretaker_access_profile_roles
+  BEFORE INSERT OR UPDATE ON public.caretaker_access
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_caretaker_access_profile_roles ();
+
+COMMENT ON FUNCTION public.enforce_practitioner_access_profile_roles () IS 'Ensures practitioner grants only link patient + practitioner profiles per PRD; runs under definer to read profiles despite RLS.';
+
+COMMENT ON FUNCTION public.enforce_caretaker_access_profile_roles () IS 'Ensures caretaker grants only link patient + caretaker profiles per PRD; runs under definer to read profiles despite RLS.';
 
 -- ---------------------------------------------------------------------------
 -- Append-only access_log: privileges + trigger (RLS policies below)

--- a/supabase/migrations/20260327130000_rls_policies.sql
+++ b/supabase/migrations/20260327130000_rls_policies.sql
@@ -175,7 +175,10 @@ REVOKE ALL ON public.access_log
 GRANT
   SELECT ON public.access_log TO authenticated;
 
--- Trusted path (Edge Function / automation) uses service_role; clients use authenticated only.
+-- Trusted path (Edge Function / automation) uses service_role; append-only: no UPDATE/DELETE privilege.
+REVOKE ALL ON public.access_log
+  FROM service_role;
+
 GRANT
   INSERT,
   SELECT ON public.access_log TO service_role;
@@ -349,7 +352,7 @@ CREATE POLICY profiles_service_role_all ON public.profiles
   USING (TRUE)
   WITH CHECK (TRUE);
 
--- symptom_presets
+-- symptom_presets (user_id immutability: phi_user_id_immutable trigger)
 CREATE POLICY symptom_presets_select ON public.symptom_presets
   FOR SELECT
   TO authenticated
@@ -440,7 +443,7 @@ CREATE POLICY preset_symptoms_delete ON public.preset_symptoms
       AND (sp.user_id = (SELECT auth.uid())
         OR public.user_is_caretaker_for_patient (sp.user_id))));
 
--- health_marker_presets
+-- health_marker_presets (user_id immutability: phi_user_id_immutable trigger)
 CREATE POLICY health_marker_presets_select ON public.health_marker_presets
   FOR SELECT
   TO authenticated
@@ -531,7 +534,7 @@ CREATE POLICY preset_health_markers_delete ON public.preset_health_markers
       AND (hp.user_id = (SELECT auth.uid())
         OR public.user_is_caretaker_for_patient (hp.user_id))));
 
--- episodes
+-- episodes (caretaker may update patient rows; changing user_id is blocked by phi_user_id_immutable)
 CREATE POLICY episodes_select ON public.episodes
   FOR SELECT
   TO authenticated
@@ -559,7 +562,7 @@ CREATE POLICY episodes_delete ON public.episodes
   USING (user_id = (SELECT auth.uid())
     OR public.user_is_caretaker_for_patient (user_id));
 
--- episode_symptoms
+-- episode_symptoms (user_id immutability: phi_user_id_immutable trigger)
 CREATE POLICY episode_symptoms_select ON public.episode_symptoms
   FOR SELECT
   TO authenticated
@@ -587,7 +590,7 @@ CREATE POLICY episode_symptoms_delete ON public.episode_symptoms
   USING (user_id = (SELECT auth.uid())
     OR public.user_is_caretaker_for_patient (user_id));
 
--- health_markers
+-- health_markers (user_id immutability: phi_user_id_immutable trigger)
 CREATE POLICY health_markers_select ON public.health_markers
   FOR SELECT
   TO authenticated
@@ -615,7 +618,7 @@ CREATE POLICY health_markers_delete ON public.health_markers
   USING (user_id = (SELECT auth.uid())
     OR public.user_is_caretaker_for_patient (user_id));
 
--- food_diary_entries
+-- food_diary_entries (user_id immutability: phi_user_id_immutable trigger)
 CREATE POLICY food_diary_entries_select ON public.food_diary_entries
   FOR SELECT
   TO authenticated
@@ -643,7 +646,7 @@ CREATE POLICY food_diary_entries_delete ON public.food_diary_entries
   USING (user_id = (SELECT auth.uid())
     OR public.user_is_caretaker_for_patient (user_id));
 
--- episode_media
+-- episode_media (user_id immutability: phi_user_id_immutable trigger)
 CREATE POLICY episode_media_select ON public.episode_media
   FOR SELECT
   TO authenticated
@@ -670,6 +673,67 @@ CREATE POLICY episode_media_delete ON public.episode_media
   TO authenticated
   USING (user_id = (SELECT auth.uid())
     OR public.user_is_caretaker_for_patient (user_id));
+
+-- PHI rows: user_id is the patient owner; caretaker UPDATE policies must not allow reassigning ownership.
+CREATE OR REPLACE FUNCTION public.enforce_phi_row_user_id_immutable ()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = pg_catalog, public, pg_temp
+  AS $$
+BEGIN
+  IF OLD.user_id IS DISTINCT FROM NEW.user_id THEN
+    IF NOT public.profiles_trusted_session_for_app_role () THEN
+      RAISE EXCEPTION '%: user_id cannot be changed on update', TG_TABLE_NAME;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.enforce_phi_row_user_id_immutable () IS 'Prevents caretaker (or patient) from moving PHI rows to another user_id; trusted session may fix data.';
+
+REVOKE ALL ON FUNCTION public.enforce_phi_row_user_id_immutable ()
+  FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.enforce_phi_row_user_id_immutable () TO authenticated;
+
+GRANT EXECUTE ON FUNCTION public.enforce_phi_row_user_id_immutable () TO service_role;
+
+CREATE TRIGGER phi_user_id_immutable
+  BEFORE UPDATE ON public.symptom_presets
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_phi_row_user_id_immutable ();
+
+CREATE TRIGGER phi_user_id_immutable
+  BEFORE UPDATE ON public.health_marker_presets
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_phi_row_user_id_immutable ();
+
+CREATE TRIGGER phi_user_id_immutable
+  BEFORE UPDATE ON public.episodes
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_phi_row_user_id_immutable ();
+
+CREATE TRIGGER phi_user_id_immutable
+  BEFORE UPDATE ON public.episode_symptoms
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_phi_row_user_id_immutable ();
+
+CREATE TRIGGER phi_user_id_immutable
+  BEFORE UPDATE ON public.health_markers
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_phi_row_user_id_immutable ();
+
+CREATE TRIGGER phi_user_id_immutable
+  BEFORE UPDATE ON public.food_diary_entries
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_phi_row_user_id_immutable ();
+
+CREATE TRIGGER phi_user_id_immutable
+  BEFORE UPDATE ON public.episode_media
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_phi_row_user_id_immutable ();
 
 -- practitioner_access (PRD grant table)
 CREATE POLICY practitioner_access_patient_all ON public.practitioner_access

--- a/supabase/migrations/20260327130000_rls_policies.sql
+++ b/supabase/migrations/20260327130000_rls_policies.sql
@@ -4,6 +4,10 @@
 -- Practitioner MFA (aal2) is centralized in user_has_practitioner_access() for Week 5.
 -- Grant tables: triggers enforce profiles.app_role on grant endpoints; helpers require
 -- matching app_role for the current user (fail-closed PHI reads/writes).
+--
+-- SECURITY DEFINER trigger functions: no GRANT EXECUTE to authenticated/service_role; superuser
+-- ownership is enough for triggers to run (PostgreSQL perm-functions). Narrow EXECUTE is only for
+-- SECURITY INVOKER RLS helpers below (policy-evaluated, not direct RPC surface).
 
 -- ---------------------------------------------------------------------------
 -- Helpers (SECURITY INVOKER: only own profile + own-visible grant rows; RLS applies.
@@ -152,13 +156,7 @@ REVOKE ALL ON FUNCTION public.enforce_practitioner_access_profile_roles ()
 REVOKE ALL ON FUNCTION public.enforce_caretaker_access_profile_roles ()
   FROM PUBLIC;
 
-GRANT EXECUTE ON FUNCTION public.enforce_practitioner_access_profile_roles () TO authenticated;
-
-GRANT EXECUTE ON FUNCTION public.enforce_caretaker_access_profile_roles () TO authenticated;
-
-GRANT EXECUTE ON FUNCTION public.enforce_practitioner_access_profile_roles () TO service_role;
-
-GRANT EXECUTE ON FUNCTION public.enforce_caretaker_access_profile_roles () TO service_role;
+-- No GRANT EXECUTE on grant-table trigger functions: superuser-owned; invokers do not need EXECUTE.
 
 -- ---------------------------------------------------------------------------
 -- Append-only access_log: privileges + trigger (RLS policies below)
@@ -192,17 +190,10 @@ BEGIN
     RAISE EXCEPTION 'access_log is append-only';
   END IF;
 
-  -- UPDATE: allow only auth.users FK ON DELETE SET NULL on actor_user_id / patient_user_id;
-  -- all other columns must be unchanged (append-only audit semantics).
+  -- UPDATE: allow only auth.users FK ON DELETE SET NULL on actor_user_id / patient_user_id.
+  -- Compare all non-FK columns via jsonb (schema-evolution safe); FK columns only unchanged or nulling.
   IF TG_OP = 'UPDATE'
-    AND OLD.id IS NOT DISTINCT FROM NEW.id
-    AND OLD.occurred_at IS NOT DISTINCT FROM NEW.occurred_at
-    AND OLD.actor_role IS NOT DISTINCT FROM NEW.actor_role
-    AND OLD.action IS NOT DISTINCT FROM NEW.action
-    AND OLD.resource_type IS NOT DISTINCT FROM NEW.resource_type
-    AND OLD.resource_id IS NOT DISTINCT FROM NEW.resource_id
-    AND OLD.request_id IS NOT DISTINCT FROM NEW.request_id
-    AND OLD.ip_hash IS NOT DISTINCT FROM NEW.ip_hash
+    AND (to_jsonb(OLD) - 'actor_user_id' - 'patient_user_id') = (to_jsonb(NEW) - 'actor_user_id' - 'patient_user_id')
     AND (
       OLD.actor_user_id IS NOT DISTINCT FROM NEW.actor_user_id
       OR (OLD.actor_user_id IS NOT NULL AND NEW.actor_user_id IS NULL)
@@ -218,7 +209,7 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION public.access_log_prevent_update_or_delete () IS 'Blocks UPDATE/DELETE except FK cleanup when referenced auth.users rows are deleted (SET NULL on actor_user_id / patient_user_id only).';
+COMMENT ON FUNCTION public.access_log_prevent_update_or_delete () IS 'Blocks UPDATE/DELETE except FK SET NULL on actor_user_id/patient_user_id; non-FK columns compared via jsonb minus those keys (new columns covered automatically).';
 
 CREATE TRIGGER access_log_append_only
   BEFORE UPDATE OR DELETE ON public.access_log
@@ -325,9 +316,8 @@ COMMENT ON FUNCTION public.profiles_enforce_app_role () IS 'Blocks practitioner 
 REVOKE ALL ON FUNCTION public.profiles_enforce_app_role ()
   FROM PUBLIC;
 
-GRANT EXECUTE ON FUNCTION public.profiles_enforce_app_role () TO authenticated;
-
-GRANT EXECUTE ON FUNCTION public.profiles_enforce_app_role () TO service_role;
+-- No GRANT EXECUTE: trigger functions owned by a superuser do not require the invoker to have
+-- EXECUTE (PostgreSQL perm-functions). Avoids callable surface; not needed for trigger firing.
 
 CREATE POLICY profiles_select_own ON public.profiles
   FOR SELECT
@@ -696,9 +686,7 @@ COMMENT ON FUNCTION public.enforce_phi_row_user_id_immutable () IS 'Prevents car
 REVOKE ALL ON FUNCTION public.enforce_phi_row_user_id_immutable ()
   FROM PUBLIC;
 
-GRANT EXECUTE ON FUNCTION public.enforce_phi_row_user_id_immutable () TO authenticated;
-
-GRANT EXECUTE ON FUNCTION public.enforce_phi_row_user_id_immutable () TO service_role;
+-- No GRANT EXECUTE: superuser-owned trigger function; invokers do not need EXECUTE (PostgreSQL perm-functions).
 
 CREATE TRIGGER phi_user_id_immutable
   BEFORE UPDATE ON public.symptom_presets

--- a/supabase/migrations/20260327130000_rls_policies.sql
+++ b/supabase/migrations/20260327130000_rls_policies.sql
@@ -185,11 +185,39 @@ CREATE OR REPLACE FUNCTION public.access_log_prevent_update_or_delete ()
   LANGUAGE plpgsql
   AS $$
 BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'access_log is append-only';
+    RETURN NULL;
+  END IF;
+
+  -- UPDATE: allow only auth.users FK ON DELETE SET NULL on actor_user_id / patient_user_id;
+  -- all other columns must be unchanged (append-only audit semantics).
+  IF TG_OP = 'UPDATE'
+    AND OLD.id IS NOT DISTINCT FROM NEW.id
+    AND OLD.occurred_at IS NOT DISTINCT FROM NEW.occurred_at
+    AND OLD.actor_role IS NOT DISTINCT FROM NEW.actor_role
+    AND OLD.action IS NOT DISTINCT FROM NEW.action
+    AND OLD.resource_type IS NOT DISTINCT FROM NEW.resource_type
+    AND OLD.resource_id IS NOT DISTINCT FROM NEW.resource_id
+    AND OLD.request_id IS NOT DISTINCT FROM NEW.request_id
+    AND OLD.ip_hash IS NOT DISTINCT FROM NEW.ip_hash
+    AND (
+      OLD.actor_user_id IS NOT DISTINCT FROM NEW.actor_user_id
+      OR (OLD.actor_user_id IS NOT NULL AND NEW.actor_user_id IS NULL)
+    )
+    AND (
+      OLD.patient_user_id IS NOT DISTINCT FROM NEW.patient_user_id
+      OR (OLD.patient_user_id IS NOT NULL AND NEW.patient_user_id IS NULL)
+    ) THEN
+    RETURN NEW;
+  END IF;
+
   RAISE EXCEPTION 'access_log is append-only';
   RETURN NULL;
-  -- Unreachable today; documents BEFORE UPDATE/DELETE trigger contract if RAISE is ever relaxed.
 END;
 $$;
+
+COMMENT ON FUNCTION public.access_log_prevent_update_or_delete () IS 'Blocks UPDATE/DELETE except FK cleanup when referenced auth.users rows are deleted (SET NULL on actor_user_id / patient_user_id only).';
 
 CREATE TRIGGER access_log_append_only
   BEFORE UPDATE OR DELETE ON public.access_log
@@ -608,12 +636,23 @@ CREATE POLICY caretaker_access_caretaker_select ON public.caretaker_access
   TO authenticated
   USING (caretaker_user_id = (SELECT auth.uid()));
 
--- access_log: read rules from PRD; no INSERT/UPDATE/DELETE for authenticated (service_role bypasses RLS)
+-- access_log: read rules from PRD; authenticated has no INSERT (trusted path uses service_role).
+-- Explicit service_role policies so INSERT/SELECT succeed even if BYPASSRLS is not set (local/self-hosted).
 CREATE POLICY access_log_select ON public.access_log
   FOR SELECT
   TO authenticated
   USING (patient_user_id = (SELECT auth.uid())
   OR actor_user_id = (SELECT auth.uid()));
+
+CREATE POLICY access_log_service_role_select ON public.access_log
+  FOR SELECT
+  TO service_role
+  USING (TRUE);
+
+CREATE POLICY access_log_service_role_insert ON public.access_log
+  FOR INSERT
+  TO service_role
+  WITH CHECK (TRUE);
 
 CREATE POLICY access_log_deny_update ON public.access_log
   FOR UPDATE

--- a/supabase/migrations/20260327130000_rls_policies.sql
+++ b/supabase/migrations/20260327130000_rls_policies.sql
@@ -187,7 +187,6 @@ CREATE OR REPLACE FUNCTION public.access_log_prevent_update_or_delete ()
 BEGIN
   IF TG_OP = 'DELETE' THEN
     RAISE EXCEPTION 'access_log is append-only';
-    RETURN NULL;
   END IF;
 
   -- UPDATE: allow only auth.users FK ON DELETE SET NULL on actor_user_id / patient_user_id;
@@ -213,7 +212,6 @@ BEGIN
   END IF;
 
   RAISE EXCEPTION 'access_log is append-only';
-  RETURN NULL;
 END;
 $$;
 
@@ -269,6 +267,7 @@ ALTER TABLE public.access_log
   ENABLE ROW LEVEL SECURITY;
 
 -- profiles: own row only; app_role is not self-service for practitioner (PRD: invitation path).
+-- Authenticated has no DELETE policy (avoids delete + reinsert to swap patient/caretaker).
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION public.profiles_trusted_session_for_app_role ()
   RETURNS boolean
@@ -327,7 +326,6 @@ GRANT EXECUTE ON FUNCTION public.profiles_enforce_app_role () TO authenticated;
 
 GRANT EXECUTE ON FUNCTION public.profiles_enforce_app_role () TO service_role;
 
--- profiles: own row only (routing metadata; not caretaker-as-patient proxy)
 CREATE POLICY profiles_select_own ON public.profiles
   FOR SELECT
   TO authenticated
@@ -344,11 +342,6 @@ CREATE POLICY profiles_update_own ON public.profiles
   TO authenticated
   USING (id = (SELECT auth.uid()))
   WITH CHECK (id = (SELECT auth.uid()));
-
-CREATE POLICY profiles_delete_own ON public.profiles
-  FOR DELETE
-  TO authenticated
-  USING (id = (SELECT auth.uid()));
 
 CREATE POLICY profiles_service_role_all ON public.profiles
   FOR ALL

--- a/supabase/migrations/20260327130000_rls_policies.sql
+++ b/supabase/migrations/20260327130000_rls_policies.sql
@@ -1,0 +1,518 @@
+-- ABStrack — Row Level Security (issue #8 / Week 2)
+--
+-- PRD: Authorized access, RLS requirements table, Access logging (append-only).
+-- Practitioner MFA (aal2) is centralized in user_has_practitioner_access() for Week 5.
+
+-- ---------------------------------------------------------------------------
+-- Helpers (SECURITY DEFINER: stable join to grant tables; Week 5: add JWT/aal predicate here)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.user_has_practitioner_access (p_patient_user_id uuid)
+  RETURNS boolean
+  LANGUAGE sql
+  STABLE
+  SECURITY DEFINER
+  SET search_path = public
+  AS $$
+    SELECT
+      EXISTS (
+        SELECT
+          1
+        FROM
+          public.practitioner_access pa
+        WHERE
+          pa.patient_user_id = p_patient_user_id
+          AND pa.practitioner_user_id = (SELECT auth.uid())
+          AND pa.revoked_at IS NULL);
+
+$$;
+
+COMMENT ON FUNCTION public.user_has_practitioner_access (uuid) IS 'True when the current user is the granted practitioner for this patient (active grant). Extend in Week 5 with fail-closed MFA (e.g. aal2) in one place.';
+
+CREATE OR REPLACE FUNCTION public.user_is_caretaker_for_patient (p_patient_user_id uuid)
+  RETURNS boolean
+  LANGUAGE sql
+  STABLE
+  SECURITY DEFINER
+  SET search_path = public
+  AS $$
+    SELECT
+      EXISTS (
+        SELECT
+          1
+        FROM
+          public.caretaker_access ca
+        WHERE
+          ca.patient_user_id = p_patient_user_id
+          AND ca.caretaker_user_id = (SELECT auth.uid())
+          AND ca.revoked_at IS NULL);
+
+$$;
+
+COMMENT ON FUNCTION public.user_is_caretaker_for_patient (uuid) IS 'True when the current user is the active caretaker linked to this patient.';
+
+GRANT EXECUTE ON FUNCTION public.user_has_practitioner_access (uuid) TO authenticated;
+
+GRANT EXECUTE ON FUNCTION public.user_is_caretaker_for_patient (uuid) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Append-only access_log: privileges + trigger (RLS policies below)
+-- ---------------------------------------------------------------------------
+REVOKE ALL ON public.access_log
+  FROM PUBLIC;
+
+REVOKE ALL ON public.access_log
+  FROM anon;
+
+REVOKE ALL ON public.access_log
+  FROM authenticated;
+
+GRANT
+  SELECT ON public.access_log TO authenticated;
+
+-- Trusted path (Edge Function / automation) uses service_role; clients use authenticated only.
+GRANT
+  INSERT,
+  SELECT ON public.access_log TO service_role;
+
+CREATE OR REPLACE FUNCTION public.access_log_prevent_update_or_delete ()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql
+  AS $$
+BEGIN
+  RAISE EXCEPTION 'access_log is append-only';
+END;
+$$;
+
+CREATE TRIGGER access_log_append_only
+  BEFORE UPDATE OR DELETE ON public.access_log
+  FOR EACH ROW
+  EXECUTE FUNCTION public.access_log_prevent_update_or_delete ();
+
+-- ---------------------------------------------------------------------------
+-- RLS: patient-owned PHI rows (same pattern on all)
+-- ---------------------------------------------------------------------------
+-- Expression: owner OR caretaker (read/write) OR practitioner (read only via helper).
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.profiles
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.symptom_presets
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.preset_symptoms
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.health_marker_presets
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.preset_health_markers
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.episodes
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.episode_symptoms
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.health_markers
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.food_diary_entries
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.episode_media
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.practitioner_access
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.caretaker_access
+  ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.access_log
+  ENABLE ROW LEVEL SECURITY;
+
+-- profiles: own row only (routing metadata; not caretaker-as-patient proxy)
+CREATE POLICY profiles_select_own ON public.profiles
+  FOR SELECT
+  TO authenticated
+  USING (id = (SELECT auth.uid()));
+
+CREATE POLICY profiles_insert_own ON public.profiles
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (id = (SELECT auth.uid()));
+
+CREATE POLICY profiles_update_own ON public.profiles
+  FOR UPDATE
+  TO authenticated
+  USING (id = (SELECT auth.uid()))
+  WITH CHECK (id = (SELECT auth.uid()));
+
+CREATE POLICY profiles_delete_own ON public.profiles
+  FOR DELETE
+  TO authenticated
+  USING (id = (SELECT auth.uid()));
+
+-- symptom_presets
+CREATE POLICY symptom_presets_select ON public.symptom_presets
+  FOR SELECT
+  TO authenticated
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id)
+    OR public.user_has_practitioner_access (user_id));
+
+CREATE POLICY symptom_presets_insert ON public.symptom_presets
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (user_id = (SELECT auth.uid())
+  OR public.user_is_caretaker_for_patient (user_id));
+
+CREATE POLICY symptom_presets_update ON public.symptom_presets
+  FOR UPDATE
+  TO authenticated
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id))
+  WITH CHECK (user_id = (SELECT auth.uid())
+  OR public.user_is_caretaker_for_patient (user_id));
+
+CREATE POLICY symptom_presets_delete ON public.symptom_presets
+  FOR DELETE
+  TO authenticated
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id));
+
+-- preset_symptoms (ownership via parent preset)
+CREATE POLICY preset_symptoms_select ON public.preset_symptoms
+  FOR SELECT
+  TO authenticated
+  USING (EXISTS (
+    SELECT
+      1
+    FROM
+      public.symptom_presets sp
+    WHERE
+      sp.id = preset_symptoms.preset_id
+      AND (sp.user_id = (SELECT auth.uid())
+        OR public.user_is_caretaker_for_patient (sp.user_id)
+        OR public.user_has_practitioner_access (sp.user_id))));
+
+CREATE POLICY preset_symptoms_insert ON public.preset_symptoms
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (EXISTS (
+    SELECT
+      1
+    FROM
+      public.symptom_presets sp
+    WHERE
+      sp.id = preset_symptoms.preset_id
+      AND (sp.user_id = (SELECT auth.uid())
+        OR public.user_is_caretaker_for_patient (sp.user_id))));
+
+CREATE POLICY preset_symptoms_update ON public.preset_symptoms
+  FOR UPDATE
+  TO authenticated
+  USING (EXISTS (
+    SELECT
+      1
+    FROM
+      public.symptom_presets sp
+    WHERE
+      sp.id = preset_symptoms.preset_id
+      AND (sp.user_id = (SELECT auth.uid())
+        OR public.user_is_caretaker_for_patient (sp.user_id))))
+  WITH CHECK (EXISTS (
+    SELECT
+      1
+    FROM
+      public.symptom_presets sp
+    WHERE
+      sp.id = preset_symptoms.preset_id
+      AND (sp.user_id = (SELECT auth.uid())
+        OR public.user_is_caretaker_for_patient (sp.user_id))));
+
+CREATE POLICY preset_symptoms_delete ON public.preset_symptoms
+  FOR DELETE
+  TO authenticated
+  USING (EXISTS (
+    SELECT
+      1
+    FROM
+      public.symptom_presets sp
+    WHERE
+      sp.id = preset_symptoms.preset_id
+      AND (sp.user_id = (SELECT auth.uid())
+        OR public.user_is_caretaker_for_patient (sp.user_id))));
+
+-- health_marker_presets
+CREATE POLICY health_marker_presets_select ON public.health_marker_presets
+  FOR SELECT
+  TO authenticated
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id)
+    OR public.user_has_practitioner_access (user_id));
+
+CREATE POLICY health_marker_presets_insert ON public.health_marker_presets
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (user_id = (SELECT auth.uid())
+  OR public.user_is_caretaker_for_patient (user_id));
+
+CREATE POLICY health_marker_presets_update ON public.health_marker_presets
+  FOR UPDATE
+  TO authenticated
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id))
+  WITH CHECK (user_id = (SELECT auth.uid())
+  OR public.user_is_caretaker_for_patient (user_id));
+
+CREATE POLICY health_marker_presets_delete ON public.health_marker_presets
+  FOR DELETE
+  TO authenticated
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id));
+
+-- preset_health_markers
+CREATE POLICY preset_health_markers_select ON public.preset_health_markers
+  FOR SELECT
+  TO authenticated
+  USING (EXISTS (
+    SELECT
+      1
+    FROM
+      public.health_marker_presets hp
+    WHERE
+      hp.id = preset_health_markers.preset_id
+      AND (hp.user_id = (SELECT auth.uid())
+        OR public.user_is_caretaker_for_patient (hp.user_id)
+        OR public.user_has_practitioner_access (hp.user_id))));
+
+CREATE POLICY preset_health_markers_insert ON public.preset_health_markers
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (EXISTS (
+    SELECT
+      1
+    FROM
+      public.health_marker_presets hp
+    WHERE
+      hp.id = preset_health_markers.preset_id
+      AND (hp.user_id = (SELECT auth.uid())
+        OR public.user_is_caretaker_for_patient (hp.user_id))));
+
+CREATE POLICY preset_health_markers_update ON public.preset_health_markers
+  FOR UPDATE
+  TO authenticated
+  USING (EXISTS (
+    SELECT
+      1
+    FROM
+      public.health_marker_presets hp
+    WHERE
+      hp.id = preset_health_markers.preset_id
+      AND (hp.user_id = (SELECT auth.uid())
+        OR public.user_is_caretaker_for_patient (hp.user_id))))
+  WITH CHECK (EXISTS (
+    SELECT
+      1
+    FROM
+      public.health_marker_presets hp
+    WHERE
+      hp.id = preset_health_markers.preset_id
+      AND (hp.user_id = (SELECT auth.uid())
+        OR public.user_is_caretaker_for_patient (hp.user_id))));
+
+CREATE POLICY preset_health_markers_delete ON public.preset_health_markers
+  FOR DELETE
+  TO authenticated
+  USING (EXISTS (
+    SELECT
+      1
+    FROM
+      public.health_marker_presets hp
+    WHERE
+      hp.id = preset_health_markers.preset_id
+      AND (hp.user_id = (SELECT auth.uid())
+        OR public.user_is_caretaker_for_patient (hp.user_id))));
+
+-- episodes
+CREATE POLICY episodes_select ON public.episodes
+  FOR SELECT
+  TO authenticated
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id)
+    OR public.user_has_practitioner_access (user_id));
+
+CREATE POLICY episodes_insert ON public.episodes
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (user_id = (SELECT auth.uid())
+  OR public.user_is_caretaker_for_patient (user_id));
+
+CREATE POLICY episodes_update ON public.episodes
+  FOR UPDATE
+  TO authenticated
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id))
+  WITH CHECK (user_id = (SELECT auth.uid())
+  OR public.user_is_caretaker_for_patient (user_id));
+
+CREATE POLICY episodes_delete ON public.episodes
+  FOR DELETE
+  TO authenticated
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id));
+
+-- episode_symptoms
+CREATE POLICY episode_symptoms_select ON public.episode_symptoms
+  FOR SELECT
+  TO authenticated
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id)
+    OR public.user_has_practitioner_access (user_id));
+
+CREATE POLICY episode_symptoms_insert ON public.episode_symptoms
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (user_id = (SELECT auth.uid())
+  OR public.user_is_caretaker_for_patient (user_id));
+
+CREATE POLICY episode_symptoms_update ON public.episode_symptoms
+  FOR UPDATE
+  TO authenticated
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id))
+  WITH CHECK (user_id = (SELECT auth.uid())
+  OR public.user_is_caretaker_for_patient (user_id));
+
+CREATE POLICY episode_symptoms_delete ON public.episode_symptoms
+  FOR DELETE
+  TO authenticated
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id));
+
+-- health_markers
+CREATE POLICY health_markers_select ON public.health_markers
+  FOR SELECT
+  TO authenticated
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id)
+    OR public.user_has_practitioner_access (user_id));
+
+CREATE POLICY health_markers_insert ON public.health_markers
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (user_id = (SELECT auth.uid())
+  OR public.user_is_caretaker_for_patient (user_id));
+
+CREATE POLICY health_markers_update ON public.health_markers
+  FOR UPDATE
+  TO authenticated
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id))
+  WITH CHECK (user_id = (SELECT auth.uid())
+  OR public.user_is_caretaker_for_patient (user_id));
+
+CREATE POLICY health_markers_delete ON public.health_markers
+  FOR DELETE
+  TO authenticated
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id));
+
+-- food_diary_entries
+CREATE POLICY food_diary_entries_select ON public.food_diary_entries
+  FOR SELECT
+  TO authenticated
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id)
+    OR public.user_has_practitioner_access (user_id));
+
+CREATE POLICY food_diary_entries_insert ON public.food_diary_entries
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (user_id = (SELECT auth.uid())
+  OR public.user_is_caretaker_for_patient (user_id));
+
+CREATE POLICY food_diary_entries_update ON public.food_diary_entries
+  FOR UPDATE
+  TO authenticated
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id))
+  WITH CHECK (user_id = (SELECT auth.uid())
+  OR public.user_is_caretaker_for_patient (user_id));
+
+CREATE POLICY food_diary_entries_delete ON public.food_diary_entries
+  FOR DELETE
+  TO authenticated
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id));
+
+-- episode_media
+CREATE POLICY episode_media_select ON public.episode_media
+  FOR SELECT
+  TO authenticated
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id)
+    OR public.user_has_practitioner_access (user_id));
+
+CREATE POLICY episode_media_insert ON public.episode_media
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (user_id = (SELECT auth.uid())
+  OR public.user_is_caretaker_for_patient (user_id));
+
+CREATE POLICY episode_media_update ON public.episode_media
+  FOR UPDATE
+  TO authenticated
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id))
+  WITH CHECK (user_id = (SELECT auth.uid())
+  OR public.user_is_caretaker_for_patient (user_id));
+
+CREATE POLICY episode_media_delete ON public.episode_media
+  FOR DELETE
+  TO authenticated
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id));
+
+-- practitioner_access (PRD grant table)
+CREATE POLICY practitioner_access_patient_all ON public.practitioner_access
+  FOR ALL
+  TO authenticated
+  USING (patient_user_id = (SELECT auth.uid()))
+  WITH CHECK (patient_user_id = (SELECT auth.uid()));
+
+CREATE POLICY practitioner_access_practitioner_select ON public.practitioner_access
+  FOR SELECT
+  TO authenticated
+  USING (practitioner_user_id = (SELECT auth.uid()));
+
+-- caretaker_access (PRD grant table)
+CREATE POLICY caretaker_access_patient_all ON public.caretaker_access
+  FOR ALL
+  TO authenticated
+  USING (patient_user_id = (SELECT auth.uid()))
+  WITH CHECK (patient_user_id = (SELECT auth.uid()));
+
+CREATE POLICY caretaker_access_caretaker_select ON public.caretaker_access
+  FOR SELECT
+  TO authenticated
+  USING (caretaker_user_id = (SELECT auth.uid()));
+
+-- access_log: read rules from PRD; no INSERT/UPDATE/DELETE for authenticated (service_role bypasses RLS)
+CREATE POLICY access_log_select ON public.access_log
+  FOR SELECT
+  TO authenticated
+  USING (patient_user_id = (SELECT auth.uid())
+  OR actor_user_id = (SELECT auth.uid()));
+
+CREATE POLICY access_log_deny_update ON public.access_log
+  FOR UPDATE
+  TO authenticated
+  USING (FALSE);
+
+CREATE POLICY access_log_deny_delete ON public.access_log
+  FOR DELETE
+  TO authenticated
+  USING (FALSE);


### PR DESCRIPTION
Closes #8

## Summary

Adds Week 2 Row Level Security aligned with the PRD: patient / caretaker / practitioner access on all core tables, grant-table policies, and layered append-only enforcement for `access_log`.

## Changes

- New migration `supabase/migrations/20260327130000_rls_policies.sql`
- Helpers `user_has_practitioner_access(uuid)` and `user_is_caretaker_for_patient(uuid)` use **`SECURITY INVOKER`** and **`SET search_path = pg_catalog, public`** so RLS applies (own profile and own-visible grant rows only). Grant inserts/updates are validated by **`enforce_practitioner_access_profile_roles`** / **`enforce_caretaker_access_profile_roles`** — **`SECURITY DEFINER`** with hardened `search_path`, so they can read other users’ `profiles` for role checks. Practitioner path remains the single place to extend for Week 5 MFA / `aal2`.
- PHI tables: read for owner, linked caretaker, or active practitioner grant; write for owner or caretaker only (no practitioner writes on patient health data)
- `practitioner_access` / `caretaker_access`: policies per PRD grant matrix
- `profiles`: own row only
- `access_log`: revoke client `INSERT`/`UPDATE`/`DELETE` for `authenticated`; `SELECT` + trusted `INSERT` for `service_role`; explicit **`service_role`** RLS policies for **`SELECT`** / **`INSERT`** so trusted paths work without relying on `BYPASSRLS`; explicit deny `UPDATE`/`DELETE` for `authenticated`; `BEFORE UPDATE OR DELETE` trigger blocks mutating edits but allows **`auth.users`** FK **`SET NULL`** cleanup on `actor_user_id` / `patient_user_id` only

## Verification

- [ ] CI: Supabase migrations workflow dry-run passes on this PR
- [ ] After merge: `db push` applies cleanly on the linked project
- [ ] Optional: spot-check two patients — B cannot read A’s `episodes` / `food_diary_entries` / presets; caretaker and practitioner paths behave as expected

## Notes

- Cloud DB is updated via `db push` (merge to `main` / workflow), not `db reset`