### PR TITLE
feat(db): add private episode-media bucket and storage.objects RLS

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,7 +28,7 @@
 - [x] Design and apply database migrations for all tables: `profiles`, `episodes`, `episode_symptoms`, `health_markers`, `food_diary_entries`, `preset_symptoms`, `preset_health_markers`, `practitioner_access`, `caretaker_access`, `episode_media`, `access_log` (append-only audit; no PHI in log rows)
 - [x] Write RLS policies for all PHI tables (patient owns data; caretaker and practitioner per grant tables; practitioner MFA rules per [PRD](PRD.md))
 - [x] Append-only `access_log`: privilege/RLS/trigger pattern so clients cannot forge or mutate log rows (trusted insert path only)
-- [ ] Create the private `episode-media` storage bucket with RLS on `storage.objects`
+- [x] Create the private `episode-media` storage bucket with RLS on `storage.objects`
 - [ ] Implement `@abstrack/types` -- all shared TypeScript interfaces and enums (episode types, meal tags, symptom response types, user roles, etc.)
 - [ ] Implement `@abstrack/supabase` -- Supabase client factory, auth helpers, typed query wrappers
 

--- a/supabase/migrations/20260328100000_episode_media_storage_bucket.sql
+++ b/supabase/migrations/20260328100000_episode_media_storage_bucket.sql
@@ -3,8 +3,9 @@
 -- Confidentiality: private bucket + RLS + TLS + platform encryption at rest — not app-layer DEK
 -- wrapping of objects. Optional @abstrack/crypto does not encrypt blobs in this bucket for MVP.
 --
--- Path convention: object keys MUST start with {patient_user_id}/... where patient_user_id is the
--- owning auth user UUID (first path segment). Aligns with public.episode_media.storage_object_key.
+-- Object key prefix (one term only): "{user_id}/..." — user_id is always public.episode_media.user_id
+-- (auth uid of the patient who owns the row). Do not use other placeholders (e.g. {patient_user_id}) in
+-- docs or client code; alternate names invite keys that do not match this column or RLS.
 --
 -- Signed URLs: time-limited URLs (e.g. ~60s) for playback/download are created by the client/app in
 -- later weeks; this migration is only the bucket and policy shell — no client decrypt step for objects.
@@ -19,12 +20,12 @@ ON CONFLICT (id)
     public = FALSE,
     name = EXCLUDED.name;
 
-COMMENT ON COLUMN public.episode_media.storage_object_key IS 'Path/key within the episode-media bucket; first segment MUST be the owning patient auth user id ({user_id}/...). RLS on storage.objects uses the same convention. No ciphertext columns in Postgres per PRD §10.';
+COMMENT ON COLUMN public.episode_media.storage_object_key IS 'Path/key in episode-media bucket; MUST be "{user_id}/..." where user_id equals this row''s user_id (see migration header). RLS on storage.objects uses the same prefix. No ciphertext columns in Postgres per PRD §10.';
 
 -- ---------------------------------------------------------------------------
--- First path segment → patient UUID (invalid or missing segment → NULL, policies fail closed)
+-- First path segment → episode_media.user_id value (invalid or missing segment → NULL, fail closed)
 -- ---------------------------------------------------------------------------
-CREATE OR REPLACE FUNCTION public.episode_media_storage_path_patient_id (p_object_name text)
+CREATE OR REPLACE FUNCTION public.episode_media_storage_path_user_id (p_object_name text)
   RETURNS uuid
   LANGUAGE sql
   STABLE
@@ -43,15 +44,15 @@ CREATE OR REPLACE FUNCTION public.episode_media_storage_path_patient_id (p_objec
         (storage.foldername (p_object_name))[1] AS seg) s;
   $$;
 
-COMMENT ON FUNCTION public.episode_media_storage_path_patient_id (text) IS 'Patient (owner) user id from episode-media object path: first segment must be a UUID. Keys MUST be {patient_user_id}/... per PRD §10 / episode_media.storage_object_key.';
+COMMENT ON FUNCTION public.episode_media_storage_path_user_id (text) IS 'Parses public.episode_media.user_id from object path: first segment must be a UUID. Keys MUST be "{user_id}/..." with that user_id per PRD §10.';
 
-REVOKE ALL ON FUNCTION public.episode_media_storage_path_patient_id (text)
+REVOKE ALL ON FUNCTION public.episode_media_storage_path_user_id (text)
   FROM PUBLIC;
 
-GRANT EXECUTE ON FUNCTION public.episode_media_storage_path_patient_id (text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.episode_media_storage_path_user_id (text) TO authenticated;
 
 -- ---------------------------------------------------------------------------
--- Single evaluation of path → patient id per policy check (avoid repeated foldername/regex)
+-- Single evaluation of path → user_id per policy check (avoid repeated foldername/regex)
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION public.episode_media_storage_can_select (p_object_name text)
   RETURNS boolean
@@ -70,10 +71,10 @@ CREATE OR REPLACE FUNCTION public.episode_media_storage_can_select (p_object_nam
       END
     FROM (
       SELECT
-        public.episode_media_storage_path_patient_id (p_object_name) AS pid) AS v;
+        public.episode_media_storage_path_user_id (p_object_name) AS pid) AS v;
   $$;
 
-COMMENT ON FUNCTION public.episode_media_storage_can_select (text) IS 'True if current user may read/list episode-media object: owner, active caretaker, or authorized practitioner. Computes path patient id once.';
+COMMENT ON FUNCTION public.episode_media_storage_can_select (text) IS 'True if current user may read/list episode-media object: owner, active caretaker, or authorized practitioner. Computes episode_media.user_id from path once.';
 
 CREATE OR REPLACE FUNCTION public.episode_media_storage_can_write (p_object_name text)
   RETURNS boolean
@@ -91,10 +92,10 @@ CREATE OR REPLACE FUNCTION public.episode_media_storage_can_write (p_object_name
       END
     FROM (
       SELECT
-        public.episode_media_storage_path_patient_id (p_object_name) AS pid) AS v;
+        public.episode_media_storage_path_user_id (p_object_name) AS pid) AS v;
   $$;
 
-COMMENT ON FUNCTION public.episode_media_storage_can_write (text) IS 'True if current user may insert/update/delete episode-media object: owner or active caretaker only. Computes path patient id once.';
+COMMENT ON FUNCTION public.episode_media_storage_can_write (text) IS 'True if current user may insert/update/delete episode-media object: owner or active caretaker only. Computes episode_media.user_id from path once.';
 
 REVOKE ALL ON FUNCTION public.episode_media_storage_can_select (text)
   FROM PUBLIC;

--- a/supabase/migrations/20260328100000_episode_media_storage_bucket.sql
+++ b/supabase/migrations/20260328100000_episode_media_storage_bucket.sql
@@ -1,0 +1,103 @@
+-- Episode media Storage (PRD §10, ROADMAP Week 2): private bucket + RLS on storage.objects.
+--
+-- Confidentiality: private bucket + RLS + TLS + platform encryption at rest — not app-layer DEK
+-- wrapping of objects. Optional @abstrack/crypto does not encrypt blobs in this bucket for MVP.
+--
+-- Path convention: object keys MUST start with {patient_user_id}/... where patient_user_id is the
+-- owning auth user UUID (first path segment). Aligns with public.episode_media.storage_object_key.
+--
+-- Signed URLs: time-limited URLs (e.g. ~60s) for playback/download are created by the client/app in
+-- later weeks; this migration is only the bucket and policy shell — no client decrypt step for objects.
+
+-- ---------------------------------------------------------------------------
+-- Bucket (private; not anonymous)
+-- ---------------------------------------------------------------------------
+INSERT INTO storage.buckets (id, name, public)
+  VALUES ('episode-media', 'episode-media', FALSE)
+ON CONFLICT (id)
+  DO UPDATE SET
+    public = FALSE,
+    name = EXCLUDED.name;
+
+COMMENT ON COLUMN public.episode_media.storage_object_key IS 'Path/key within the episode-media bucket; first segment MUST be the owning patient auth user id ({user_id}/...). RLS on storage.objects uses the same convention. No ciphertext columns in Postgres per PRD §10.';
+
+-- ---------------------------------------------------------------------------
+-- First path segment → patient UUID (invalid or missing segment → NULL, policies fail closed)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.episode_media_storage_path_patient_id (p_object_name text)
+  RETURNS uuid
+  LANGUAGE sql
+  STABLE
+  SECURITY INVOKER
+  SET search_path = pg_catalog, storage, public
+  AS $$
+    SELECT
+      CASE WHEN seg IS NOT NULL
+        AND seg ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN
+        seg::uuid
+      ELSE
+        NULL::uuid
+      END
+    FROM (
+      SELECT
+        (storage.foldername (p_object_name))[1] AS seg) s;
+  $$;
+
+COMMENT ON FUNCTION public.episode_media_storage_path_patient_id (text) IS 'Patient (owner) user id from episode-media object path: first segment must be a UUID. Keys MUST be {patient_user_id}/... per PRD §10 / episode_media.storage_object_key.';
+
+REVOKE ALL ON FUNCTION public.episode_media_storage_path_patient_id (text)
+  FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.episode_media_storage_path_patient_id (text) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- storage.objects — episode-media only; no anon policies (anonymous has no access)
+-- ---------------------------------------------------------------------------
+ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY episode_media_storage_select ON storage.objects
+  FOR SELECT
+  TO authenticated
+  USING (
+    bucket_id = 'episode-media'
+    AND public.episode_media_storage_path_patient_id (name) IS NOT NULL
+    AND (
+      public.episode_media_storage_path_patient_id (name) = (SELECT auth.uid())
+      OR public.user_is_caretaker_for_patient (public.episode_media_storage_path_patient_id (name))
+      OR public.user_has_practitioner_access (public.episode_media_storage_path_patient_id (name))));
+
+CREATE POLICY episode_media_storage_insert ON storage.objects
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'episode-media'
+    AND public.episode_media_storage_path_patient_id (name) IS NOT NULL
+    AND (
+      public.episode_media_storage_path_patient_id (name) = (SELECT auth.uid())
+      OR public.user_is_caretaker_for_patient (public.episode_media_storage_path_patient_id (name))));
+
+CREATE POLICY episode_media_storage_update ON storage.objects
+  FOR UPDATE
+  TO authenticated
+  USING (
+    bucket_id = 'episode-media'
+    AND public.episode_media_storage_path_patient_id (name) IS NOT NULL
+    AND (
+      public.episode_media_storage_path_patient_id (name) = (SELECT auth.uid())
+      OR public.user_is_caretaker_for_patient (public.episode_media_storage_path_patient_id (name))))
+  WITH CHECK (
+    bucket_id = 'episode-media'
+    AND public.episode_media_storage_path_patient_id (name) IS NOT NULL
+    AND (
+      public.episode_media_storage_path_patient_id (name) = (SELECT auth.uid())
+      OR public.user_is_caretaker_for_patient (public.episode_media_storage_path_patient_id (name))));
+
+CREATE POLICY episode_media_storage_delete ON storage.objects
+  FOR DELETE
+  TO authenticated
+  USING (
+    bucket_id = 'episode-media'
+    AND public.episode_media_storage_path_patient_id (name) IS NOT NULL
+    AND (
+      public.episode_media_storage_path_patient_id (name) = (SELECT auth.uid())
+      OR public.user_is_caretaker_for_patient (public.episode_media_storage_path_patient_id (name))));

--- a/supabase/migrations/20260328100000_episode_media_storage_bucket.sql
+++ b/supabase/migrations/20260328100000_episode_media_storage_bucket.sql
@@ -51,6 +51,62 @@ REVOKE ALL ON FUNCTION public.episode_media_storage_path_patient_id (text)
 GRANT EXECUTE ON FUNCTION public.episode_media_storage_path_patient_id (text) TO authenticated;
 
 -- ---------------------------------------------------------------------------
+-- Single evaluation of path → patient id per policy check (avoid repeated foldername/regex)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.episode_media_storage_can_select (p_object_name text)
+  RETURNS boolean
+  LANGUAGE sql
+  STABLE
+  SECURITY INVOKER
+  SET search_path = pg_catalog, public
+  AS $$
+    SELECT
+      CASE
+        WHEN v.pid IS NULL THEN FALSE
+        WHEN v.pid = (SELECT auth.uid()) THEN TRUE
+        WHEN public.user_is_caretaker_for_patient (v.pid) THEN TRUE
+        WHEN public.user_has_practitioner_access (v.pid) THEN TRUE
+        ELSE FALSE
+      END
+    FROM (
+      SELECT
+        public.episode_media_storage_path_patient_id (p_object_name) AS pid) AS v;
+  $$;
+
+COMMENT ON FUNCTION public.episode_media_storage_can_select (text) IS 'True if current user may read/list episode-media object: owner, active caretaker, or authorized practitioner. Computes path patient id once.';
+
+CREATE OR REPLACE FUNCTION public.episode_media_storage_can_write (p_object_name text)
+  RETURNS boolean
+  LANGUAGE sql
+  STABLE
+  SECURITY INVOKER
+  SET search_path = pg_catalog, public
+  AS $$
+    SELECT
+      CASE
+        WHEN v.pid IS NULL THEN FALSE
+        WHEN v.pid = (SELECT auth.uid()) THEN TRUE
+        WHEN public.user_is_caretaker_for_patient (v.pid) THEN TRUE
+        ELSE FALSE
+      END
+    FROM (
+      SELECT
+        public.episode_media_storage_path_patient_id (p_object_name) AS pid) AS v;
+  $$;
+
+COMMENT ON FUNCTION public.episode_media_storage_can_write (text) IS 'True if current user may insert/update/delete episode-media object: owner or active caretaker only. Computes path patient id once.';
+
+REVOKE ALL ON FUNCTION public.episode_media_storage_can_select (text)
+  FROM PUBLIC;
+
+REVOKE ALL ON FUNCTION public.episode_media_storage_can_write (text)
+  FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.episode_media_storage_can_select (text) TO authenticated;
+
+GRANT EXECUTE ON FUNCTION public.episode_media_storage_can_write (text) TO authenticated;
+
+-- ---------------------------------------------------------------------------
 -- storage.objects — episode-media only; no anon policies (anonymous has no access)
 -- ---------------------------------------------------------------------------
 ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
@@ -60,44 +116,28 @@ CREATE POLICY episode_media_storage_select ON storage.objects
   TO authenticated
   USING (
     bucket_id = 'episode-media'
-    AND public.episode_media_storage_path_patient_id (name) IS NOT NULL
-    AND (
-      public.episode_media_storage_path_patient_id (name) = (SELECT auth.uid())
-      OR public.user_is_caretaker_for_patient (public.episode_media_storage_path_patient_id (name))
-      OR public.user_has_practitioner_access (public.episode_media_storage_path_patient_id (name))));
+    AND public.episode_media_storage_can_select (name));
 
 CREATE POLICY episode_media_storage_insert ON storage.objects
   FOR INSERT
   TO authenticated
   WITH CHECK (
     bucket_id = 'episode-media'
-    AND public.episode_media_storage_path_patient_id (name) IS NOT NULL
-    AND (
-      public.episode_media_storage_path_patient_id (name) = (SELECT auth.uid())
-      OR public.user_is_caretaker_for_patient (public.episode_media_storage_path_patient_id (name))));
+    AND public.episode_media_storage_can_write (name));
 
 CREATE POLICY episode_media_storage_update ON storage.objects
   FOR UPDATE
   TO authenticated
   USING (
     bucket_id = 'episode-media'
-    AND public.episode_media_storage_path_patient_id (name) IS NOT NULL
-    AND (
-      public.episode_media_storage_path_patient_id (name) = (SELECT auth.uid())
-      OR public.user_is_caretaker_for_patient (public.episode_media_storage_path_patient_id (name))))
+    AND public.episode_media_storage_can_write (name))
   WITH CHECK (
     bucket_id = 'episode-media'
-    AND public.episode_media_storage_path_patient_id (name) IS NOT NULL
-    AND (
-      public.episode_media_storage_path_patient_id (name) = (SELECT auth.uid())
-      OR public.user_is_caretaker_for_patient (public.episode_media_storage_path_patient_id (name))));
+    AND public.episode_media_storage_can_write (name));
 
 CREATE POLICY episode_media_storage_delete ON storage.objects
   FOR DELETE
   TO authenticated
   USING (
     bucket_id = 'episode-media'
-    AND public.episode_media_storage_path_patient_id (name) IS NOT NULL
-    AND (
-      public.episode_media_storage_path_patient_id (name) = (SELECT auth.uid())
-      OR public.user_is_caretaker_for_patient (public.episode_media_storage_path_patient_id (name))));
+    AND public.episode_media_storage_can_write (name));


### PR DESCRIPTION
Closes #9

## Summary

Adds the private `episode-media` Storage bucket and RLS on `storage.objects` so only the owning patient, their caretaker (active `caretaker_access`), or their authorized practitioner (`practitioner_access`, same helper as PHI tables) can access objects. Upload/update/delete are limited to patient and caretaker; practitioners get read-only access, aligned with `episode_media` and PRD §10.

## Details

- New migration: bucket insert (`public = false`); helpers `episode_media_storage_path_user_id()`, `episode_media_storage_can_select()`, and `episode_media_storage_can_write()`; scoped policies on `storage.objects`. Object keys use `"{user_id}/..."` where `user_id` is `episode_media.user_id` (see migration comments).
- Comments document path convention, signed URLs as a later client concern, and no app-layer DEK wrapping in Storage.
- Roadmap: mark Week 2 “episode-media bucket + RLS” task complete.

## Checklist

- [ ] Supabase migrations workflow dry-run passes on the PR
- [ ] After merge to `main`, confirm Supabase migrations deploy job succeeds