### PR TITLE
fix(db): remove storage.objects ALTER incompatible with hosted Supabase

### DIFF
--- a/supabase/migrations/20260328100000_episode_media_storage_bucket.sql
+++ b/supabase/migrations/20260328100000_episode_media_storage_bucket.sql
@@ -109,8 +109,9 @@ GRANT EXECUTE ON FUNCTION public.episode_media_storage_can_write (text) TO authe
 
 -- ---------------------------------------------------------------------------
 -- storage.objects — episode-media only; no anon policies (anonymous has no access)
+-- RLS is already enabled on storage.objects by the platform; do not ALTER that table here — the
+-- migration DB role cannot own storage schema tables (SQLSTATE 42501 on hosted Supabase).
 -- ---------------------------------------------------------------------------
-ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
 
 CREATE POLICY episode_media_storage_select ON storage.objects
   FOR SELECT


### PR DESCRIPTION
Follow-up to #9 — original merge landed before the hosted Supabase fix; branch was restored and re-opened as this PR.

## Summary

Removes `ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY` from the episode-media migration. Hosted projects no longer allow the migration role to alter `storage.objects` (SQLSTATE 42501); RLS is already enabled there by default.

## Checklist

- [ ] Supabase migrations workflow dry-run passes
- [ ] After merge, `supabase db push` / deploy job succeeds
- [ ] Bucket `episode-media` is private; four `storage.objects` policies exist