### PR TITLE
Client factory auth helpers typed data access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,14 +35,11 @@
 # Pass the publishable key (or legacy anon) as the second argument to
 # `createClient(url, key)` in client code; same RLS behavior.
 #
-# Secret key (or legacy service_role): server-only — Next.js Route Handlers /
-# Server Actions, trusted scripts, CI. Never `NEXT_PUBLIC_*`, `EXPO_PUBLIC_*`,
-# or mobile/client bundles. Prefer rotating `sb_secret_...` keys in the
-# dashboard over JWT secret rotation when possible.
+# Secret key (`sb_secret_...` → `SUPABASE_SECRET_KEY`): server-only for
+# `@abstrack/supabase/admin`. Never `NEXT_PUBLIC_*`, `EXPO_PUBLIC_*`, or client bundles.
 #
-# Legacy anon / service_role JWT keys still work during migration and are what
-# the Supabase CLI and self-hosted stacks use today; keep them in comments
-# below if your workflow needs them.
+# Legacy JWT anon keys may still be used for **client** `createClient` during migration;
+# this repo does not define a `SUPABASE_SERVICE_ROLE_KEY` env — use the dashboard secret key only.
 #
 # Edge Functions: publishable/secret keys have JWT verification caveats vs
 # legacy keys — see the “Known limitations” section in the API keys doc above.
@@ -57,12 +54,11 @@ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_your_key
 EXPO_PUBLIC_SUPABASE_URL=https://YOUR_PROJECT_REF.supabase.co
 EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_your_key
 
-# --- Server-only (optional; uncomment when a server route or script needs elevated API access)
+# --- Server-only (optional; uncomment when a server route or script imports @abstrack/supabase/admin)
 # SUPABASE_SECRET_KEY=sb_secret_your_key
 
-# --- Legacy (optional — Supabase hosted migration / CLI / self-host; same slots as publishable/secret)
+# --- Legacy publishable slot only (optional — until you use sb_publishable_* everywhere)
 # NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-# SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 
 # --- Shared packages (@abstrack/supabase, future PowerSync wiring)
 # Libraries read `process.env` from the consuming app’s bundle or Node context.

--- a/.github/workflows/supabase-db-types-pr.yml
+++ b/.github/workflows/supabase-db-types-pr.yml
@@ -29,6 +29,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - uses: supabase/setup-cli@v1
         with:
           version: ${{ env.SUPABASE_CLI_VERSION }}
@@ -40,7 +44,8 @@ jobs:
 
       - name: Check Database types match migrations
         run: |
-          cp packages/supabase/src/lib/database.types.ts /tmp/database.types.committed.ts
+          # Compare generated body only — committed file may include a hand-maintained header comment.
           supabase gen types typescript --local --schema public > /tmp/database.types.generated.ts
-          npx --yes prettier@3.6.2 --write /tmp/database.types.committed.ts /tmp/database.types.generated.ts
-          diff -u /tmp/database.types.committed.ts /tmp/database.types.generated.ts
+          awk '/^export type Json/{flag=1} flag' packages/supabase/src/lib/database.types.ts > /tmp/database.types.committed-body.ts
+          npx --yes prettier@3.6.2 --write /tmp/database.types.committed-body.ts /tmp/database.types.generated.ts
+          diff -u /tmp/database.types.committed-body.ts /tmp/database.types.generated.ts

--- a/.github/workflows/supabase-db-types-pr.yml
+++ b/.github/workflows/supabase-db-types-pr.yml
@@ -1,0 +1,46 @@
+# Ensure packages/supabase/src/lib/database.types.ts matches the schema produced by applying
+# supabase/migrations/* to a fresh local database (no Supabase Cloud secrets required).
+#
+# Runs on pull requests that touch migration SQL (same-repo only; mirrors the migrations dry-run policy).
+# Developers typically also run db push + gen types --linked against cloud before merge (see docs/SUPABASE_CLOUD_DEVELOPER.md).
+# On main, supabase-migrations.yml checks types against --linked after db push (no bot commit).
+
+name: Supabase Database types (PR)
+
+on:
+  pull_request:
+    paths:
+      - 'supabase/migrations/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: supabase-db-types-pr-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      SUPABASE_CLI_VERSION: 2.84.4
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: ${{ env.SUPABASE_CLI_VERSION }}
+
+      - name: Start local stack and apply migrations
+        run: |
+          supabase db start
+          supabase db reset --yes
+
+      - name: Check Database types match migrations
+        run: |
+          cp packages/supabase/src/lib/database.types.ts /tmp/database.types.committed.ts
+          supabase gen types typescript --local --schema public > /tmp/database.types.generated.ts
+          npx --yes prettier@3.6.2 --write /tmp/database.types.committed.ts /tmp/database.types.generated.ts
+          diff -u /tmp/database.types.committed.ts /tmp/database.types.generated.ts

--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -1,7 +1,12 @@
 # Apply pending SQL migrations from supabase/migrations/ to the linked Supabase Cloud project.
 # Requires repository secrets (see docs/DEV_SETUP.md §4).
 #
-# - push to main: applies migrations (supabase db push)
+# Intended workflow (docs/SUPABASE_CLOUD_DEVELOPER.md): developers also run `db push` + `gen types --linked`
+# locally before merge so one PR can include migration + database.types.ts. This workflow still runs `db push`
+# on main as a backstop and verifies types match cloud (no auto-commit).
+#
+# - push to main: applies migrations (supabase db push), then verifies that
+#   packages/supabase/src/lib/database.types.ts matches supabase gen types --linked (fails if not).
 # - pull_request: dry-run only (supabase db push --dry-run) when migration files change
 # - workflow_dispatch: manual deploy (deploy job only runs on refs/heads/main so a mistaken
 #   dispatch from a feature branch cannot push unmerged migrations to the linked project).
@@ -75,3 +80,20 @@ jobs:
 
       - name: Push migrations to Supabase Cloud
         run: supabase db push --yes
+
+      - name: Verify Database types match linked project (no auto-commit)
+        run: |
+          supabase gen types typescript --linked --schema public > /tmp/database.types.generated.ts
+          npx --yes prettier@3.6.2 --write /tmp/database.types.generated.ts
+          cp packages/supabase/src/lib/database.types.ts /tmp/database.types.committed.ts
+          npx --yes prettier@3.6.2 --write /tmp/database.types.committed.ts
+          if diff -q /tmp/database.types.committed.ts /tmp/database.types.generated.ts >/dev/null; then
+            echo "Database types match linked project."
+            exit 0
+          fi
+          echo "::error::packages/supabase/src/lib/database.types.ts does not match the linked Supabase project after db push."
+          echo "Run locally (Supabase CLI logged in and linked to this project), then commit:"
+          echo "  pnpm dlx supabase gen types typescript --linked --schema public > packages/supabase/src/lib/database.types.ts"
+          echo "  pnpm exec prettier --write packages/supabase/src/lib/database.types.ts"
+          diff -u /tmp/database.types.committed.ts /tmp/database.types.generated.ts || true
+          exit 1

--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -71,6 +71,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - uses: supabase/setup-cli@v1
         with:
           version: ${{ env.SUPABASE_CLI_VERSION }}
@@ -83,11 +87,11 @@ jobs:
 
       - name: Verify Database types match linked project (no auto-commit)
         run: |
+          # Compare generated body only — committed file may include a hand-maintained header comment.
           supabase gen types typescript --linked --schema public > /tmp/database.types.generated.ts
-          npx --yes prettier@3.6.2 --write /tmp/database.types.generated.ts
-          cp packages/supabase/src/lib/database.types.ts /tmp/database.types.committed.ts
-          npx --yes prettier@3.6.2 --write /tmp/database.types.committed.ts
-          if diff -q /tmp/database.types.committed.ts /tmp/database.types.generated.ts >/dev/null; then
+          awk '/^export type Json/{flag=1} flag' packages/supabase/src/lib/database.types.ts > /tmp/database.types.committed-body.ts
+          npx --yes prettier@3.6.2 --write /tmp/database.types.committed-body.ts /tmp/database.types.generated.ts
+          if diff -q /tmp/database.types.committed-body.ts /tmp/database.types.generated.ts >/dev/null; then
             echo "Database types match linked project."
             exit 0
           fi
@@ -95,5 +99,5 @@ jobs:
           echo "Run locally (Supabase CLI logged in and linked to this project), then commit:"
           echo "  pnpm dlx supabase gen types typescript --linked --schema public > packages/supabase/src/lib/database.types.ts"
           echo "  pnpm exec prettier --write packages/supabase/src/lib/database.types.ts"
-          diff -u /tmp/database.types.committed.ts /tmp/database.types.generated.ts || true
+          diff -u /tmp/database.types.committed-body.ts /tmp/database.types.generated.ts || true
           exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Repository instructions for AI coding agents
+
+## Supabase: cloud + CLI on Sarah’s machine for migrations
+
+**Sarah uses Supabase Cloud.** **GitHub Actions** runs **`supabase db push`** when code merges to **`main`** (backstop: `main` and cloud stay aligned).
+
+**For migration work, the recommended flow** is that **Sarah also runs `db push` from her laptop** (linked CLI) **before merge**, then **`gen types typescript --linked`** + Prettier, then commits **migration SQL + `database.types.ts` in one PR**. That way `--linked` sees the new schema because cloud already has the migration.
+
+Details: **[docs/SUPABASE_CLOUD_DEVELOPER.md](docs/SUPABASE_CLOUD_DEVELOPER.md)**.
+
+- **`supabase db reset`** is **local Docker only** (or CI-only), not cloud.
+- **`database.types.ts` is not auto-committed** by any bot.
+
+## When you MUST tell Sarah to run commands (migrations / types)
+
+If you add, edit, or rename **`supabase/migrations/*.sql`**, or change anything that affects **`database.types.ts`**, tell her **in the same response** to follow the **recommended workflow** in **SUPABASE_CLOUD_DEVELOPER.md**—at minimum these commands **from the repo root** (after `login` + `link`):
+
+```bash
+pnpm dlx supabase db push
+pnpm dlx supabase gen types typescript --linked --schema public > packages/supabase/src/lib/database.types.ts
+pnpm exec prettier --write packages/supabase/src/lib/database.types.ts
+```
+
+Then **commit** both the migration file(s) and **`packages/supabase/src/lib/database.types.ts`**.
+
+**Order matters:** `db push` **before** `gen types --linked` (linked reads **cloud**).
+
+## Tell Sarah when she must run something (general)
+
+If a step needs **her** terminal, **dashboard**, or **GitHub** settings, say so explicitly—do not imply it already ran.
+
+## Before changing automation
+
+Do **not** change `.github/workflows/*` deployment, permissions, or secrets without **asking Sarah first**.

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -6,6 +6,7 @@
     "eas-build-post-install": "cd ../../ && node tools/scripts/eas-build-post-install.mjs . apps/mobile"
   },
   "dependencies": {
+    "@abstrack/supabase": "workspace:*",
     "@expo/metro-config": "*",
     "@testing-library/react-native": "*",
     "expo": "*",

--- a/apps/mobile/src/app/App.spec.tsx
+++ b/apps/mobile/src/app/App.spec.tsx
@@ -2,8 +2,17 @@ import * as React from 'react';
 import { render } from '@testing-library/react-native';
 
 import App from './App';
+import { createMobileSupabaseClient } from '../lib/supabase-wiring';
 
 test('renders correctly', () => {
   const { getByTestId } = render(<App />);
   expect(getByTestId('heading')).toHaveTextContent(/Welcome/);
+});
+
+test('@abstrack/supabase native factory wires with env', () => {
+  process.env.EXPO_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+  process.env.EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'sb_publishable_test';
+  expect(createMobileSupabaseClient()).toBeTruthy();
+  delete process.env.EXPO_PUBLIC_SUPABASE_URL;
+  delete process.env.EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
 });

--- a/apps/mobile/src/app/App.spec.tsx
+++ b/apps/mobile/src/app/App.spec.tsx
@@ -9,10 +9,33 @@ test('renders correctly', () => {
   expect(getByTestId('heading')).toHaveTextContent(/Welcome/);
 });
 
-test('@abstrack/supabase native factory wires with env', () => {
-  process.env.EXPO_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
-  process.env.EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'sb_publishable_test';
-  expect(createMobileSupabaseClient()).toBeTruthy();
-  delete process.env.EXPO_PUBLIC_SUPABASE_URL;
-  delete process.env.EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+describe('@abstrack/supabase native factory', () => {
+  const ENV_KEYS = [
+    'EXPO_PUBLIC_SUPABASE_URL',
+    'EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY',
+  ] as const;
+  const snapshot: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      snapshot[key] = process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = snapshot[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  test('wires with env', () => {
+    process.env.EXPO_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'sb_publishable_test';
+    expect(createMobileSupabaseClient()).toBeTruthy();
+  });
 });

--- a/apps/mobile/src/lib/supabase-wiring.ts
+++ b/apps/mobile/src/lib/supabase-wiring.ts
@@ -1,0 +1,21 @@
+import {
+  createSupabaseNativeClient,
+  type NativeAuthStorage,
+} from '@abstrack/supabase';
+
+const memory: Record<string, string> = {};
+
+/** In-memory storage for tests / early wiring; swap for AsyncStorage in production auth flows. */
+export const mobileDevAuthStorage: NativeAuthStorage = {
+  getItem: (key) => memory[key] ?? null,
+  setItem: (key, value) => {
+    memory[key] = value;
+  },
+  removeItem: (key) => {
+    delete memory[key];
+  },
+};
+
+export function createMobileSupabaseClient() {
+  return createSupabaseNativeClient(mobileDevAuthStorage);
+}

--- a/apps/mobile/src/lib/supabase-wiring.ts
+++ b/apps/mobile/src/lib/supabase-wiring.ts
@@ -1,7 +1,7 @@
 import {
   createSupabaseNativeClient,
   type NativeAuthStorage,
-} from '@abstrack/supabase';
+} from '@abstrack/supabase/native';
 
 const memory: Record<string, string> = {};
 

--- a/apps/mobile/src/lib/supabase-wiring.ts
+++ b/apps/mobile/src/lib/supabase-wiring.ts
@@ -1,3 +1,4 @@
+import type { AbstrackSupabaseClient } from '@abstrack/supabase';
 import {
   createSupabaseNativeClient,
   type NativeAuthStorage,
@@ -16,6 +17,6 @@ export const mobileDevAuthStorage: NativeAuthStorage = {
   },
 };
 
-export function createMobileSupabaseClient() {
+export function createMobileSupabaseClient(): AbstrackSupabaseClient {
   return createSupabaseNativeClient(mobileDevAuthStorage);
 }

--- a/apps/mobile/tsconfig.app.json
+++ b/apps/mobile/tsconfig.app.json
@@ -38,5 +38,10 @@
     "**/*.jsx",
     ".expo/types/**/*.ts",
     "expo-env.d.ts"
+  ],
+  "references": [
+    {
+      "path": "../../packages/supabase/tsconfig.lib.json"
+    }
   ]
 }

--- a/apps/practitioner/package.json
+++ b/apps/practitioner/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
+    "@abstrack/supabase": "workspace:*",
     "next": "~16.0.1",
     "react": "19.1.0",
     "react-dom": "19.1.0"

--- a/apps/practitioner/specs/index.spec.tsx
+++ b/apps/practitioner/specs/index.spec.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import Page from '../src/app/page';
+import type { PractitionerSupabaseProfilesRow } from '../src/lib/supabase-wiring';
 
 describe('Page', () => {
   it('should render successfully', () => {
     const { baseElement } = render(<Page />);
     expect(baseElement).toBeTruthy();
+  });
+
+  it('resolves @abstrack/supabase types', () => {
+    const row: PractitionerSupabaseProfilesRow | null = null;
+    expect(row).toBeNull();
   });
 });

--- a/apps/practitioner/src/lib/supabase-wiring.ts
+++ b/apps/practitioner/src/lib/supabase-wiring.ts
@@ -1,0 +1,5 @@
+import type { Database } from '@abstrack/supabase';
+
+/** Compile-time check that the practitioner app resolves `@abstrack/supabase`. */
+export type PractitionerSupabaseProfilesRow =
+  Database['public']['Tables']['profiles']['Row'];

--- a/apps/practitioner/tsconfig.json
+++ b/apps/practitioner/tsconfig.json
@@ -50,7 +50,7 @@
   ],
   "references": [
     {
-      "path": "../../packages/supabase/tsconfig.lib.json"
+      "path": "../../packages/supabase"
     }
   ]
 }

--- a/apps/practitioner/tsconfig.json
+++ b/apps/practitioner/tsconfig.json
@@ -50,7 +50,7 @@
   ],
   "references": [
     {
-      "path": "../../packages/supabase"
+      "path": "../../packages/supabase/tsconfig.lib.json"
     }
   ]
 }

--- a/apps/practitioner/tsconfig.json
+++ b/apps/practitioner/tsconfig.json
@@ -47,5 +47,10 @@
     "eslint.config.js",
     "eslint.config.cjs",
     "eslint.config.mjs"
+  ],
+  "references": [
+    {
+      "path": "../../packages/supabase"
+    }
   ]
 }

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
+    "@abstrack/supabase": "workspace:*",
     "@abstrack/types": "workspace:*",
     "next": "~16.0.1",
     "react": "19.1.0",

--- a/apps/web/src/lib/abstrack-types-wiring.ts
+++ b/apps/web/src/lib/abstrack-types-wiring.ts
@@ -1,9 +1,14 @@
 import type { EpisodeRow, FoodDiaryEntryRow, ProfileRow } from '@abstrack/types';
+import type { Database } from '@abstrack/supabase';
 
 /**
- * Compile-only wiring: `@abstrack/types` must resolve when the web app typechecks.
+ * Compile-only wiring: `@abstrack/types` and `@abstrack/supabase` must resolve when the web app typechecks.
  * Not imported at runtime; kept in the program via tsconfig `include`.
  */
 export type WebAppAbstrackTypesWiring = Pick<ProfileRow, 'app_role'> &
   Pick<EpisodeRow, 'episode_type'> &
   Pick<FoodDiaryEntryRow, 'meal_tag'>;
+
+/** `Database` table row for `profiles` (Week 2 schema). */
+export type WebSupabaseProfilesRow =
+  Database['public']['Tables']['profiles']['Row'];

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -50,10 +50,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/types/tsconfig.lib.json"
+      "path": "../../packages/types"
     },
     {
-      "path": "../../packages/supabase/tsconfig.lib.json"
+      "path": "../../packages/supabase"
     }
   ]
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -47,5 +47,13 @@
     "eslint.config.js",
     "eslint.config.cjs",
     "eslint.config.mjs"
+  ],
+  "references": [
+    {
+      "path": "../../packages/types"
+    },
+    {
+      "path": "../../packages/supabase"
+    }
   ]
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -50,10 +50,10 @@
   ],
   "references": [
     {
-      "path": "../../packages/types"
+      "path": "../../packages/types/tsconfig.lib.json"
     },
     {
-      "path": "../../packages/supabase"
+      "path": "../../packages/supabase/tsconfig.lib.json"
     }
   ]
 }

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -152,7 +152,7 @@ If you copied the full `.env.example` into `apps/mobile/.env`, that file also co
 2. Remove or comment out variables you do not use yet; **uncomment and set** at minimum:
    - **Next apps:** `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (or legacy `NEXT_PUBLIC_SUPABASE_ANON_KEY` if you have not migrated).
    - **Mobile:** only the **`EXPO_PUBLIC_*`** pair above (after trimming any copied `NEXT_PUBLIC_*` lines — see previous subsection).
-3. Optional server-only keys (`SUPABASE_SECRET_KEY` or legacy `SUPABASE_SERVICE_ROLE_KEY`) belong only in **server** contexts (e.g. Next Route Handlers), never in `EXPO_PUBLIC_*` or client bundles.
+3. Optional server-only **`SUPABASE_SECRET_KEY`** (`sb_secret_...`) belongs only in **server** contexts (e.g. Next Route Handlers), never in `EXPO_PUBLIC_*` or client bundles. `@abstrack/supabase/admin` does not use legacy JWT `service_role` env vars.
 
 Get URLs and keys from the [Supabase dashboard](https://supabase.com/dashboard): **Project Settings → API** / **API Keys**, or **Integrations → Data API** for the API URL. For Email/password auth (PRD), enable **Authentication → Providers → Email**.
 

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -165,6 +165,8 @@ Get URLs and keys from the [Supabase dashboard](https://supabase.com/dashboard):
 
 ## 4. Supabase database migrations (cloud CLI and CI)
 
+**Supabase workflow (cloud + CLI + GitHub Actions):** **[SUPABASE_CLOUD_DEVELOPER.md](SUPABASE_CLOUD_DEVELOPER.md)** — keep **Actions `db push` on `main`**; for a **single PR** with migrations + types, run **`db push`** and **`gen types --linked`** from your laptop **before merge**. **AI assistants:** **[AGENTS.md](../AGENTS.md)**.
+
 App environment variables (`NEXT_PUBLIC_SUPABASE_URL`, keys) let clients call the **Data API**; they do **not** apply SQL from the repo. Schema changes live in [`supabase/migrations/`](../supabase/migrations/) and must be applied to your hosted Postgres with the **Supabase CLI** (or an equivalent process).
 
 Official reference: [Managing Environments](https://supabase.com/docs/guides/cli/managing-environments) (CLI + GitHub Actions).
@@ -207,6 +209,8 @@ After new files exist in `supabase/migrations/`, apply them to the linked projec
 pnpm dlx supabase db push
 ```
 
+**Recommended with this repo:** run **`db push`** from your laptop **before merging** a migration PR, then **`gen types typescript --linked`** and update `packages/supabase/src/lib/database.types.ts` (see **[SUPABASE_CLOUD_DEVELOPER.md](SUPABASE_CLOUD_DEVELOPER.md)**). **GitHub Actions** still runs **`db push`** on **`main`** after merge as a backstop.
+
 Useful variants:
 
 - **`pnpm dlx supabase db push --dry-run`** — prints which migrations would run without applying them (good for checks before merge).
@@ -225,6 +229,8 @@ The workflow [`.github/workflows/supabase-migrations.yml`](../.github/workflows/
 | `SUPABASE_DB_PASSWORD` | Postgres password for the `postgres` role (from **Connect** or **Database → Settings**; see §4 above). |
 
 Add these under **Repository → Settings → Secrets and variables → Actions**. The workflow runs **`supabase db push --dry-run`** on pull requests that change migration files (same-repo branches only; **fork PRs do not receive secrets**, so migrate checks are skipped there), and **`supabase db push`** on pushes to `main` when migration paths change. You can also run the workflow manually (**Actions → Supabase migrations → Run workflow**).
+
+**Types file:** [`.github/workflows/supabase-migrations.yml`](../.github/workflows/supabase-migrations.yml) runs **`supabase gen types typescript --linked`** after `db push` on `main` only to **verify** the committed `packages/supabase/src/lib/database.types.ts` matches cloud—it **does not commit**. If it fails, follow **[SUPABASE_CLOUD_DEVELOPER.md](SUPABASE_CLOUD_DEVELOPER.md)**. [`.github/workflows/supabase-db-types-pr.yml`](../.github/workflows/supabase-db-types-pr.yml) may compare types to migration SQL on PRs using a **CI-only** Docker stack.
 
 If you later use **separate staging and production** projects, duplicate the pattern with different secrets (for example `STAGING_PROJECT_ID` / `PRODUCTION_PROJECT_ID`) as in the [demo workflow](https://supabase.com/docs/guides/cli/managing-environments#configure-github-actions).
 
@@ -320,7 +326,7 @@ The workspace pins **React 19.1.x** to match **Expo SDK 54** and to stay aligned
 - [ ] `pnpm install --frozen-lockfile` succeeded
 - [ ] `apps/web/.env.local` and `apps/practitioner/.env.local` created from `.env.example` and filled with project credentials
 - [ ] `apps/mobile/.env` created from `.env.example`, **trimmed** to `EXPO_PUBLIC_*` only, and filled with real values
-- [ ] Supabase CLI can talk to your cloud project: `pnpm dlx supabase login`, `pnpm dlx supabase link --project-ref <ref>`, then `pnpm dlx supabase db push` when you have pending migrations ([§4](#4-supabase-database-migrations-cloud-cli-and-ci))
+- [ ] Supabase CLI: `login`, `link`, and for migration PRs **`db push` + `gen types --linked`** + Prettier before merge ([§4](#4-supabase-database-migrations-cloud-cli-and-ci), [SUPABASE_CLOUD_DEVELOPER.md](SUPABASE_CLOUD_DEVELOPER.md))
 - [ ] If using GitHub Actions for migrations: repository secrets set (`SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_ID`, `SUPABASE_DB_PASSWORD`) per [§4](#4-supabase-database-migrations-cloud-cli-and-ci)
 - [ ] `pnpm exec nx run-many -t lint test typecheck` (and build excluding mobile if you match CI) passes
 - [ ] `pnpm exec nx dev web` (and/or other apps) runs as expected

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -29,8 +29,8 @@
 - [x] Write RLS policies for all PHI tables (patient owns data; caretaker and practitioner per grant tables; practitioner MFA rules per [PRD](PRD.md))
 - [x] Append-only `access_log`: privilege/RLS/trigger pattern so clients cannot forge or mutate log rows (trusted insert path only)
 - [x] Create the private `episode-media` storage bucket with RLS on `storage.objects`
-- [ ] Implement `@abstrack/types` -- all shared TypeScript interfaces and enums (episode types, meal tags, symptom response types, user roles, etc.)
-- [ ] Implement `@abstrack/supabase` -- Supabase client factory, auth helpers, typed query wrappers
+- [x] Implement `@abstrack/types` -- all shared TypeScript interfaces and enums (episode types, meal tags, symptom response types, user roles, etc.)
+- [x] Implement `@abstrack/supabase` -- Supabase client factory, auth helpers, typed query wrappers
 
 **Why this week:** Foundation work with no UI to build or test -- ideal while school is busy. Everything downstream depends on the schema and types being correct. PHI is stored as normal columns protected by RLS, TLS, and platform encryption at rest ([PRD](PRD.md)).
 
@@ -43,9 +43,10 @@
 **Tasks:**
 
 - [ ] Patient sign-up and login: email/password via Supabase Auth
-- [ ] Persistent session via Supabase Auth refresh tokens (patient default: stays logged in; optional "require re-auth on app open" can be deferred or stubbed)
+- [ ] Persistent session via Supabase Auth refresh tokens (patient default: stays logged in); **optional patient preference** to require re-authentication when opening the app
 - [ ] Password reset via email link; password change does **not** re-encrypt PHI (server stores plaintext PHI under RLS per [PRD](PRD.md))
-- [ ] Optional: `@abstrack/crypto` package **only** for non-PHI utilities if needed (e.g. helpers); **not** used for encrypting database columns or shared keys between roles
+- [ ] Wire **`healthCheckProfilesLimit1`** from `@abstrack/supabase` in **one** patient app (web or mobile) as part of validating sign-in/session: env keys, session, and RLS end-to-end
+- [ ] `@abstrack/crypto`: README (and package entry) state **non-PHI utilities only** per PRD (no database PHI encryption, no shared PHI keys). Replace the placeholder export with **one** small non-PHI utility (e.g. stable id / hash helper for non-sensitive identifiers)
 - [ ] Document security baseline for the repo: TLS, RLS, grant tables (`practitioner_access`, `caretaker_access`), alignment with PRD security section
 
 **Why this week:** Establishes auth without a client-side encryption key hierarchy. The product safeguards are RLS, grants, TLS, audit logging, and (later) SQLCipher on device—not field-level E2E crypto.
@@ -80,7 +81,7 @@
 
 - [ ] TOTP setup flow for practitioners via Supabase Auth MFA API (mandatory for practitioners)
 - [ ] Practitioner MFA **fail-closed** per [PRD](PRD.md): RLS and/or **Edge Function** (or equivalent) verifies MFA via Auth APIs before patient-data reads; hooks alone must not be the sole control if they can fail open
-- [ ] Optional: JWT claims / role metadata for routing; practitioner patient-data access must satisfy MFA rules in policy or server path
+- [ ] JWT claims / role metadata for routing; practitioner patient-data access must satisfy MFA rules in policy or server path
 - [ ] Frontend MFA gating in practitioner app (no patient routes until MFA verified)
 
 **Second half (April 16-19, school finished):**
@@ -114,7 +115,7 @@
   - Free text note + meal tag (Breakfast/Lunch/Dinner/Snack/Other) + timestamp
   - Stored as plaintext in PostgreSQL under RLS (`food_diary_entries.food_note` per [PRD](PRD.md))
 - [ ] General wellness logging:
-  - "How are you feeling" mood/wellness entry with optional notes
+  - "How are you feeling" mood/wellness entry with a notes field
   - Ad-hoc symptom logging (without starting a full episode)
   - Ad-hoc health marker capture
 
@@ -130,7 +131,7 @@
 - [ ] Photo capture within episode prompt flow
 - [ ] Immediate playback preview + re-record option
 - [ ] **Server-side confidentiality for media (not client DEK):** upload to private `episode-media` bucket; access via RLS on `storage.objects` and **time-limited signed URLs**; confidentiality from private bucket + RLS + TLS + platform at-rest encryption ([PRD](PRD.md) Section 10)
-- [ ] Optional thumbnail object in same bucket (same access controls as primary file)
+- [ ] Thumbnail object in same bucket as primary media (same access controls as primary file)
 - [ ] Playback: obtain signed URL → download over TLS → display in `<video>` / `<img>` or RN equivalents (**no** application-layer decrypt step for stored objects)
 - [ ] Implement `@abstrack/powersync`:
   - PowerSync schema matching Supabase tables
@@ -249,10 +250,10 @@ graph TD
     W9 --> W10
 ```
 
-## Risk Mitigation Notes
+## Notes (constraints, not scope cuts)
 
-- **PowerSync + RLS consistency:** Sync Rules must mirror grant logic (patient / caretaker / practitioner). Treat RLS as authoritative for API access; validate rule changes in tests ([PRD](PRD.md) Architecture). If PowerSync setup is difficult, media can upload when online first; full offline sync can slip toward week 9 only if needed.
-- **Practitioner MFA fail-closed:** Prefer an Edge Function (or equivalent) that verifies MFA before returning patient data; do not rely on JWT hooks alone if they can omit claims. If blocked, narrow scope to "demo with verified MFA session only" rather than weakening the model.
-- **SQLCipher / offline queue:** Week 7 pairs media and offline sync. Device-bound encryption for queued blobs is recommended in the PRD; it is separate from server-side PHI encryption and does not involve sharing keys between users.
-- **Charts:** Scheduled in week 9 with server-side aggregation to match PRD and avoid heavy client downloads. If time is tight, food diary correlation (the most complex chart) can be cut.
-- **Presentation prep:** A full week is reserved. The demo script should be drafted by mid-week 10 to allow rehearsal time.
+- **PowerSync + RLS consistency:** Sync Rules must mirror grant logic (patient / caretaker / practitioner). Treat RLS as authoritative for API access; validate rule changes in tests ([PRD](PRD.md) Architecture). Week 7 delivers online media upload and the offline queue + PowerSync work as listed in that week’s tasks.
+- **Practitioner MFA fail-closed:** Use an Edge Function (or equivalent) that verifies MFA before returning patient data; do not rely on JWT hooks alone if they can omit claims. This is part of Week 5’s practitioner MFA work, not a downgrade path.
+- **SQLCipher / offline queue:** Week 7 pairs media and offline sync. Device-bound encryption for queued blobs matches the PRD; it is separate from server-side PHI encryption and does not involve sharing keys between users.
+- **Charts:** Week 9 includes server-side aggregation for all charts in that week’s task list, including food diary correlation—no client-side download of full histories for aggregation.
+- **Presentation prep:** Week 10 reserves time for polish, report, and presentation; draft the demo script by mid-week 10 so rehearsal is on schedule.

--- a/docs/SUPABASE_CLOUD_DEVELOPER.md
+++ b/docs/SUPABASE_CLOUD_DEVELOPER.md
@@ -80,6 +80,20 @@ Then the migration hits cloud when **CI runs `db push` on `main`** after merge. 
 
 ---
 
+## After you change migrations or `database.types.ts`: check the TypeScript package
+
+**`db push` and `gen types` only refresh the schema snapshot.** They do **not** compile or test **`@abstrack/supabase`** (clients, auth, queries). After any migration/typegen work—or before you push a PR that touches `packages/supabase`—run:
+
+```bash
+pnpm exec nx run supabase:lint
+pnpm exec nx run supabase:test
+pnpm exec nx run supabase:build
+```
+
+For the whole workspace (closer to CI), see [DEV_SETUP.md §5](DEV_SETUP.md#5-verify-the-workspace).
+
+---
+
 ## PR check (Docker in CI only)
 
 [`.github/workflows/supabase-db-types-pr.yml`](../.github/workflows/supabase-db-types-pr.yml) may compare committed types to output from migrations applied in a **temporary** CI database—not your cloud. It does **not** replace the recommended **local `db push` + `--linked`** flow for your machine; it is an extra guard on PRs that touch migrations.

--- a/docs/SUPABASE_CLOUD_DEVELOPER.md
+++ b/docs/SUPABASE_CLOUD_DEVELOPER.md
@@ -1,0 +1,118 @@
+# Supabase Cloud — what you do, when (and notes for AI)
+
+This project uses **Supabase Cloud** as the development database.
+
+**Recommended setup (this repo):**
+
+1. **GitHub Actions** still runs **`supabase db push`** when changes land on **`main`**—so merged code and cloud stay aligned even if you forget a manual step.
+2. **You manually** run **`db push`** from your laptop **when needed** (usually **before merge**, on your feature branch) so cloud has the new migration **before** you run **`gen types typescript --linked`**. That lets you put **migration SQL + `database.types.ts` in one PR** without waiting for merge.
+
+**There is no requirement to run a local Supabase Docker stack** for this path—only the Supabase **CLI** (login + link + `db push` + `gen types`).
+
+---
+
+## Ground rules (read first)
+
+| Fact | Implication |
+|------|-------------|
+| **Canonical DB is Supabase Cloud** | `db push` applies `supabase/migrations/` to your hosted project (CLI on your laptop **and/or** GitHub Actions on `main`). |
+| **`supabase db reset` is local-only** | It only affects a **Docker** database from `supabase db start` (your machine or CI). It does **not** reset cloud. |
+| **`gen types typescript --linked` reads cloud** | It does not “read” new SQL from git until that SQL has been applied to cloud via **`db push`**. |
+
+---
+
+## Recommended workflow: one PR (manual `db push` + `gen types`, CI as backstop)
+
+Use this when you add or change **`supabase/migrations/*.sql`** and want **`database.types.ts` in the same PR**:
+
+1. **Supabase CLI once per machine:** `pnpm dlx supabase login` and `pnpm dlx supabase link --project-ref <project-ref>` (see [DEV_SETUP.md §4](DEV_SETUP.md#4-supabase-database-migrations-cloud-cli-and-ci)).
+2. **Commit** your new/edited migration file(s) on your branch.
+3. **Apply migrations to cloud from your laptop** (same linked project as production/dev cloud):
+
+   ```bash
+   pnpm dlx supabase db push
+   ```
+
+   Optional: `pnpm dlx supabase db push --dry-run` first.
+
+4. **Regenerate types** (cloud now matches your migration):
+
+   ```bash
+   pnpm dlx supabase gen types typescript --linked --schema public > packages/supabase/src/lib/database.types.ts
+   pnpm exec prettier --write packages/supabase/src/lib/database.types.ts
+   ```
+
+5. **Commit** `packages/supabase/src/lib/database.types.ts` and **open / update your PR** with both files.
+6. **Merge to `main`.** GitHub Actions runs **`db push` again**; for migrations you already applied, that is typically a **no-op**. The workflow then **verifies** that committed `database.types.ts` matches **`gen types --linked`** output—if something drifted, fix and push.
+
+**Why manual `db push` before merge?** So cloud is updated **before** `--linked` typegen. If you only relied on CI `db push` after merge, `--linked` could not reflect the new schema until after merge—splitting migration and types across PRs.
+
+**You still keep GitHub Actions** so **`main`** stays the source of truth: merges you make without a local `db push` (e.g. hotfix) still apply pending migrations from git to cloud.
+
+---
+
+## If you skip local `db push` before merge
+
+Then the migration hits cloud when **CI runs `db push` on `main`** after merge. **`gen types --linked`** only works **after** that. You would need to **regenerate types and commit** in a **follow-up** commit (or PR) unless the [PR types workflow](../.github/workflows/supabase-db-types-pr.yml) already forced an updated file via its Docker-based check.
+
+---
+
+## One-time setup checklist
+
+1. **GitHub Actions:** repository secrets for [`.github/workflows/supabase-migrations.yml`](../.github/workflows/supabase-migrations.yml)—see [DEV_SETUP.md §4](DEV_SETUP.md#4-supabase-database-migrations-cloud-cli-and-ci) (`SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_ID`, `SUPABASE_DB_PASSWORD`).
+2. **Your laptop (for the recommended migration flow):** `pnpm dlx supabase login`, `pnpm dlx supabase link --project-ref <project-ref>`.
+
+---
+
+## Day-to-day: no database work
+
+- Ordinary app code: no Supabase CLI.
+- Env files point at cloud (DEV_SETUP §3).
+
+---
+
+## Types file: no bot
+
+| What | Who / what |
+|------|------------|
+| **`database.types.ts` in git** | **You** regenerate with **`gen types --linked`** + Prettier and **commit**. Nothing auto-commits. |
+| **Verify on `main`** | After CI `db push`, the workflow **diffs** committed types vs `--linked` output; **fails** if they differ (run the regen commands and push). |
+
+---
+
+## PR check (Docker in CI only)
+
+[`.github/workflows/supabase-db-types-pr.yml`](../.github/workflows/supabase-db-types-pr.yml) may compare committed types to output from migrations applied in a **temporary** CI database—not your cloud. It does **not** replace the recommended **local `db push` + `--linked`** flow for your machine; it is an extra guard on PRs that touch migrations.
+
+---
+
+## If you never run Docker locally
+
+**You do not need Docker** for the recommended path—only **`db push`** and **`gen types --linked`** against cloud. Docker appears only **inside** certain GitHub Actions jobs.
+
+---
+
+## Instructions for AI assistants (Cursor, Copilot, etc.)
+
+1. **Assume Supabase Cloud** for development—not `supabase start` on Sarah’s laptop unless she says so.
+
+2. **Recommended migration flow for Sarah:** when changing **`supabase/migrations/`**, tell her—in the **same message**—to run **`db push`** to cloud **then** **`gen types --linked`** + Prettier **then** commit **both** migration and `packages/supabase/src/lib/database.types.ts` **before** or as part of merge (see **Recommended workflow** above). **GitHub Actions** still runs `db push` on `main` as a backstop.
+
+3. **Never imply `supabase db reset` affects cloud.** Local Docker only (or CI-only).
+
+4. **Say explicitly** when she must use **her terminal** (CLI login, link, `db push`, `gen types`) vs what CI does after merge.
+
+5. **Do not** imply a bot commits `database.types.ts`.
+
+6. **Ask before changing** `.github/workflows/*` deployment or secrets without her approval.
+
+---
+
+## Related files
+
+| Topic | Location |
+|-------|----------|
+| CLI install, link, secrets | [DEV_SETUP.md §4](DEV_SETUP.md#4-supabase-database-migrations-cloud-cli-and-ci) |
+| Migrations + verify on `main` | [`.github/workflows/supabase-migrations.yml`](../.github/workflows/supabase-migrations.yml) |
+| PR types check | [`.github/workflows/supabase-db-types-pr.yml`](../.github/workflows/supabase-db-types-pr.yml) |
+| App env vars | [`packages/supabase/README.md`](../packages/supabase/README.md), [`.env.example`](../.env.example) |

--- a/packages/supabase/README.md
+++ b/packages/supabase/README.md
@@ -42,8 +42,8 @@ Full template: [`.env.example`](../../.env.example).
 
 ## Server-only admin API (`@abstrack/supabase/admin`)
 
-- **`getSupabaseServiceRoleKey()`** — reads **`SUPABASE_SECRET_KEY`** (`sb_secret_...`) only.
-- **`getSupabaseAdminClient()`** — service-role client (bypasses RLS). Use only in audited server jobs or admin routes.
+- **`getSupabaseSecretKey()`** — reads **`SUPABASE_SECRET_KEY`** (`sb_secret_...`) only (not the legacy JWT `service_role` env name).
+- **`getSupabaseAdminClient()`** — client built with that secret key; **bypasses RLS** (elevated access). Use only in audited server jobs or admin routes.
 
 ## Regenerate / automation
 

--- a/packages/supabase/README.md
+++ b/packages/supabase/README.md
@@ -1,12 +1,10 @@
-# supabase
+# `@abstrack/supabase`
 
-**Status:** Scaffold only. The exported API is still the Nx-generated placeholder (`supabase()` in `src/lib/supabase.ts`). Planned work — Supabase client factory, auth helpers, and typed query wrappers — is tracked under **Week 2** in [docs/ROADMAP.md](../../docs/ROADMAP.md).
-
-The sections below document **environment variables** the apps will use once that implementation exists; they are accurate for setup today.
+Shared Supabase **client factories**, **auth helpers**, and a **`Database`** type for `SupabaseClient<Database>` aligned with the **public** schema (normal PHI columns under RLS per PRD). You **regenerate** `database.types.ts` locally with **`gen types --linked`** after **`db push`** to cloud; CI on `main` **verifies** a match (see [Regenerate / automation](#regenerate--automation) and **[docs/SUPABASE_CLOUD_DEVELOPER.md](../../docs/SUPABASE_CLOUD_DEVELOPER.md)**).
 
 ## Environment variables
 
-Use [Supabase hosted API keys](https://supabase.com/docs/guides/api/api-keys) as follows. Prefer **publishable** (`sb_publishable_...`) and **secret** (`sb_secret_...`) over legacy JWT **anon** / **service_role** keys (legacy keys still work during migration; CLI and self-hosted setups often need them).
+Use [Supabase hosted API keys](https://supabase.com/docs/guides/api/api-keys) as follows. Prefer **publishable** (`sb_publishable_...`) and **secret** (`sb_secret_...`) over legacy JWT **anon** / **service_role** keys.
 
 ### What to copy from the dashboard
 
@@ -16,7 +14,7 @@ Use [Supabase hosted API keys](https://supabase.com/docs/guides/api/api-keys) as
 | `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` / `EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | **Project Settings → API Keys** → publishable key | `sb_publishable_...` |
 | `SUPABASE_SECRET_KEY` | **Project Settings → API Keys** → secret key (server-only) | `sb_secret_...` |
 
-Pass **URL + publishable key** (or legacy anon) into `createClient(url, key)` for browser and mobile clients. Use **secret key** (or legacy `service_role`) only in trusted server code, CI, or scripts — never in `NEXT_PUBLIC_*`, `EXPO_PUBLIC_*`, or app bundles.
+Pass **URL + publishable key** (or legacy anon) into browser, SSR, and mobile clients. Use **secret key** (or legacy `SUPABASE_SERVICE_ROLE_KEY`) only in trusted server code — import **`@abstrack/supabase/admin`**, never the main entry, from route handlers or scripts.
 
 ### Where to set them in this repo
 
@@ -24,20 +22,58 @@ Pass **URL + publishable key** (or legacy anon) into `createClient(url, key)` fo
 |----------|------|
 | `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | `apps/web/.env.local`, `apps/practitioner/.env.local` |
 | `EXPO_PUBLIC_SUPABASE_URL`, `EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | `apps/mobile/.env` |
-| `SUPABASE_SECRET_KEY` | Same app’s `.env.local` when that Next server code runs, or CI secrets |
+| `SUPABASE_SECRET_KEY` | Same app’s `.env.local` when Next server code runs, or CI secrets |
 
 ### Legacy (optional)
 
-If you have not migrated: `NEXT_PUBLIC_SUPABASE_ANON_KEY` / `EXPO_PUBLIC_SUPABASE_ANON_KEY` (JWT “anon” from **API Keys → Legacy**) and `SUPABASE_SERVICE_ROLE_KEY` (JWT “service_role”) — same `createClient` second-argument slot as the publishable key; do not expose `service_role`.
+`NEXT_PUBLIC_SUPABASE_ANON_KEY` / `EXPO_PUBLIC_SUPABASE_ANON_KEY` and `SUPABASE_SERVICE_ROLE_KEY` — same second argument to `createClient`; do not expose `service_role` to clients.
 
-Full template and notes: [`.env.example`](../../.env.example).
+Full template: [`.env.example`](../../.env.example).
 
-## Building
+## Public API (`@abstrack/supabase`)
 
-Run `nx build supabase` to build the library.
+- **`Database`**, **`Json`** — types for `SupabaseClient<Database>`.
+- **`getSupabaseUrl`**, **`getSupabasePublishableKey`** — read documented env names (client-safe).
+- **`getSupabaseBrowserClient()`** — Next.js client components via `@supabase/ssr` `createBrowserClient`.
+- **`createSupabaseServerClient(cookies)`** — server components, route handlers, middleware; pass `getAll` / `setAll` from `next/headers` or `NextRequest`/`NextResponse` per [Supabase SSR](https://supabase.com/docs/guides/auth/server-side/nextjs).
+- **`createSupabaseNativeClient(storage)`** — React Native / Expo; pass `AsyncStorage` (or similar) for session persistence.
+- **Auth:** `signInWithEmailPassword`, `signUpWithEmailPassword`, `signOut`, `getSession`, `getAuthUser` (prefer `getAuthUser` on the server).
+- **Queries:** `fetchProfileByUserId`, `healthCheckProfilesLimit1` (lightweight RLS/session check).
 
-## Running unit tests
+## Server-only admin API (`@abstrack/supabase/admin`)
 
-Run `nx test supabase` to execute the unit tests via [Vitest](https://vitest.dev/) from the **workspace root**. This package does **not** list `vitest` in its own `package.json` — it is not a runtime dependency of the library, and duplicating it here would widen the dependency graph for no benefit.
+- **`getSupabaseServiceRoleKey()`** — reads `SUPABASE_SECRET_KEY` or `SUPABASE_SERVICE_ROLE_KEY`.
+- **`getSupabaseAdminClient()`** — service-role client (bypasses RLS). Use only in audited server jobs or admin routes.
 
-`@nx/dependency-checks` would otherwise disagree with that layout (missing vs obsolete `vitest` depending on how the build graph sees `vitest.config.*`). Each Vitest library therefore sets `ignoredDependencies: ['vitest']` on that rule in its **`eslint.config.mjs`**. The same pattern applies to `ui`, `crypto`, `types`, and `powersync` under `packages/*`.
+## Regenerate / automation
+
+**Recommended (one PR with migration + types):** from the repo root, linked to the same Supabase Cloud project—**`db push` first**, then typegen (**`--linked` reads cloud**):
+
+```bash
+pnpm dlx supabase db push
+pnpm dlx supabase gen types typescript --linked --schema public > packages/supabase/src/lib/database.types.ts
+pnpm exec prettier --write packages/supabase/src/lib/database.types.ts
+```
+
+Commit migration file(s) and `database.types.ts`. **GitHub Actions** still runs **`db push`** on **`main`** after merge as a backstop. Full narrative: **[docs/SUPABASE_CLOUD_DEVELOPER.md](../../docs/SUPABASE_CLOUD_DEVELOPER.md)**.
+
+**On `main` after CI `db push`:** [`.github/workflows/supabase-migrations.yml`](../../.github/workflows/supabase-migrations.yml) **diffs** committed `database.types.ts` against `gen types --linked` output—**does not commit**; fix locally and push if it fails.
+
+**On pull requests that change `supabase/migrations/`:** [`.github/workflows/supabase-db-types-pr.yml`](../../.github/workflows/supabase-db-types-pr.yml) may use a **CI-only** Docker stack as an extra check.
+
+**Optional (local Docker, not cloud):**
+
+```bash
+supabase db start && supabase db reset --yes
+supabase gen types typescript --local --schema public > packages/supabase/src/lib/database.types.ts
+pnpm exec prettier --write packages/supabase/src/lib/database.types.ts
+```
+
+## Building and tests
+
+```bash
+nx build supabase
+nx test supabase
+```
+
+Vitest runs from the workspace root; this package does not list `vitest` in its own `package.json`. `@nx/dependency-checks` ignores `vitest` in `eslint.config.mjs` (same pattern as other libraries here).

--- a/packages/supabase/README.md
+++ b/packages/supabase/README.md
@@ -30,15 +30,25 @@ Pass **URL + publishable key** (or legacy anon) into browser, SSR, and mobile cl
 
 Full template: [`.env.example`](../../.env.example).
 
-## Public API (`@abstrack/supabase`)
+## Package entrypoints
 
-- **`Database`**, **`Json`** — types for `SupabaseClient<Database>`.
-- **`getSupabaseUrl`**, **`getSupabasePublishableKey`** — read documented env names (client-safe).
-- **`getSupabaseBrowserClient()`** — Next.js client components via `@supabase/ssr` `createBrowserClient`.
-- **`createSupabaseServerClient(cookies)`** — server components, route handlers, middleware; pass `getAll` / `setAll` from `next/headers` or `NextRequest`/`NextResponse` per [Supabase SSR](https://supabase.com/docs/guides/auth/server-side/nextjs).
-- **`createSupabaseNativeClient(storage)`** — React Native / Expo; pass `AsyncStorage` (or similar) for session persistence.
-- **Auth:** `signInWithEmailPassword`, `signUpWithEmailPassword`, `signOut`, `getSession`, `getAuthUser` (prefer `getAuthUser` on the server).
-- **Queries:** `fetchProfileByUserId`, `healthCheckProfilesLimit1` (lightweight RLS/session check).
+The **default** export (`@abstrack/supabase`) is **Metro-safe**: it does not load `@supabase/ssr`. Use **subpaths** for Next.js so React Native never pulls SSR code.
+
+| Import | Use when |
+|--------|----------|
+| **`@abstrack/supabase`** | Shared types, env readers, **`createSupabaseNativeClient`**, auth helpers, query helpers (Expo / shared code). |
+| **`@abstrack/supabase/browser`** | Next.js **client components** — `getSupabaseBrowserClient()` (`@supabase/ssr`). |
+| **`@abstrack/supabase/server`** | Next.js **server** — `createSupabaseServerClient(cookies)`; pass cookie `getAll` / `setAll` per [Supabase SSR](https://supabase.com/docs/guides/auth/server-side/nextjs). |
+| **`@abstrack/supabase/native`** | Optional alias for **`createSupabaseNativeClient`** only (same as main export; explicit “no SSR” surface). |
+| **`@abstrack/supabase/admin`** | Secret-key server client only (see below). |
+
+### Main (`@abstrack/supabase`)
+
+- **`Database`**, **`Json`**, **`AbstrackSupabaseClient`**
+- **`getSupabaseUrl`**, **`getSupabasePublishableKey`**
+- **`createSupabaseNativeClient`**, **`NativeAuthStorage`**, **`NativeClientOptions`**
+- **Auth:** `signInWithEmailPassword`, `signUpWithEmailPassword`, `signOut`, `getSession`, `getAuthUser`
+- **Queries:** `fetchProfileByUserId`, `healthCheckProfilesLimit1`
 
 ## Server-only admin API (`@abstrack/supabase/admin`)
 

--- a/packages/supabase/README.md
+++ b/packages/supabase/README.md
@@ -14,7 +14,7 @@ Use [Supabase hosted API keys](https://supabase.com/docs/guides/api/api-keys) as
 | `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` / `EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | **Project Settings → API Keys** → publishable key | `sb_publishable_...` |
 | `SUPABASE_SECRET_KEY` | **Project Settings → API Keys** → secret key (server-only) | `sb_secret_...` |
 
-Pass **URL + publishable key** (or legacy anon) into browser, SSR, and mobile clients. Use **secret key** (or legacy `SUPABASE_SERVICE_ROLE_KEY`) only in trusted server code — import **`@abstrack/supabase/admin`**, never the main entry, from route handlers or scripts.
+Pass **URL + publishable key** (or legacy anon) into browser, SSR, and mobile clients. Use **`SUPABASE_SECRET_KEY`** (`sb_secret_...`) only in trusted server code — import **`@abstrack/supabase/admin`**, never the main entry, from route handlers or scripts. **`@abstrack/supabase/admin` does not read legacy JWT `service_role` keys.**
 
 ### Where to set them in this repo
 
@@ -24,9 +24,9 @@ Pass **URL + publishable key** (or legacy anon) into browser, SSR, and mobile cl
 | `EXPO_PUBLIC_SUPABASE_URL`, `EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | `apps/mobile/.env` |
 | `SUPABASE_SECRET_KEY` | Same app’s `.env.local` when Next server code runs, or CI secrets |
 
-### Legacy (optional)
+### Legacy (optional, clients only)
 
-`NEXT_PUBLIC_SUPABASE_ANON_KEY` / `EXPO_PUBLIC_SUPABASE_ANON_KEY` and `SUPABASE_SERVICE_ROLE_KEY` — same second argument to `createClient`; do not expose `service_role` to clients.
+`NEXT_PUBLIC_SUPABASE_ANON_KEY` / `EXPO_PUBLIC_SUPABASE_ANON_KEY` — fallback for `createClient` when publishable keys are not enabled yet. Do not use JWT **service_role** in client bundles; server admin uses **`SUPABASE_SECRET_KEY`** only.
 
 Full template: [`.env.example`](../../.env.example).
 
@@ -42,7 +42,7 @@ Full template: [`.env.example`](../../.env.example).
 
 ## Server-only admin API (`@abstrack/supabase/admin`)
 
-- **`getSupabaseServiceRoleKey()`** — reads `SUPABASE_SECRET_KEY` or `SUPABASE_SERVICE_ROLE_KEY`.
+- **`getSupabaseServiceRoleKey()`** — reads **`SUPABASE_SECRET_KEY`** (`sb_secret_...`) only.
 - **`getSupabaseAdminClient()`** — service-role client (bypasses RLS). Use only in audited server jobs or admin routes.
 
 ## Regenerate / automation

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -13,9 +13,17 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./admin": {
+      "@abstrack/source": "./src/admin.ts",
+      "types": "./dist/admin.d.ts",
+      "import": "./dist/admin.js",
+      "default": "./dist/admin.js"
     }
   },
   "dependencies": {
+    "@supabase/ssr": "^0.6.1",
+    "@supabase/supabase-js": "^2.100.1",
     "tslib": "^2.3.0"
   }
 }

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -14,6 +14,24 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./browser": {
+      "@abstrack/source": "./src/browser.ts",
+      "types": "./dist/browser.d.ts",
+      "import": "./dist/browser.js",
+      "default": "./dist/browser.js"
+    },
+    "./server": {
+      "@abstrack/source": "./src/server.ts",
+      "types": "./dist/server.d.ts",
+      "import": "./dist/server.js",
+      "default": "./dist/server.js"
+    },
+    "./native": {
+      "@abstrack/source": "./src/native.ts",
+      "types": "./dist/native.d.ts",
+      "import": "./dist/native.js",
+      "default": "./dist/native.js"
+    },
     "./admin": {
       "@abstrack/source": "./src/admin.ts",
       "types": "./dist/admin.d.ts",

--- a/packages/supabase/src/admin.spec.ts
+++ b/packages/supabase/src/admin.spec.ts
@@ -1,15 +1,23 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { getSupabaseServiceRoleKey } from './admin.js';
 
 describe('@abstrack/supabase/admin', () => {
-  const snapshot = {
-    SUPABASE_SECRET_KEY: process.env.SUPABASE_SECRET_KEY,
-    SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
-  };
+  let snapshotSecret: string | undefined;
+
+  beforeEach(() => {
+    snapshotSecret = process.env.SUPABASE_SECRET_KEY;
+  });
+
+  afterEach(() => {
+    if (snapshotSecret === undefined) {
+      delete process.env.SUPABASE_SECRET_KEY;
+    } else {
+      process.env.SUPABASE_SECRET_KEY = snapshotSecret;
+    }
+  });
 
   it('getSupabaseServiceRoleKey throws when secret env is missing', () => {
     delete process.env.SUPABASE_SECRET_KEY;
-    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
     expect(() => getSupabaseServiceRoleKey()).toThrow(
       /Missing SUPABASE_SECRET_KEY/,
     );
@@ -18,15 +26,5 @@ describe('@abstrack/supabase/admin', () => {
   it('getSupabaseServiceRoleKey reads SUPABASE_SECRET_KEY', () => {
     process.env.SUPABASE_SECRET_KEY = 'sb_secret_unit_test';
     expect(getSupabaseServiceRoleKey()).toBe('sb_secret_unit_test');
-    if (snapshot.SUPABASE_SECRET_KEY === undefined) {
-      delete process.env.SUPABASE_SECRET_KEY;
-    } else {
-      process.env.SUPABASE_SECRET_KEY = snapshot.SUPABASE_SECRET_KEY;
-    }
-    if (snapshot.SUPABASE_SERVICE_ROLE_KEY === undefined) {
-      delete process.env.SUPABASE_SERVICE_ROLE_KEY;
-    } else {
-      process.env.SUPABASE_SERVICE_ROLE_KEY = snapshot.SUPABASE_SERVICE_ROLE_KEY;
-    }
   });
 });

--- a/packages/supabase/src/admin.spec.ts
+++ b/packages/supabase/src/admin.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { getSupabaseServiceRoleKey } from './admin.js';
+import { getSupabaseSecretKey } from './admin.js';
 
 describe('@abstrack/supabase/admin', () => {
   let snapshotSecret: string | undefined;
@@ -16,15 +16,13 @@ describe('@abstrack/supabase/admin', () => {
     }
   });
 
-  it('getSupabaseServiceRoleKey throws when secret env is missing', () => {
+  it('getSupabaseSecretKey throws when secret env is missing', () => {
     delete process.env.SUPABASE_SECRET_KEY;
-    expect(() => getSupabaseServiceRoleKey()).toThrow(
-      /Missing SUPABASE_SECRET_KEY/,
-    );
+    expect(() => getSupabaseSecretKey()).toThrow(/Missing SUPABASE_SECRET_KEY/);
   });
 
-  it('getSupabaseServiceRoleKey reads SUPABASE_SECRET_KEY', () => {
+  it('getSupabaseSecretKey reads SUPABASE_SECRET_KEY', () => {
     process.env.SUPABASE_SECRET_KEY = 'sb_secret_unit_test';
-    expect(getSupabaseServiceRoleKey()).toBe('sb_secret_unit_test');
+    expect(getSupabaseSecretKey()).toBe('sb_secret_unit_test');
   });
 });

--- a/packages/supabase/src/admin.spec.ts
+++ b/packages/supabase/src/admin.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { getSupabaseServiceRoleKey } from './admin.js';
+
+describe('@abstrack/supabase/admin', () => {
+  const snapshot = {
+    SUPABASE_SECRET_KEY: process.env.SUPABASE_SECRET_KEY,
+    SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
+  };
+
+  it('getSupabaseServiceRoleKey throws when secret env is missing', () => {
+    delete process.env.SUPABASE_SECRET_KEY;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    expect(() => getSupabaseServiceRoleKey()).toThrow(
+      /Missing SUPABASE_SECRET_KEY/,
+    );
+  });
+
+  it('getSupabaseServiceRoleKey reads SUPABASE_SECRET_KEY', () => {
+    process.env.SUPABASE_SECRET_KEY = 'sb_secret_unit_test';
+    expect(getSupabaseServiceRoleKey()).toBe('sb_secret_unit_test');
+    if (snapshot.SUPABASE_SECRET_KEY === undefined) {
+      delete process.env.SUPABASE_SECRET_KEY;
+    } else {
+      process.env.SUPABASE_SECRET_KEY = snapshot.SUPABASE_SECRET_KEY;
+    }
+    if (snapshot.SUPABASE_SERVICE_ROLE_KEY === undefined) {
+      delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    } else {
+      process.env.SUPABASE_SERVICE_ROLE_KEY = snapshot.SUPABASE_SERVICE_ROLE_KEY;
+    }
+  });
+});

--- a/packages/supabase/src/admin.ts
+++ b/packages/supabase/src/admin.ts
@@ -1,0 +1,8 @@
+/**
+ * Service-role client and secret key — **server-only**. Import `@abstrack/supabase/admin`
+ * from Node / Next server segments only; never from client components or mobile UI bundles.
+ */
+export {
+  getSupabaseAdminClient,
+  getSupabaseServiceRoleKey,
+} from './lib/admin-client.js';

--- a/packages/supabase/src/admin.ts
+++ b/packages/supabase/src/admin.ts
@@ -1,8 +1,8 @@
 /**
- * Service-role client and secret key — **server-only**. Import `@abstrack/supabase/admin`
+ * Secret-key admin client — **server-only** (bypasses RLS). Import `@abstrack/supabase/admin`
  * from Node / Next server segments only; never from client components or mobile UI bundles.
  */
 export {
   getSupabaseAdminClient,
-  getSupabaseServiceRoleKey,
+  getSupabaseSecretKey,
 } from './lib/admin-client.js';

--- a/packages/supabase/src/browser.ts
+++ b/packages/supabase/src/browser.ts
@@ -1,0 +1,2 @@
+/** Next.js client components — imports `@supabase/ssr`. Do not use from React Native. */
+export { getSupabaseBrowserClient } from './lib/browser-client.js';

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -1,16 +1,16 @@
+/**
+ * Universal entry: types, env, React Native client, auth, and queries.
+ * Does **not** import `@supabase/ssr` — safe for Metro without pulling Next SSR code.
+ *
+ * Next.js: import browser/server factories from `@abstrack/supabase/browser` and
+ * `@abstrack/supabase/server`.
+ */
 export type { Database, Json } from './lib/database.types.js';
 export {
   getSupabasePublishableKey,
   getSupabaseUrl,
 } from './lib/env-public.js';
-export {
-  getSupabaseBrowserClient,
-  type AbstrackSupabaseClient,
-} from './lib/browser-client.js';
-export {
-  createSupabaseServerClient,
-  type CookieMethodsServer,
-} from './lib/server-client.js';
+export type { AbstrackSupabaseClient } from './lib/supabase-client-type.js';
 export {
   createSupabaseNativeClient,
   type NativeAuthStorage,

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -1,1 +1,29 @@
-export * from './lib/supabase.js';
+export type { Database, Json } from './lib/database.types.js';
+export {
+  getSupabasePublishableKey,
+  getSupabaseUrl,
+} from './lib/env-public.js';
+export {
+  getSupabaseBrowserClient,
+  type AbstrackSupabaseClient,
+} from './lib/browser-client.js';
+export {
+  createSupabaseServerClient,
+  type CookieMethodsServer,
+} from './lib/server-client.js';
+export {
+  createSupabaseNativeClient,
+  type NativeAuthStorage,
+  type NativeClientOptions,
+} from './lib/native-client.js';
+export {
+  getAuthUser,
+  getSession,
+  signInWithEmailPassword,
+  signOut,
+  signUpWithEmailPassword,
+} from './lib/auth.js';
+export {
+  fetchProfileByUserId,
+  healthCheckProfilesLimit1,
+} from './lib/queries.js';

--- a/packages/supabase/src/lib/admin-client.ts
+++ b/packages/supabase/src/lib/admin-client.ts
@@ -3,11 +3,12 @@ import type { Database } from './database.types.js';
 import { getSupabaseUrl } from './env-public.js';
 
 /**
- * Server-only **secret** API key (`sb_secret_...` from the dashboard).
+ * Server-only **secret** API key (`sb_secret_...` from Project Settings → API Keys).
+ * Named for what you configure (`SUPABASE_SECRET_KEY`), not the old JWT `service_role` env name.
  * Per [Supabase API keys](https://supabase.com/docs/guides/api/api-keys), use publishable + secret keys;
- * this package does not read legacy JWT `service_role` env vars. Never import this module from client code.
+ * legacy JWT service_role keys are not read here. Never import this module from client code.
  */
-export function getSupabaseServiceRoleKey(): string {
+export function getSupabaseSecretKey(): string {
   const key =
     typeof process !== 'undefined' && process.env
       ? process.env.SUPABASE_SECRET_KEY
@@ -21,10 +22,11 @@ export function getSupabaseServiceRoleKey(): string {
 }
 
 /**
- * Bypasses RLS — use only in trusted server jobs, migrations tooling, or audited admin routes.
+ * Supabase client using the **secret** key — bypasses RLS (same privilege level as classic “service role”).
+ * Use only in trusted server jobs, migrations tooling, or audited admin routes.
  */
 export function getSupabaseAdminClient() {
-  return createClient<Database>(getSupabaseUrl(), getSupabaseServiceRoleKey(), {
+  return createClient<Database>(getSupabaseUrl(), getSupabaseSecretKey(), {
     auth: {
       persistSession: false,
       autoRefreshToken: false,

--- a/packages/supabase/src/lib/admin-client.ts
+++ b/packages/supabase/src/lib/admin-client.ts
@@ -3,17 +3,18 @@ import type { Database } from './database.types.js';
 import { getSupabaseUrl } from './env-public.js';
 
 /**
- * Server-only secret or legacy service_role JWT. Never import this module from client code.
+ * Server-only **secret** API key (`sb_secret_...` from the dashboard).
+ * Per [Supabase API keys](https://supabase.com/docs/guides/api/api-keys), use publishable + secret keys;
+ * this package does not read legacy JWT `service_role` env vars. Never import this module from client code.
  */
 export function getSupabaseServiceRoleKey(): string {
   const key =
-    (typeof process !== 'undefined' && process.env
-      ? process.env.SUPABASE_SECRET_KEY ??
-        process.env.SUPABASE_SERVICE_ROLE_KEY
-      : undefined) ?? undefined;
+    typeof process !== 'undefined' && process.env
+      ? process.env.SUPABASE_SECRET_KEY
+      : undefined;
   if (!key) {
     throw new Error(
-      'Missing SUPABASE_SECRET_KEY or SUPABASE_SERVICE_ROLE_KEY (server-only).',
+      'Missing SUPABASE_SECRET_KEY (server-only). Set the secret key from Project Settings → API Keys.',
     );
   }
   return key;

--- a/packages/supabase/src/lib/admin-client.ts
+++ b/packages/supabase/src/lib/admin-client.ts
@@ -1,0 +1,32 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Database } from './database.types.js';
+import { getSupabaseUrl } from './env-public.js';
+
+/**
+ * Server-only secret or legacy service_role JWT. Never import this module from client code.
+ */
+export function getSupabaseServiceRoleKey(): string {
+  const key =
+    (typeof process !== 'undefined' && process.env
+      ? process.env.SUPABASE_SECRET_KEY ??
+        process.env.SUPABASE_SERVICE_ROLE_KEY
+      : undefined) ?? undefined;
+  if (!key) {
+    throw new Error(
+      'Missing SUPABASE_SECRET_KEY or SUPABASE_SERVICE_ROLE_KEY (server-only).',
+    );
+  }
+  return key;
+}
+
+/**
+ * Bypasses RLS — use only in trusted server jobs, migrations tooling, or audited admin routes.
+ */
+export function getSupabaseAdminClient() {
+  return createClient<Database>(getSupabaseUrl(), getSupabaseServiceRoleKey(), {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+}

--- a/packages/supabase/src/lib/auth-assignability.spec.ts
+++ b/packages/supabase/src/lib/auth-assignability.spec.ts
@@ -1,15 +1,37 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { signInWithEmailPassword } from './auth.js';
 import { createSupabaseServerClient } from './server-client.js';
 
+const ENV_KEYS = [
+  'NEXT_PUBLIC_SUPABASE_URL',
+  'NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY',
+] as const;
+
 describe('client assignability', () => {
+  const snapshot: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      snapshot[key] = process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = snapshot[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
   it('createSupabaseServerClient result is accepted by auth helpers (types only)', () => {
     process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'sb_publishable_test';
     const client = createSupabaseServerClient({ getAll: () => [] });
     const deferred = () => signInWithEmailPassword(client, 'a@example.com', 'pw');
     expect(deferred).toBeDefined();
-    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
-    delete process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
   });
 });

--- a/packages/supabase/src/lib/auth-assignability.spec.ts
+++ b/packages/supabase/src/lib/auth-assignability.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { signInWithEmailPassword } from './auth.js';
+import { createSupabaseServerClient } from './server-client.js';
+
+describe('client assignability', () => {
+  it('createSupabaseServerClient result is accepted by auth helpers (types only)', () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'sb_publishable_test';
+    const client = createSupabaseServerClient({ getAll: () => [] });
+    const deferred = () => signInWithEmailPassword(client, 'a@example.com', 'pw');
+    expect(deferred).toBeDefined();
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    delete process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+  });
+});

--- a/packages/supabase/src/lib/auth.ts
+++ b/packages/supabase/src/lib/auth.ts
@@ -1,0 +1,43 @@
+import type { AbstrackSupabaseClient } from './browser-client.js';
+
+export type { AbstrackSupabaseClient };
+
+export async function signInWithEmailPassword(
+  client: AbstrackSupabaseClient,
+  email: string,
+  password: string,
+) {
+  return client.auth.signInWithPassword({ email, password });
+}
+
+export async function signUpWithEmailPassword(
+  client: AbstrackSupabaseClient,
+  email: string,
+  password: string,
+  options?: {
+    emailRedirectTo?: string;
+    data?: Record<string, unknown>;
+  },
+) {
+  return client.auth.signUp({
+    email,
+    password,
+    options: {
+      emailRedirectTo: options?.emailRedirectTo,
+      data: options?.data,
+    },
+  });
+}
+
+export async function signOut(client: AbstrackSupabaseClient) {
+  return client.auth.signOut();
+}
+
+export async function getSession(client: AbstrackSupabaseClient) {
+  return client.auth.getSession();
+}
+
+/** Prefer on the server when verifying identity (validates with Auth server). */
+export async function getAuthUser(client: AbstrackSupabaseClient) {
+  return client.auth.getUser();
+}

--- a/packages/supabase/src/lib/auth.ts
+++ b/packages/supabase/src/lib/auth.ts
@@ -1,4 +1,4 @@
-import type { AbstrackSupabaseClient } from './browser-client.js';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
 
 export type { AbstrackSupabaseClient };
 

--- a/packages/supabase/src/lib/browser-client.ts
+++ b/packages/supabase/src/lib/browser-client.ts
@@ -1,0 +1,19 @@
+import { createBrowserClient } from '@supabase/ssr';
+import type { Database } from './database.types.js';
+import { getSupabasePublishableKey, getSupabaseUrl } from './env-public.js';
+
+/** Shared client shape for auth/query helpers (browser or server factories). */
+export type AbstrackSupabaseClient = ReturnType<
+  typeof createBrowserClient<Database>
+>;
+
+/**
+ * Next.js / web client components. Uses `@supabase/ssr` cookie session handling.
+ * Pair with {@link createSupabaseServerClient} on the server (middleware + RSC / routes).
+ */
+export function getSupabaseBrowserClient() {
+  return createBrowserClient<Database>(
+    getSupabaseUrl(),
+    getSupabasePublishableKey(),
+  );
+}

--- a/packages/supabase/src/lib/browser-client.ts
+++ b/packages/supabase/src/lib/browser-client.ts
@@ -1,4 +1,5 @@
 import { createBrowserClient } from '@supabase/ssr';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from './database.types.js';
 import { getSupabasePublishableKey, getSupabaseUrl } from './env-public.js';
 
@@ -6,9 +7,9 @@ import { getSupabasePublishableKey, getSupabaseUrl } from './env-public.js';
  * Next.js / web client components. Uses `@supabase/ssr` cookie session handling.
  * Pair with {@link createSupabaseServerClient} on the server (middleware + RSC / routes).
  */
-export function getSupabaseBrowserClient() {
+export function getSupabaseBrowserClient(): SupabaseClient<Database> {
   return createBrowserClient<Database>(
     getSupabaseUrl(),
     getSupabasePublishableKey(),
-  );
+  ) as unknown as SupabaseClient<Database>;
 }

--- a/packages/supabase/src/lib/browser-client.ts
+++ b/packages/supabase/src/lib/browser-client.ts
@@ -2,11 +2,6 @@ import { createBrowserClient } from '@supabase/ssr';
 import type { Database } from './database.types.js';
 import { getSupabasePublishableKey, getSupabaseUrl } from './env-public.js';
 
-/** Shared client shape for auth/query helpers (browser or server factories). */
-export type AbstrackSupabaseClient = ReturnType<
-  typeof createBrowserClient<Database>
->;
-
 /**
  * Next.js / web client components. Uses `@supabase/ssr` cookie session handling.
  * Pair with {@link createSupabaseServerClient} on the server (middleware + RSC / routes).

--- a/packages/supabase/src/lib/database.types.ts
+++ b/packages/supabase/src/lib/database.types.ts
@@ -1,3 +1,15 @@
+/**
+ * Generated Supabase `Database` type (public schema). Do not edit by hand.
+ *
+ * Regenerate after migrations are applied to your linked project, then format:
+ *
+ *   pnpm dlx supabase gen types typescript --linked --schema public > packages/supabase/src/lib/database.types.ts
+ *   pnpm exec prettier --write packages/supabase/src/lib/database.types.ts
+ *
+ * CI on `main` diffs this file against `gen types --linked` after `db push`.
+ * See docs/SUPABASE_CLOUD_DEVELOPER.md.
+ */
+
 export type Json =
   | string
   | number

--- a/packages/supabase/src/lib/database.types.ts
+++ b/packages/supabase/src/lib/database.types.ts
@@ -1,0 +1,679 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: '14.1';
+  };
+  public: {
+    Tables: {
+      access_log: {
+        Row: {
+          action: string;
+          actor_role: string;
+          actor_user_id: string | null;
+          id: string;
+          ip_hash: string | null;
+          occurred_at: string;
+          patient_user_id: string | null;
+          request_id: string | null;
+          resource_id: string | null;
+          resource_type: string;
+        };
+        Insert: {
+          action: string;
+          actor_role: string;
+          actor_user_id?: string | null;
+          id?: string;
+          ip_hash?: string | null;
+          occurred_at?: string;
+          patient_user_id?: string | null;
+          request_id?: string | null;
+          resource_id?: string | null;
+          resource_type: string;
+        };
+        Update: {
+          action?: string;
+          actor_role?: string;
+          actor_user_id?: string | null;
+          id?: string;
+          ip_hash?: string | null;
+          occurred_at?: string;
+          patient_user_id?: string | null;
+          request_id?: string | null;
+          resource_id?: string | null;
+          resource_type?: string;
+        };
+        Relationships: [];
+      };
+      caretaker_access: {
+        Row: {
+          caretaker_user_id: string;
+          created_at: string;
+          id: string;
+          patient_user_id: string;
+          revoked_at: string | null;
+        };
+        Insert: {
+          caretaker_user_id: string;
+          created_at?: string;
+          id?: string;
+          patient_user_id: string;
+          revoked_at?: string | null;
+        };
+        Update: {
+          caretaker_user_id?: string;
+          created_at?: string;
+          id?: string;
+          patient_user_id?: string;
+          revoked_at?: string | null;
+        };
+        Relationships: [];
+      };
+      episode_media: {
+        Row: {
+          created_at: string;
+          duration_seconds: number | null;
+          episode_id: string;
+          episode_symptom_id: string | null;
+          id: string;
+          media_type: string;
+          storage_object_key: string;
+          thumbnail_storage_key: string | null;
+          updated_at: string;
+          upload_completed_at: string | null;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          duration_seconds?: number | null;
+          episode_id: string;
+          episode_symptom_id?: string | null;
+          id?: string;
+          media_type: string;
+          storage_object_key: string;
+          thumbnail_storage_key?: string | null;
+          updated_at?: string;
+          upload_completed_at?: string | null;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string;
+          duration_seconds?: number | null;
+          episode_id?: string;
+          episode_symptom_id?: string | null;
+          id?: string;
+          media_type?: string;
+          storage_object_key?: string;
+          thumbnail_storage_key?: string | null;
+          updated_at?: string;
+          upload_completed_at?: string | null;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'episode_media_episode_fk';
+            columns: ['user_id', 'episode_id'];
+            isOneToOne: false;
+            referencedRelation: 'episodes';
+            referencedColumns: ['user_id', 'id'];
+          },
+          {
+            foreignKeyName: 'episode_media_symptom_step_fk';
+            columns: ['episode_id', 'episode_symptom_id'];
+            isOneToOne: false;
+            referencedRelation: 'episode_symptoms';
+            referencedColumns: ['episode_id', 'id'];
+          },
+        ];
+      };
+      episode_symptoms: {
+        Row: {
+          created_at: string;
+          episode_id: string | null;
+          id: string;
+          preset_symptom_id: string | null;
+          response_boolean: boolean | null;
+          response_severity: number | null;
+          response_text: string | null;
+          response_type: string;
+          sort_order: number;
+          symptom_name: string;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          episode_id?: string | null;
+          id?: string;
+          preset_symptom_id?: string | null;
+          response_boolean?: boolean | null;
+          response_severity?: number | null;
+          response_text?: string | null;
+          response_type: string;
+          sort_order?: number;
+          symptom_name: string;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string;
+          episode_id?: string | null;
+          id?: string;
+          preset_symptom_id?: string | null;
+          response_boolean?: boolean | null;
+          response_severity?: number | null;
+          response_text?: string | null;
+          response_type?: string;
+          sort_order?: number;
+          symptom_name?: string;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'episode_symptoms_episode_fk';
+            columns: ['user_id', 'episode_id'];
+            isOneToOne: false;
+            referencedRelation: 'episodes';
+            referencedColumns: ['user_id', 'id'];
+          },
+          {
+            foreignKeyName: 'episode_symptoms_preset_symptom_id_fkey';
+            columns: ['preset_symptom_id'];
+            isOneToOne: false;
+            referencedRelation: 'preset_symptoms';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      episodes: {
+        Row: {
+          created_at: string;
+          ended_at: string | null;
+          episode_label: string | null;
+          episode_type: string;
+          id: string;
+          note: string | null;
+          started_at: string;
+          symptom_preset_id: string | null;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          ended_at?: string | null;
+          episode_label?: string | null;
+          episode_type?: string;
+          id?: string;
+          note?: string | null;
+          started_at: string;
+          symptom_preset_id?: string | null;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string;
+          ended_at?: string | null;
+          episode_label?: string | null;
+          episode_type?: string;
+          id?: string;
+          note?: string | null;
+          started_at?: string;
+          symptom_preset_id?: string | null;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'episodes_symptom_preset_id_fk';
+            columns: ['symptom_preset_id'];
+            isOneToOne: false;
+            referencedRelation: 'symptom_presets';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      food_diary_entries: {
+        Row: {
+          created_at: string;
+          episode_id: string | null;
+          food_note: string;
+          id: string;
+          logged_at: string;
+          meal_tag: string;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          episode_id?: string | null;
+          food_note: string;
+          id?: string;
+          logged_at: string;
+          meal_tag: string;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string;
+          episode_id?: string | null;
+          food_note?: string;
+          id?: string;
+          logged_at?: string;
+          meal_tag?: string;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'food_diary_episode_id_fk';
+            columns: ['episode_id'];
+            isOneToOne: false;
+            referencedRelation: 'episodes';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      health_marker_presets: {
+        Row: {
+          created_at: string;
+          id: string;
+          name: string;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          name: string;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          name?: string;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
+      health_markers: {
+        Row: {
+          created_at: string;
+          custom_name: string | null;
+          custom_unit: string | null;
+          diastolic_numeric: number | null;
+          episode_id: string | null;
+          id: string;
+          marker_kind: string;
+          notes: string | null;
+          recorded_at: string;
+          systolic_numeric: number | null;
+          updated_at: string;
+          user_id: string;
+          value_numeric: number | null;
+        };
+        Insert: {
+          created_at?: string;
+          custom_name?: string | null;
+          custom_unit?: string | null;
+          diastolic_numeric?: number | null;
+          episode_id?: string | null;
+          id?: string;
+          marker_kind: string;
+          notes?: string | null;
+          recorded_at: string;
+          systolic_numeric?: number | null;
+          updated_at?: string;
+          user_id: string;
+          value_numeric?: number | null;
+        };
+        Update: {
+          created_at?: string;
+          custom_name?: string | null;
+          custom_unit?: string | null;
+          diastolic_numeric?: number | null;
+          episode_id?: string | null;
+          id?: string;
+          marker_kind?: string;
+          notes?: string | null;
+          recorded_at?: string;
+          systolic_numeric?: number | null;
+          updated_at?: string;
+          user_id?: string;
+          value_numeric?: number | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'health_markers_episode_fk';
+            columns: ['user_id', 'episode_id'];
+            isOneToOne: false;
+            referencedRelation: 'episodes';
+            referencedColumns: ['user_id', 'id'];
+          },
+        ];
+      };
+      practitioner_access: {
+        Row: {
+          created_at: string;
+          id: string;
+          patient_user_id: string;
+          practitioner_user_id: string;
+          revoked_at: string | null;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          patient_user_id: string;
+          practitioner_user_id: string;
+          revoked_at?: string | null;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          patient_user_id?: string;
+          practitioner_user_id?: string;
+          revoked_at?: string | null;
+        };
+        Relationships: [];
+      };
+      preset_health_markers: {
+        Row: {
+          created_at: string;
+          custom_name: string | null;
+          custom_unit: string | null;
+          id: string;
+          marker_kind: string;
+          preset_id: string;
+          sort_order: number;
+          updated_at: string;
+        };
+        Insert: {
+          created_at?: string;
+          custom_name?: string | null;
+          custom_unit?: string | null;
+          id?: string;
+          marker_kind: string;
+          preset_id: string;
+          sort_order: number;
+          updated_at?: string;
+        };
+        Update: {
+          created_at?: string;
+          custom_name?: string | null;
+          custom_unit?: string | null;
+          id?: string;
+          marker_kind?: string;
+          preset_id?: string;
+          sort_order?: number;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'preset_health_markers_preset_id_fkey';
+            columns: ['preset_id'];
+            isOneToOne: false;
+            referencedRelation: 'health_marker_presets';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      preset_symptoms: {
+        Row: {
+          created_at: string;
+          id: string;
+          preset_id: string;
+          prompt_instruction: string | null;
+          response_type: string;
+          sort_order: number;
+          symptom_name: string;
+          updated_at: string;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          preset_id: string;
+          prompt_instruction?: string | null;
+          response_type: string;
+          sort_order: number;
+          symptom_name: string;
+          updated_at?: string;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          preset_id?: string;
+          prompt_instruction?: string | null;
+          response_type?: string;
+          sort_order?: number;
+          symptom_name?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'preset_symptoms_preset_id_fkey';
+            columns: ['preset_id'];
+            isOneToOne: false;
+            referencedRelation: 'symptom_presets';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      profiles: {
+        Row: {
+          app_role: string;
+          created_at: string;
+          display_name: string | null;
+          id: string;
+          updated_at: string;
+        };
+        Insert: {
+          app_role: string;
+          created_at?: string;
+          display_name?: string | null;
+          id: string;
+          updated_at?: string;
+        };
+        Update: {
+          app_role?: string;
+          created_at?: string;
+          display_name?: string | null;
+          id?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
+      symptom_presets: {
+        Row: {
+          created_at: string;
+          id: string;
+          name: string;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          name: string;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          name?: string;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      episode_media_storage_can_select: {
+        Args: { p_object_name: string };
+        Returns: boolean;
+      };
+      episode_media_storage_can_write: {
+        Args: { p_object_name: string };
+        Returns: boolean;
+      };
+      episode_media_storage_path_user_id: {
+        Args: { p_object_name: string };
+        Returns: string;
+      };
+      profiles_trusted_session_for_app_role: { Args: never; Returns: boolean };
+      user_has_practitioner_access: {
+        Args: { p_patient_user_id: string };
+        Returns: boolean;
+      };
+      user_is_caretaker_for_patient: {
+        Args: { p_patient_user_id: string };
+        Returns: boolean;
+      };
+    };
+    Enums: {
+      [_ in never]: never;
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
+  };
+};
+
+type DatabaseWithoutInternals = Omit<Database, '__InternalSupabase'>;
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<
+  keyof Database,
+  'public'
+>];
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])[TableName] extends {
+      Row: infer R;
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema['Tables'] &
+        DefaultSchema['Views'])
+    ? (DefaultSchema['Tables'] &
+        DefaultSchema['Views'])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R;
+      }
+      ? R
+      : never
+    : never;
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema['Tables']
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Insert: infer I;
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
+    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I;
+      }
+      ? I
+      : never
+    : never;
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema['Tables']
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Update: infer U;
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
+    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U;
+      }
+      ? U
+      : never
+    : never;
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema['Enums']
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums'][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema['Enums']
+    ? DefaultSchema['Enums'][DefaultSchemaEnumNameOrOptions]
+    : never;
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema['CompositeTypes']
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
+    ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
+    : never;
+
+export const Constants = {
+  public: {
+    Enums: {},
+  },
+} as const;

--- a/packages/supabase/src/lib/env-public.ts
+++ b/packages/supabase/src/lib/env-public.ts
@@ -1,0 +1,47 @@
+/**
+ * Client-safe Supabase URL and publishable (anon) key resolution.
+ * Documented names: `packages/supabase/README.md`, `.env.example`, `docs/DEV_SETUP.md`.
+ *
+ * Server-only secrets (`SUPABASE_SECRET_KEY`, etc.) live in `admin-client.ts` and are not
+ * imported from the main package entry.
+ */
+
+function readEnv(name: string): string | undefined {
+  if (typeof process === 'undefined' || !process.env) {
+    return undefined;
+  }
+  const v = process.env[name];
+  return v === '' ? undefined : v;
+}
+
+/** Project URL (Next, Expo, or generic server `SUPABASE_URL`). */
+export function getSupabaseUrl(): string {
+  const url =
+    readEnv('NEXT_PUBLIC_SUPABASE_URL') ??
+    readEnv('EXPO_PUBLIC_SUPABASE_URL') ??
+    readEnv('SUPABASE_URL');
+  if (!url) {
+    throw new Error(
+      'Missing Supabase URL. Set NEXT_PUBLIC_SUPABASE_URL, EXPO_PUBLIC_SUPABASE_URL, or SUPABASE_URL.',
+    );
+  }
+  return url;
+}
+
+/**
+ * Publishable or legacy anon JWT — safe for browsers and mobile bundles.
+ * Never use the service role / secret key here.
+ */
+export function getSupabasePublishableKey(): string {
+  const key =
+    readEnv('NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY') ??
+    readEnv('EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY') ??
+    readEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY') ??
+    readEnv('EXPO_PUBLIC_SUPABASE_ANON_KEY');
+  if (!key) {
+    throw new Error(
+      'Missing Supabase publishable/anon key. Set NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY or EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY (or legacy *_ANON_KEY).',
+    );
+  }
+  return key;
+}

--- a/packages/supabase/src/lib/env-public.ts
+++ b/packages/supabase/src/lib/env-public.ts
@@ -15,7 +15,11 @@ function normalizeEnv(value: string | undefined): string | undefined {
   return value === undefined || value === '' ? undefined : value;
 }
 
-/** Project URL (Next, Expo, or generic server `SUPABASE_URL`). */
+/**
+ * Project URL. Prefer **`NEXT_PUBLIC_SUPABASE_URL`** (Next) or **`EXPO_PUBLIC_SUPABASE_URL`** (Expo)
+ * so the value is available in client bundles. **`SUPABASE_URL`** is only read in environments
+ * with a full `process.env` (e.g. Node server); it is **not** exposed to browser or Expo client code.
+ */
 export function getSupabaseUrl(): string {
   const url =
     normalizeEnv(process.env.NEXT_PUBLIC_SUPABASE_URL) ??
@@ -23,7 +27,7 @@ export function getSupabaseUrl(): string {
     normalizeEnv(process.env.SUPABASE_URL);
   if (!url) {
     throw new Error(
-      'Missing Supabase URL. Set NEXT_PUBLIC_SUPABASE_URL, EXPO_PUBLIC_SUPABASE_URL, or SUPABASE_URL.',
+      'Missing Supabase URL. Set NEXT_PUBLIC_SUPABASE_URL (Next.js) or EXPO_PUBLIC_SUPABASE_URL (Expo) for client code. SUPABASE_URL is optional and server/Node-only—it is not inlined into browser or mobile bundles.',
     );
   }
   return url;

--- a/packages/supabase/src/lib/env-public.ts
+++ b/packages/supabase/src/lib/env-public.ts
@@ -2,24 +2,25 @@
  * Client-safe Supabase URL and publishable (anon) key resolution.
  * Documented names: `packages/supabase/README.md`, `.env.example`, `docs/DEV_SETUP.md`.
  *
+ * **Static `process.env.NEXT_PUBLIC_*` / `EXPO_PUBLIC_*` reads only** — Next.js and Expo
+ * inline these at build time only when the property access is statically analyzable.
+ * Dynamic `process.env[name]` breaks inlining, so client bundles can miss configured values.
+ *
  * Server-only secrets (`SUPABASE_SECRET_KEY`, etc.) live in `admin-client.ts` and are not
  * imported from the main package entry.
  */
 
-function readEnv(name: string): string | undefined {
-  if (typeof process === 'undefined' || !process.env) {
-    return undefined;
-  }
-  const v = process.env[name];
-  return v === '' ? undefined : v;
+/** Treat missing or empty string as unset (`.env` often uses `VAR=` for optional keys). */
+function normalizeEnv(value: string | undefined): string | undefined {
+  return value === undefined || value === '' ? undefined : value;
 }
 
 /** Project URL (Next, Expo, or generic server `SUPABASE_URL`). */
 export function getSupabaseUrl(): string {
   const url =
-    readEnv('NEXT_PUBLIC_SUPABASE_URL') ??
-    readEnv('EXPO_PUBLIC_SUPABASE_URL') ??
-    readEnv('SUPABASE_URL');
+    normalizeEnv(process.env.NEXT_PUBLIC_SUPABASE_URL) ??
+    normalizeEnv(process.env.EXPO_PUBLIC_SUPABASE_URL) ??
+    normalizeEnv(process.env.SUPABASE_URL);
   if (!url) {
     throw new Error(
       'Missing Supabase URL. Set NEXT_PUBLIC_SUPABASE_URL, EXPO_PUBLIC_SUPABASE_URL, or SUPABASE_URL.',
@@ -34,10 +35,10 @@ export function getSupabaseUrl(): string {
  */
 export function getSupabasePublishableKey(): string {
   const key =
-    readEnv('NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY') ??
-    readEnv('EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY') ??
-    readEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY') ??
-    readEnv('EXPO_PUBLIC_SUPABASE_ANON_KEY');
+    normalizeEnv(process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY) ??
+    normalizeEnv(process.env.EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY) ??
+    normalizeEnv(process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) ??
+    normalizeEnv(process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY);
   if (!key) {
     throw new Error(
       'Missing Supabase publishable/anon key. Set NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY or EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY (or legacy *_ANON_KEY).',

--- a/packages/supabase/src/lib/native-client.ts
+++ b/packages/supabase/src/lib/native-client.ts
@@ -1,0 +1,36 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Database } from './database.types.js';
+import { getSupabasePublishableKey, getSupabaseUrl } from './env-public.js';
+
+/** Async-capable storage (e.g. `@react-native-async-storage/async-storage`). */
+export type NativeAuthStorage = {
+  getItem: (key: string) => Promise<string | null> | string | null;
+  setItem: (key: string, value: string) => Promise<void> | void;
+  removeItem: (key: string) => Promise<void> | void;
+};
+
+export type NativeClientOptions = {
+  url?: string;
+  key?: string;
+};
+
+/**
+ * React Native / Expo: pass a storage adapter (e.g. `AsyncStorage` from
+ * `@react-native-async-storage/async-storage`). Optional overrides for URL/key
+ * (defaults read `EXPO_PUBLIC_*` from the Metro bundle).
+ */
+export function createSupabaseNativeClient(
+  storage: NativeAuthStorage,
+  options?: NativeClientOptions,
+) {
+  const url = options?.url ?? getSupabaseUrl();
+  const key = options?.key ?? getSupabasePublishableKey();
+  return createClient<Database>(url, key, {
+    auth: {
+      storage,
+      autoRefreshToken: true,
+      persistSession: true,
+      detectSessionInUrl: false,
+    },
+  });
+}

--- a/packages/supabase/src/lib/queries.ts
+++ b/packages/supabase/src/lib/queries.ts
@@ -5,7 +5,7 @@ export async function fetchProfileByUserId(
   client: AbstrackSupabaseClient,
   userId: string,
 ) {
-  return client.from('profiles').select('*').eq('id', userId).maybeSingle();
+  return await client.from('profiles').select('*').eq('id', userId).maybeSingle();
 }
 
 /**
@@ -13,5 +13,5 @@ export async function fetchProfileByUserId(
  * no rows when RLS blocks or user has no profile yet).
  */
 export async function healthCheckProfilesLimit1(client: AbstrackSupabaseClient) {
-  return client.from('profiles').select('id').limit(1);
+  return await client.from('profiles').select('id').limit(1);
 }

--- a/packages/supabase/src/lib/queries.ts
+++ b/packages/supabase/src/lib/queries.ts
@@ -1,0 +1,17 @@
+import type { AbstrackSupabaseClient } from './auth.js';
+
+/** Single profile row for the given auth user id, if RLS allows. */
+export async function fetchProfileByUserId(
+  client: AbstrackSupabaseClient,
+  userId: string,
+) {
+  return client.from('profiles').select('*').eq('id', userId).maybeSingle();
+}
+
+/**
+ * Minimal read to validate connectivity and session + RLS (empty error when allowed,
+ * no rows when RLS blocks or user has no profile yet).
+ */
+export async function healthCheckProfilesLimit1(client: AbstrackSupabaseClient) {
+  return client.from('profiles').select('id').limit(1);
+}

--- a/packages/supabase/src/lib/queries.ts
+++ b/packages/supabase/src/lib/queries.ts
@@ -1,4 +1,4 @@
-import type { AbstrackSupabaseClient } from './auth.js';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
 
 /** Single profile row for the given auth user id, if RLS allows. */
 export async function fetchProfileByUserId(

--- a/packages/supabase/src/lib/server-client.ts
+++ b/packages/supabase/src/lib/server-client.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from '@supabase/ssr';
 import type { CookieMethodsServer } from '@supabase/ssr';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from './database.types.js';
 import { getSupabasePublishableKey, getSupabaseUrl } from './env-public.js';
 
@@ -10,10 +11,12 @@ export type { CookieMethodsServer };
  * `next/headers` / `NextRequest` / `NextResponse` per Supabase SSR guides.
  * Use **publishable/anon** key only — never the service role key.
  */
-export function createSupabaseServerClient(cookies: CookieMethodsServer) {
+export function createSupabaseServerClient(
+  cookies: CookieMethodsServer,
+): SupabaseClient<Database> {
   return createServerClient<Database>(
     getSupabaseUrl(),
     getSupabasePublishableKey(),
     { cookies },
-  );
+  ) as unknown as SupabaseClient<Database>;
 }

--- a/packages/supabase/src/lib/server-client.ts
+++ b/packages/supabase/src/lib/server-client.ts
@@ -1,0 +1,19 @@
+import { createServerClient } from '@supabase/ssr';
+import type { CookieMethodsServer } from '@supabase/ssr';
+import type { Database } from './database.types.js';
+import { getSupabasePublishableKey, getSupabaseUrl } from './env-public.js';
+
+export type { CookieMethodsServer };
+
+/**
+ * Next.js server components, route handlers, and middleware: pass cookie methods from
+ * `next/headers` / `NextRequest` / `NextResponse` per Supabase SSR guides.
+ * Use **publishable/anon** key only — never the service role key.
+ */
+export function createSupabaseServerClient(cookies: CookieMethodsServer) {
+  return createServerClient<Database>(
+    getSupabaseUrl(),
+    getSupabasePublishableKey(),
+    { cookies },
+  );
+}

--- a/packages/supabase/src/lib/supabase-client-type.ts
+++ b/packages/supabase/src/lib/supabase-client-type.ts
@@ -2,7 +2,11 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from './database.types.js';
 
 /**
- * Any Supabase client for this schema (browser, Next server, or React Native).
- * Defined with `@supabase/supabase-js` only so auth/query helpers do not import `@supabase/ssr`.
+ * Canonical app client type from `@supabase/supabase-js`.
+ *
+ * `@supabase/ssr` factories are still typed with an older `SupabaseClient<Database, SchemaName, Schema>`
+ * triple that no longer matches v2.100’s class generics, which makes their return values not assignable
+ * to `createClient`’s `SupabaseClient` (protected `supabaseUrl` / nominal class rules). Our SSR helpers
+ * therefore assert to this alias at the boundary.
  */
 export type AbstrackSupabaseClient = SupabaseClient<Database>;

--- a/packages/supabase/src/lib/supabase-client-type.ts
+++ b/packages/supabase/src/lib/supabase-client-type.ts
@@ -1,0 +1,8 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from './database.types.js';
+
+/**
+ * Any Supabase client for this schema (browser, Next server, or React Native).
+ * Defined with `@supabase/supabase-js` only so auth/query helpers do not import `@supabase/ssr`.
+ */
+export type AbstrackSupabaseClient = SupabaseClient<Database>;

--- a/packages/supabase/src/lib/supabase.spec.ts
+++ b/packages/supabase/src/lib/supabase.spec.ts
@@ -63,7 +63,7 @@ describe('env-public', () => {
 describe('public entry', () => {
   it('does not expose service-role helpers', () => {
     expect(main).not.toHaveProperty('getSupabaseAdminClient');
-    expect(main).not.toHaveProperty('getSupabaseServiceRoleKey');
+    expect(main).not.toHaveProperty('getSupabaseSecretKey');
   });
 });
 

--- a/packages/supabase/src/lib/supabase.spec.ts
+++ b/packages/supabase/src/lib/supabase.spec.ts
@@ -1,7 +1,69 @@
-import { supabase } from './supabase.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as main from '../index.js';
+import { getSupabasePublishableKey, getSupabaseUrl } from './env-public.js';
 
-describe('supabase', () => {
-  it('should work', () => {
-    expect(supabase()).toEqual('supabase');
+const urlKeys = [
+  'NEXT_PUBLIC_SUPABASE_URL',
+  'EXPO_PUBLIC_SUPABASE_URL',
+  'SUPABASE_URL',
+] as const;
+const keyKeys = [
+  'NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY',
+  'EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY',
+  'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+  'EXPO_PUBLIC_SUPABASE_ANON_KEY',
+] as const;
+
+describe('env-public', () => {
+  const snapshot: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of [...urlKeys, ...keyKeys]) {
+      snapshot[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of [...urlKeys, ...keyKeys]) {
+      if (snapshot[k] === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = snapshot[k];
+      }
+    }
+  });
+
+  it('getSupabaseUrl throws when unset', () => {
+    expect(() => getSupabaseUrl()).toThrow(/Missing Supabase URL/);
+  });
+
+  it('getSupabaseUrl prefers NEXT_PUBLIC_', () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://a.test';
+    process.env.EXPO_PUBLIC_SUPABASE_URL = 'https://b.test';
+    expect(getSupabaseUrl()).toBe('https://a.test');
+  });
+
+  it('getSupabasePublishableKey throws when unset', () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://x.test';
+    expect(() => getSupabasePublishableKey()).toThrow(
+      /Missing Supabase publishable/,
+    );
+  });
+
+  it('getSupabasePublishableKey reads publishable or legacy anon', () => {
+    process.env.EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'sb_publishable_x';
+    expect(getSupabasePublishableKey()).toBe('sb_publishable_x');
+    delete process.env.EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'eyJlegacy';
+    expect(getSupabasePublishableKey()).toBe('eyJlegacy');
   });
 });
+
+describe('public entry', () => {
+  it('does not expose service-role helpers', () => {
+    expect(main).not.toHaveProperty('getSupabaseAdminClient');
+    expect(main).not.toHaveProperty('getSupabaseServiceRoleKey');
+  });
+});
+

--- a/packages/supabase/src/lib/supabase.spec.ts
+++ b/packages/supabase/src/lib/supabase.spec.ts
@@ -65,5 +65,10 @@ describe('public entry', () => {
     expect(main).not.toHaveProperty('getSupabaseAdminClient');
     expect(main).not.toHaveProperty('getSupabaseSecretKey');
   });
+
+  it('does not pull Next SSR entrypoints (use @abstrack/supabase/browser and /server)', () => {
+    expect(main).not.toHaveProperty('getSupabaseBrowserClient');
+    expect(main).not.toHaveProperty('createSupabaseServerClient');
+  });
 });
 

--- a/packages/supabase/src/lib/supabase.ts
+++ b/packages/supabase/src/lib/supabase.ts
@@ -1,3 +1,0 @@
-export function supabase(): string {
-  return 'supabase';
-}

--- a/packages/supabase/src/native.ts
+++ b/packages/supabase/src/native.ts
@@ -1,0 +1,9 @@
+/**
+ * React Native / Expo client factory only (no `@supabase/ssr`).
+ * The main `@abstrack/supabase` entry also exports this; use this path when you want an explicit native-only import surface.
+ */
+export {
+  createSupabaseNativeClient,
+  type NativeAuthStorage,
+  type NativeClientOptions,
+} from './lib/native-client.js';

--- a/packages/supabase/src/server.ts
+++ b/packages/supabase/src/server.ts
@@ -1,0 +1,5 @@
+/** Next.js server / middleware / route handlers — imports `@supabase/ssr`. Do not use from React Native. */
+export {
+  createSupabaseServerClient,
+  type CookieMethodsServer,
+} from './lib/server-client.js';

--- a/packages/supabase/tsconfig.lib.json
+++ b/packages/supabase/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "rootDir": "src",
     "outDir": "dist",
     "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "composite": true,
+    "declaration": true,
     "emitDeclarationOnly": false,
     "forceConsistentCasingInFileNames": true,
     "types": ["node"]

--- a/packages/types/tsconfig.lib.json
+++ b/packages/types/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "rootDir": "src",
     "outDir": "dist",
     "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "composite": true,
+    "declaration": true,
     "emitDeclarationOnly": false,
     "forceConsistentCasingInFileNames": true,
     "types": ["node"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
 
   apps/mobile:
     dependencies:
+      '@abstrack/supabase':
+        specifier: workspace:*
+        version: link:../../packages/supabase
       '@expo/metro-config':
         specifier: '*'
         version: 54.0.14(expo@54.0.33)
@@ -284,6 +287,9 @@ importers:
 
   apps/practitioner:
     dependencies:
+      '@abstrack/supabase':
+        specifier: workspace:*
+        version: link:../../packages/supabase
       next:
         specifier: ~16.0.1
         version: 16.0.11(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.97.3)
@@ -298,6 +304,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@abstrack/supabase':
+        specifier: workspace:*
+        version: link:../../packages/supabase
       '@abstrack/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -327,6 +336,12 @@ importers:
 
   packages/supabase:
     dependencies:
+      '@supabase/ssr':
+        specifier: ^0.6.1
+        version: 0.6.1(@supabase/supabase-js@2.100.1)
+      '@supabase/supabase-js':
+        specifier: ^2.100.1
+        version: 2.100.1
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
@@ -3053,6 +3068,38 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@supabase/auth-js@2.100.1':
+    resolution: {integrity: sha512-c5FB4nrG7cs1mLSzFGuIVl2iR2YO5XkSJ96uF4zubYm8YDn71XOi2emE9sBm/avfGCj61jaRBLOvxEAVnpys0Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.100.1':
+    resolution: {integrity: sha512-mo8QheoV4KR+wSubtyEWhZUxWnCM7YZ23TncccMAlbWAHb8YTDqRGRm9IalWCAswniKyud6buZCk9snRqI86KA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.0':
+    resolution: {integrity: sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==}
+
+  '@supabase/postgrest-js@2.100.1':
+    resolution: {integrity: sha512-OIh4mOSo2LdqF2kox76OAPDtcSs+PwKABJOjc6plUV4/LXhFEsI2uwdEEIs7K7fd141qehWEVl/Y+Ts0fNvYsw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.100.1':
+    resolution: {integrity: sha512-FHuRWPX4qZQ4x+0Q+ZrKaBZnOiVGiwsgiAUJM98pYRib1yeaE/fOM1lZ1ozd+4gA8Udw23OyaD8SxKS5mT5NYw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/ssr@0.6.1':
+    resolution: {integrity: sha512-QtQgEMvaDzr77Mk3vZ3jWg2/y+D8tExYF7vcJT+wQ8ysuvOeGGjYbZlvj5bHYsj/SpC0bihcisnwPrM4Gp5G4g==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.43.4
+
+  '@supabase/storage-js@2.100.1':
+    resolution: {integrity: sha512-x9xpEIoWM4xKiAlwfWTgHPSN6N4Y0aS4FVU4F6ZPbq7Gayw08SrtC6/YH/gOr8CjXQr0HxXYXDop2xGTSjubYA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.100.1':
+    resolution: {integrity: sha512-CAeFm5sfX8sbTzxoxRafhohreIzl9a7R6qHTck3MrgTqm5M5g/u0IHfEKYzI9w/17r8NINl8UZrw2i08wrO7Iw==}
+    engines: {node: '>=20.0.0'}
+
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
     engines: {node: '>=14'}
@@ -4623,6 +4670,10 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cookies@0.9.1:
     resolution: {integrity: sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==}
     engines: {node: '>= 0.8'}
@@ -6029,6 +6080,10 @@ packages:
 
   hyphenate-style-name@1.1.0:
     resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -13441,6 +13496,51 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@supabase/auth-js@2.100.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.100.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.0': {}
+
+  '@supabase/postgrest-js@2.100.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.100.1':
+    dependencies:
+      '@supabase/phoenix': 0.4.0
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/ssr@0.6.1(@supabase/supabase-js@2.100.1)':
+    dependencies:
+      '@supabase/supabase-js': 2.100.1
+      cookie: 1.1.1
+
+  '@supabase/storage-js@2.100.1':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.100.1':
+    dependencies:
+      '@supabase/auth-js': 2.100.1
+      '@supabase/functions-js': 2.100.1
+      '@supabase/postgrest-js': 2.100.1
+      '@supabase/realtime-js': 2.100.1
+      '@supabase/storage-js': 2.100.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -15241,6 +15341,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  cookie@1.1.1: {}
+
   cookies@0.9.1:
     dependencies:
       depd: 2.0.0
@@ -17029,6 +17131,8 @@ snapshots:
   hyperdyperid@1.2.0: {}
 
   hyphenate-style-name@1.1.0: {}
+
+  iceberg-js@0.8.1: {}
 
   iconv-lite@0.4.24:
     dependencies:


### PR DESCRIPTION
Closes #11

## Summary

Delivers the Week 2 **shared Supabase layer**: typed browser/server/native clients, auth helpers, small typed queries, a **separate admin entry** for the service role, **generated `Database` types**, CI that applies migrations on `main` and **verifies** types (no bot commits), PR-time types check against migrations, and documentation for cloud-first + local `db push` / `gen types`. Also updates **`docs/ROADMAP.md`** for Week 2 completion, Week 3 tasks, and planning-note wording.

## `@abstrack/supabase`

- **Replace** monolithic `src/lib/supabase.ts` with focused modules:
  - `browser-client.ts` — `getSupabaseBrowserClient()` via `@supabase/ssr` `createBrowserClient`
  - `server-client.ts` — `createSupabaseServerClient()` for Next server + cookies
  - `native-client.ts` — `createSupabaseNativeClient()` for React Native / storage
  - `auth.ts` — sign-in/up/out, `getSession`, `getAuthUser`
  - `queries.ts` — `fetchProfileByUserId`, `healthCheckProfilesLimit1`
  - `env-public.ts` — `getSupabaseUrl`, `getSupabasePublishableKey` (documented env names)
  - `database.types.ts` — Supabase-generated `Database` / `Json` for `public` schema
- **`@abstrack/supabase/admin`** — `getSupabaseAdminClient()` / service role key (not part of default bundle).
- **Tests:** extended `supabase.spec.ts`, `admin.spec.ts`, `auth-assignability.spec.ts`.
- **Dependencies:** `@supabase/ssr`, `@supabase/supabase-js` (and lockfile updates).
- **README:** env mapping, public API, regen commands, CI behavior.

## GitHub Actions

- **`supabase-migrations.yml`:** On `main`, after `db push`, **diff** committed `database.types.ts` vs `gen types --linked` (fail with instructions if drift). Comments document human `db push` + typegen before merge. PR path: **`db push --dry-run`** (same-repo only; secrets).
- **`supabase-db-types-pr.yml` (new):** On PRs touching `supabase/migrations/**`, Docker `db start` / `db reset`, then **`gen types --local`** vs committed types (no cloud secrets).

## Documentation

- **`docs/SUPABASE_CLOUD_DEVELOPER.md` (new):** Cloud-first workflow, recommended `db push` + `gen types --linked` before merge, CI as backstop, AI assistant notes.
- **`AGENTS.md` (new):** Repo rules for agents (Supabase, commands for Sarah, workflow boundaries).
- **`docs/DEV_SETUP.md`:** §4 aligned with the above (Actions + local CLI).
- **`packages/supabase/src/lib/database.types.ts`:** File header with regen commands (if still present after any local regen).

## Apps (compile / smoke wiring)

- **`apps/web`**, **`apps/mobile`**, **`apps/practitioner`:** add `@abstrack/supabase` dependency where needed.
- **Wiring / tests:** `apps/web/src/lib/abstrack-types-wiring.ts` (types import), `apps/mobile/src/lib/supabase-wiring.ts` + `App.spec.tsx`, `apps/practitioner/src/lib/supabase-wiring.ts` + spec import.
- **`apps/web/next-env.d.ts`:** incidental TypeScript reference tweak.

## Roadmap (`docs/ROADMAP.md`)

- Mark **`@abstrack/types`** complete for Week 2.
- Week 3: session + **optional patient preference** (re-auth on app open), **`healthCheckProfilesLimit1`** in one patient app, **`@abstrack/crypto`** scope + first non-PHI utility, security baseline doc; remove vague defer/slip language from notes in favor of week-bound tasks.

## What this PR does *not* change

- **No edits to `supabase/migrations/*.sql`** in this branch — schema files in git are unchanged here; `database.types.ts` is meant to match the already-deployed cloud schema.

## How to verify locally

```bash
pnpm install
pnpm exec nx run supabase:lint
pnpm exec nx run supabase:test
pnpm exec nx run supabase:build