### PR TITLE
feat(types): add schema-aligned enums and row types, wire web to @abstrack/types, note crypto non-PHI scope, bump CI pnpm to 10.33.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 10.29.2
+          version: 10.33.0
           run_install: false
 
       # This enables task distribution via Nx Cloud

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
+    "@abstrack/types": "workspace:*",
     "next": "~16.0.1",
     "react": "19.1.0",
     "react-dom": "19.1.0"

--- a/apps/web/src/lib/abstrack-types-wiring.ts
+++ b/apps/web/src/lib/abstrack-types-wiring.ts
@@ -1,0 +1,9 @@
+import type { EpisodeRow, FoodDiaryEntryRow, ProfileRow } from '@abstrack/types';
+
+/**
+ * Compile-only wiring: `@abstrack/types` must resolve when the web app typechecks.
+ * Not imported at runtime; kept in the program via tsconfig `include`.
+ */
+export type WebAppAbstrackTypesWiring = Pick<ProfileRow, 'app_role'> &
+  Pick<EpisodeRow, 'episode_type'> &
+  Pick<FoodDiaryEntryRow, 'meal_tag'>;

--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -1,3 +1,7 @@
+/**
+ * `@abstrack/crypto` — non-PHI utilities only. Application-layer PHI encryption is not
+ * part of this model; see PRD Technical Stack and Security (plaintext PHI under RLS).
+ */
 export function crypto(): string {
   return 'crypto';
 }

--- a/packages/types/src/lib/types.spec.ts
+++ b/packages/types/src/lib/types.spec.ts
@@ -1,7 +1,142 @@
-import { types } from './types.js';
+import { describe, expect, it } from 'vitest';
+import {
+  ACCESS_LOG_ACTOR_ROLES,
+  APP_ROLES,
+  EPISODE_TYPES,
+  HEALTH_MARKER_KINDS,
+  MEDIA_TYPES,
+  MEAL_TAGS,
+  PRESET_HEALTH_MARKER_KINDS,
+  SYMPTOM_RESPONSE_TYPES,
+  isAccessLogActorRole,
+  isAppRole,
+  isEpisodeType,
+  isHealthMarkerKind,
+  isMealTag,
+  isMediaType,
+  isPresetHealthMarkerKind,
+  isSymptomResponseType,
+} from './types.js';
 
-describe('types', () => {
-  it('should work', () => {
-    expect(types()).toEqual('types');
+/** Schema CHECK lists — keep in sync with 20260327120000_abstrack_core_schema.sql */
+const SCHEMA_APP_ROLES = ['patient', 'caretaker', 'practitioner'] as const;
+const SCHEMA_EPISODE_TYPES = ['ABS', 'Other'] as const;
+const SCHEMA_MEAL_TAGS = [
+  'Breakfast',
+  'Lunch',
+  'Dinner',
+  'Snack',
+  'Other',
+] as const;
+const SCHEMA_SYMPTOM_RESPONSE = [
+  'yes_no',
+  'severity_scale',
+  'free_text',
+  'photo',
+  'video',
+] as const;
+const SCHEMA_PRESET_MARKER_KINDS = [
+  'bac',
+  'blood_glucose',
+  'blood_pressure',
+  'heart_rate',
+  'weight',
+  'custom',
+] as const;
+const SCHEMA_HEALTH_MARKER_KINDS = [
+  ...SCHEMA_PRESET_MARKER_KINDS,
+  'wellness_mood',
+] as const;
+const SCHEMA_ACCESS_ACTOR_ROLES = [
+  'patient',
+  'caretaker',
+  'practitioner',
+  'system',
+  'service',
+] as const;
+const SCHEMA_MEDIA_TYPES = ['photo', 'video'] as const;
+
+function expectSameStringSet(
+  exported: readonly string[],
+  schema: readonly string[],
+): void {
+  expect(new Set(exported)).toEqual(new Set(schema));
+  expect(exported.length).toBe(schema.length);
+}
+
+describe('domain vocabulary (schema alignment)', () => {
+  it('APP_ROLES matches profiles.app_role CHECK', () => {
+    expectSameStringSet(APP_ROLES, SCHEMA_APP_ROLES);
+  });
+
+  it('EPISODE_TYPES matches episodes.episode_type CHECK', () => {
+    expectSameStringSet(EPISODE_TYPES, SCHEMA_EPISODE_TYPES);
+  });
+
+  it('MEAL_TAGS matches food_diary_entries.meal_tag CHECK', () => {
+    expectSameStringSet(MEAL_TAGS, SCHEMA_MEAL_TAGS);
+  });
+
+  it('SYMPTOM_RESPONSE_TYPES matches preset_symptoms / episode_symptoms CHECK', () => {
+    expectSameStringSet(SYMPTOM_RESPONSE_TYPES, SCHEMA_SYMPTOM_RESPONSE);
+  });
+
+  it('PRESET_HEALTH_MARKER_KINDS matches preset_health_markers.marker_kind CHECK', () => {
+    expectSameStringSet(PRESET_HEALTH_MARKER_KINDS, SCHEMA_PRESET_MARKER_KINDS);
+  });
+
+  it('HEALTH_MARKER_KINDS matches health_markers.marker_kind CHECK', () => {
+    expectSameStringSet(HEALTH_MARKER_KINDS, SCHEMA_HEALTH_MARKER_KINDS);
+  });
+
+  it('ACCESS_LOG_ACTOR_ROLES matches access_log.actor_role CHECK', () => {
+    expectSameStringSet(ACCESS_LOG_ACTOR_ROLES, SCHEMA_ACCESS_ACTOR_ROLES);
+  });
+
+  it('MEDIA_TYPES matches episode_media.media_type CHECK', () => {
+    expectSameStringSet(MEDIA_TYPES, SCHEMA_MEDIA_TYPES);
+  });
+});
+
+describe('type guards', () => {
+  it('isAppRole', () => {
+    expect(isAppRole('patient')).toBe(true);
+    expect(isAppRole('system')).toBe(false);
+    expect(isAppRole(null)).toBe(false);
+  });
+
+  it('isEpisodeType', () => {
+    expect(isEpisodeType('ABS')).toBe(true);
+    expect(isEpisodeType('abs')).toBe(false);
+  });
+
+  it('isMealTag', () => {
+    expect(isMealTag('Breakfast')).toBe(true);
+    expect(isMealTag('breakfast')).toBe(false);
+  });
+
+  it('isSymptomResponseType', () => {
+    expect(isSymptomResponseType('severity_scale')).toBe(true);
+    expect(isSymptomResponseType('scale')).toBe(false);
+  });
+
+  it('isPresetHealthMarkerKind', () => {
+    expect(isPresetHealthMarkerKind('bac')).toBe(true);
+    expect(isPresetHealthMarkerKind('wellness_mood')).toBe(false);
+  });
+
+  it('isHealthMarkerKind', () => {
+    expect(isHealthMarkerKind('wellness_mood')).toBe(true);
+    expect(isHealthMarkerKind('unknown')).toBe(false);
+  });
+
+  it('isMediaType', () => {
+    expect(isMediaType('photo')).toBe(true);
+    expect(isMediaType('audio')).toBe(false);
+  });
+
+  it('isAccessLogActorRole', () => {
+    expect(isAccessLogActorRole('service')).toBe(true);
+    expect(isAccessLogActorRole('admin')).toBe(false);
   });
 });

--- a/packages/types/src/lib/types.ts
+++ b/packages/types/src/lib/types.ts
@@ -1,3 +1,525 @@
-export function types(): string {
-  return 'types';
+/**
+ * Shared domain enums and table-aligned row shapes for ABStrack.
+ * Values mirror `supabase/migrations/20260327120000_abstrack_core_schema.sql`
+ * and PRD vocabulary (plaintext columns — serializable primitives only).
+ */
+
+// ---------------------------------------------------------------------------
+// User roles (profiles.app_role — PRD “Users & Roles”)
+// ---------------------------------------------------------------------------
+
+export const APP_ROLES = ['patient', 'caretaker', 'practitioner'] as const;
+export type AppRole = (typeof APP_ROLES)[number];
+
+// ---------------------------------------------------------------------------
+// Episode type (episodes.episode_type — PRD §4)
+// ---------------------------------------------------------------------------
+
+export const EPISODE_TYPES = ['ABS', 'Other'] as const;
+export type EpisodeType = (typeof EPISODE_TYPES)[number];
+
+// ---------------------------------------------------------------------------
+// Meal tags (food_diary_entries.meal_tag — PRD §6)
+// ---------------------------------------------------------------------------
+
+export const MEAL_TAGS = [
+  'Breakfast',
+  'Lunch',
+  'Dinner',
+  'Snack',
+  'Other',
+] as const;
+export type MealTag = (typeof MEAL_TAGS)[number];
+
+// ---------------------------------------------------------------------------
+// Symptom response types (preset_symptoms / episode_symptoms — PRD §2)
+// ---------------------------------------------------------------------------
+
+export const SYMPTOM_RESPONSE_TYPES = [
+  'yes_no',
+  'severity_scale',
+  'free_text',
+  'photo',
+  'video',
+] as const;
+export type SymptomResponseType = (typeof SYMPTOM_RESPONSE_TYPES)[number];
+
+// ---------------------------------------------------------------------------
+// Health marker kinds
+// ---------------------------------------------------------------------------
+
+/** Lines in `preset_health_markers` (subset of measurement kinds). */
+export const PRESET_HEALTH_MARKER_KINDS = [
+  'bac',
+  'blood_glucose',
+  'blood_pressure',
+  'heart_rate',
+  'weight',
+  'custom',
+] as const;
+export type PresetHealthMarkerKind = (typeof PRESET_HEALTH_MARKER_KINDS)[number];
+
+/** Rows in `health_markers` (includes wellness-only kind). */
+export const HEALTH_MARKER_KINDS = [
+  ...PRESET_HEALTH_MARKER_KINDS,
+  'wellness_mood',
+] as const;
+export type HealthMarkerKind = (typeof HEALTH_MARKER_KINDS)[number];
+
+// ---------------------------------------------------------------------------
+// Episode media
+// ---------------------------------------------------------------------------
+
+export const MEDIA_TYPES = ['photo', 'video'] as const;
+export type MediaType = (typeof MEDIA_TYPES)[number];
+
+// ---------------------------------------------------------------------------
+// Audit log actor role (access_log.actor_role — broader than app profiles)
+// ---------------------------------------------------------------------------
+
+export const ACCESS_LOG_ACTOR_ROLES = [
+  'patient',
+  'caretaker',
+  'practitioner',
+  'system',
+  'service',
+] as const;
+export type AccessLogActorRole = (typeof ACCESS_LOG_ACTOR_ROLES)[number];
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isAppRole(value: unknown): value is AppRole {
+  return (
+    typeof value === 'string' &&
+    (APP_ROLES as readonly string[]).includes(value)
+  );
 }
+
+export function isEpisodeType(value: unknown): value is EpisodeType {
+  return (
+    typeof value === 'string' &&
+    (EPISODE_TYPES as readonly string[]).includes(value)
+  );
+}
+
+export function isMealTag(value: unknown): value is MealTag {
+  return (
+    typeof value === 'string' &&
+    (MEAL_TAGS as readonly string[]).includes(value)
+  );
+}
+
+export function isSymptomResponseType(
+  value: unknown,
+): value is SymptomResponseType {
+  return (
+    typeof value === 'string' &&
+    (SYMPTOM_RESPONSE_TYPES as readonly string[]).includes(value)
+  );
+}
+
+export function isPresetHealthMarkerKind(
+  value: unknown,
+): value is PresetHealthMarkerKind {
+  return (
+    typeof value === 'string' &&
+    (PRESET_HEALTH_MARKER_KINDS as readonly string[]).includes(value)
+  );
+}
+
+export function isHealthMarkerKind(value: unknown): value is HealthMarkerKind {
+  return (
+    typeof value === 'string' &&
+    (HEALTH_MARKER_KINDS as readonly string[]).includes(value)
+  );
+}
+
+export function isMediaType(value: unknown): value is MediaType {
+  return (
+    typeof value === 'string' &&
+    (MEDIA_TYPES as readonly string[]).includes(value)
+  );
+}
+
+export function isAccessLogActorRole(
+  value: unknown,
+): value is AccessLogActorRole {
+  return (
+    typeof value === 'string' &&
+    (ACCESS_LOG_ACTOR_ROLES as readonly string[]).includes(value)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Timestamps & IDs (Supabase / PostgREST JSON)
+// ---------------------------------------------------------------------------
+
+/** ISO 8601 timestamptz string from Postgres. */
+export type IsoTimestamptz = string;
+
+/** UUID string. */
+export type Uuid = string;
+
+// ---------------------------------------------------------------------------
+// Row shapes (public schema)
+// ---------------------------------------------------------------------------
+
+export interface ProfileRow {
+  id: Uuid;
+  display_name: string | null;
+  app_role: AppRole;
+  created_at: IsoTimestamptz;
+  updated_at: IsoTimestamptz;
+}
+
+export type ProfileInsert = {
+  id: Uuid;
+  app_role: AppRole;
+  display_name?: string | null;
+};
+
+export type ProfileUpdate = Partial<
+  Pick<ProfileRow, 'display_name' | 'app_role'>
+>;
+
+export interface SymptomPresetRow {
+  id: Uuid;
+  user_id: Uuid;
+  name: string;
+  created_at: IsoTimestamptz;
+  updated_at: IsoTimestamptz;
+}
+
+export type SymptomPresetInsert = Pick<SymptomPresetRow, 'user_id' | 'name'> & {
+  id?: Uuid;
+};
+
+export type SymptomPresetUpdate = Partial<Pick<SymptomPresetRow, 'name'>>;
+
+export interface PresetSymptomRow {
+  id: Uuid;
+  preset_id: Uuid;
+  sort_order: number;
+  symptom_name: string;
+  response_type: SymptomResponseType;
+  prompt_instruction: string | null;
+  created_at: IsoTimestamptz;
+  updated_at: IsoTimestamptz;
+}
+
+export type PresetSymptomInsert = Pick<
+  PresetSymptomRow,
+  'preset_id' | 'sort_order' | 'symptom_name' | 'response_type'
+> & {
+  id?: Uuid;
+  prompt_instruction?: string | null;
+};
+
+export type PresetSymptomUpdate = Partial<
+  Pick<
+    PresetSymptomRow,
+    'sort_order' | 'symptom_name' | 'response_type' | 'prompt_instruction'
+  >
+>;
+
+export interface HealthMarkerPresetRow {
+  id: Uuid;
+  user_id: Uuid;
+  name: string;
+  created_at: IsoTimestamptz;
+  updated_at: IsoTimestamptz;
+}
+
+export type HealthMarkerPresetInsert = Pick<
+  HealthMarkerPresetRow,
+  'user_id' | 'name'
+> & {
+  id?: Uuid;
+};
+
+export type HealthMarkerPresetUpdate = Partial<
+  Pick<HealthMarkerPresetRow, 'name'>
+>;
+
+export interface PresetHealthMarkerRow {
+  id: Uuid;
+  preset_id: Uuid;
+  sort_order: number;
+  marker_kind: PresetHealthMarkerKind;
+  custom_name: string | null;
+  custom_unit: string | null;
+  created_at: IsoTimestamptz;
+  updated_at: IsoTimestamptz;
+}
+
+export type PresetHealthMarkerInsert = Pick<
+  PresetHealthMarkerRow,
+  'preset_id' | 'sort_order' | 'marker_kind'
+> & {
+  id?: Uuid;
+  custom_name?: string | null;
+  custom_unit?: string | null;
+};
+
+export type PresetHealthMarkerUpdate = Partial<
+  Pick<
+    PresetHealthMarkerRow,
+    'sort_order' | 'marker_kind' | 'custom_name' | 'custom_unit'
+  >
+>;
+
+export interface EpisodeRow {
+  id: Uuid;
+  user_id: Uuid;
+  symptom_preset_id: Uuid | null;
+  episode_type: EpisodeType;
+  episode_label: string | null;
+  note: string | null;
+  started_at: IsoTimestamptz;
+  ended_at: IsoTimestamptz | null;
+  created_at: IsoTimestamptz;
+  updated_at: IsoTimestamptz;
+}
+
+export type EpisodeInsert = Pick<
+  EpisodeRow,
+  'user_id' | 'started_at'
+> & {
+  id?: Uuid;
+  symptom_preset_id?: Uuid | null;
+  episode_type?: EpisodeType;
+  episode_label?: string | null;
+  note?: string | null;
+  ended_at?: IsoTimestamptz | null;
+};
+
+export type EpisodeUpdate = Partial<
+  Pick<
+    EpisodeRow,
+    | 'symptom_preset_id'
+    | 'episode_type'
+    | 'episode_label'
+    | 'note'
+    | 'started_at'
+    | 'ended_at'
+  >
+>;
+
+export interface EpisodeSymptomRow {
+  id: Uuid;
+  user_id: Uuid;
+  episode_id: Uuid | null;
+  preset_symptom_id: Uuid | null;
+  symptom_name: string;
+  response_type: SymptomResponseType;
+  response_boolean: boolean | null;
+  response_severity: number | null;
+  response_text: string | null;
+  sort_order: number;
+  created_at: IsoTimestamptz;
+  updated_at: IsoTimestamptz;
+}
+
+export type EpisodeSymptomInsert = Pick<
+  EpisodeSymptomRow,
+  'user_id' | 'symptom_name' | 'response_type'
+> & {
+  id?: Uuid;
+  episode_id?: Uuid | null;
+  preset_symptom_id?: Uuid | null;
+  response_boolean?: boolean | null;
+  response_severity?: number | null;
+  response_text?: string | null;
+  sort_order?: number;
+};
+
+export type EpisodeSymptomUpdate = Partial<
+  Pick<
+    EpisodeSymptomRow,
+    | 'episode_id'
+    | 'preset_symptom_id'
+    | 'symptom_name'
+    | 'response_type'
+    | 'response_boolean'
+    | 'response_severity'
+    | 'response_text'
+    | 'sort_order'
+  >
+>;
+
+export interface HealthMarkerRow {
+  id: Uuid;
+  user_id: Uuid;
+  episode_id: Uuid | null;
+  marker_kind: HealthMarkerKind;
+  custom_name: string | null;
+  custom_unit: string | null;
+  value_numeric: number | null;
+  systolic_numeric: number | null;
+  diastolic_numeric: number | null;
+  recorded_at: IsoTimestamptz;
+  notes: string | null;
+  created_at: IsoTimestamptz;
+  updated_at: IsoTimestamptz;
+}
+
+export type HealthMarkerInsert = Pick<
+  HealthMarkerRow,
+  'user_id' | 'marker_kind' | 'recorded_at'
+> & {
+  id?: Uuid;
+  episode_id?: Uuid | null;
+  custom_name?: string | null;
+  custom_unit?: string | null;
+  value_numeric?: number | null;
+  systolic_numeric?: number | null;
+  diastolic_numeric?: number | null;
+  notes?: string | null;
+};
+
+export type HealthMarkerUpdate = Partial<
+  Pick<
+    HealthMarkerRow,
+    | 'episode_id'
+    | 'marker_kind'
+    | 'custom_name'
+    | 'custom_unit'
+    | 'value_numeric'
+    | 'systolic_numeric'
+    | 'diastolic_numeric'
+    | 'recorded_at'
+    | 'notes'
+  >
+>;
+
+export interface FoodDiaryEntryRow {
+  id: Uuid;
+  user_id: Uuid;
+  episode_id: Uuid | null;
+  meal_tag: MealTag;
+  food_note: string;
+  logged_at: IsoTimestamptz;
+  created_at: IsoTimestamptz;
+  updated_at: IsoTimestamptz;
+}
+
+export type FoodDiaryEntryInsert = Pick<
+  FoodDiaryEntryRow,
+  'user_id' | 'meal_tag' | 'food_note' | 'logged_at'
+> & {
+  id?: Uuid;
+  episode_id?: Uuid | null;
+};
+
+export type FoodDiaryEntryUpdate = Partial<
+  Pick<
+    FoodDiaryEntryRow,
+    'episode_id' | 'meal_tag' | 'food_note' | 'logged_at'
+  >
+>;
+
+export interface PractitionerAccessRow {
+  id: Uuid;
+  patient_user_id: Uuid;
+  practitioner_user_id: Uuid;
+  created_at: IsoTimestamptz;
+  revoked_at: IsoTimestamptz | null;
+}
+
+export type PractitionerAccessInsert = Pick<
+  PractitionerAccessRow,
+  'patient_user_id' | 'practitioner_user_id'
+> & {
+  id?: Uuid;
+  revoked_at?: IsoTimestamptz | null;
+};
+
+export type PractitionerAccessUpdate = Partial<
+  Pick<PractitionerAccessRow, 'revoked_at'>
+>;
+
+export interface CaretakerAccessRow {
+  id: Uuid;
+  patient_user_id: Uuid;
+  caretaker_user_id: Uuid;
+  created_at: IsoTimestamptz;
+  revoked_at: IsoTimestamptz | null;
+}
+
+export type CaretakerAccessInsert = Pick<
+  CaretakerAccessRow,
+  'patient_user_id' | 'caretaker_user_id'
+> & {
+  id?: Uuid;
+  revoked_at?: IsoTimestamptz | null;
+};
+
+export type CaretakerAccessUpdate = Partial<
+  Pick<CaretakerAccessRow, 'revoked_at'>
+>;
+
+export interface EpisodeMediaRow {
+  id: Uuid;
+  user_id: Uuid;
+  episode_id: Uuid;
+  episode_symptom_id: Uuid | null;
+  storage_object_key: string;
+  thumbnail_storage_key: string | null;
+  media_type: MediaType;
+  duration_seconds: number | null;
+  upload_completed_at: IsoTimestamptz | null;
+  created_at: IsoTimestamptz;
+  updated_at: IsoTimestamptz;
+}
+
+export type EpisodeMediaInsert = Pick<
+  EpisodeMediaRow,
+  'user_id' | 'episode_id' | 'storage_object_key' | 'media_type'
+> & {
+  id?: Uuid;
+  episode_symptom_id?: Uuid | null;
+  thumbnail_storage_key?: string | null;
+  duration_seconds?: number | null;
+  upload_completed_at?: IsoTimestamptz | null;
+};
+
+export type EpisodeMediaUpdate = Partial<
+  Pick<
+    EpisodeMediaRow,
+    | 'episode_symptom_id'
+    | 'storage_object_key'
+    | 'thumbnail_storage_key'
+    | 'media_type'
+    | 'duration_seconds'
+    | 'upload_completed_at'
+  >
+>;
+
+/** Append-only audit metadata; no PHI columns. */
+export interface AccessLogRow {
+  id: Uuid;
+  occurred_at: IsoTimestamptz;
+  actor_user_id: Uuid | null;
+  actor_role: AccessLogActorRole;
+  patient_user_id: Uuid | null;
+  action: string;
+  resource_type: string;
+  resource_id: Uuid | null;
+  request_id: string | null;
+  ip_hash: string | null;
+}
+
+export type AccessLogInsert = Pick<
+  AccessLogRow,
+  'actor_role' | 'action' | 'resource_type'
+> & {
+  id?: Uuid;
+  occurred_at?: IsoTimestamptz;
+  actor_user_id?: Uuid | null;
+  patient_user_id?: Uuid | null;
+  resource_id?: Uuid | null;
+  request_id?: string | null;
+  ip_hash?: string | null;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@abstrack/types':
+        specifier: workspace:*
+        version: link:../../packages/types
       next:
         specifier: ~16.0.1
         version: 16.0.11(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.97.3)


### PR DESCRIPTION
Closes #10 

## Summary

Implements Week 2 shared domain types in `@abstrack/types`: enums and table-aligned row/insert/update shapes matching `20260327120000_abstrack_core_schema.sql` and PRD vocabulary (plaintext serializable fields only). Adds Vitest coverage for schema-aligned constants and type guards. Wires `@abstrack/web` to the workspace package for a compile check. Documents `@abstrack/crypto` as non-PHI-only per PRD. Aligns CI with local pnpm `10.33.0`.

## Changes

- **`@abstrack/types`**: `AppRole`, episode type, meal tags, symptom response types, health marker kinds, media types, access-log actor roles; guards; `*Row` / `*Insert` / `*Update` for core public tables.
- **`apps/web`**: `workspace:*` dependency on `@abstrack/types`; type-only wiring module under `src/lib/` so `tsc` resolves shared types.
- **`@abstrack/crypto`**: short file comment on intended scope (no app-layer PHI encryption).
- **CI**: `pnpm/action-setup` version → `10.33.0`.
- **`pnpm-lock.yaml`**: updated for the new web dependency.

## How to verify

- `pnpm install`
- `pnpm exec nx run @abstrack/types:build`
- `pnpm exec nx run @abstrack/types:test`
- `pnpm exec tsc -p apps/web/tsconfig.json --noEmit`

## Notes

- Types package stays free of `@abstrack/supabase` (pure shared types).