### PR TITLE
fix(ci): pass .prettierrc when formatting temp database.types in Supabase workflows

### DIFF
--- a/.github/workflows/supabase-db-types-pr.yml
+++ b/.github/workflows/supabase-db-types-pr.yml
@@ -47,5 +47,6 @@ jobs:
           # Compare generated body only — committed file may include a hand-maintained header comment.
           supabase gen types typescript --local --schema public > /tmp/database.types.generated.ts
           awk '/^export type Json/{flag=1} flag' packages/supabase/src/lib/database.types.ts > /tmp/database.types.committed-body.ts
-          npx --yes prettier@3.6.2 --write /tmp/database.types.committed-body.ts /tmp/database.types.generated.ts
+          # Prettier resolves config from the file path; /tmp would miss repo .prettierrc and format differently.
+          npx --yes prettier@3.6.2 --config .prettierrc --write /tmp/database.types.committed-body.ts /tmp/database.types.generated.ts
           diff -u /tmp/database.types.committed-body.ts /tmp/database.types.generated.ts

--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -90,7 +90,8 @@ jobs:
           # Compare generated body only — committed file may include a hand-maintained header comment.
           supabase gen types typescript --linked --schema public > /tmp/database.types.generated.ts
           awk '/^export type Json/{flag=1} flag' packages/supabase/src/lib/database.types.ts > /tmp/database.types.committed-body.ts
-          npx --yes prettier@3.6.2 --write /tmp/database.types.committed-body.ts /tmp/database.types.generated.ts
+          # Prettier resolves config from the file path; /tmp would miss repo .prettierrc and format differently.
+          npx --yes prettier@3.6.2 --config .prettierrc --write /tmp/database.types.committed-body.ts /tmp/database.types.generated.ts
           if diff -q /tmp/database.types.committed-body.ts /tmp/database.types.generated.ts >/dev/null; then
             echo "Database types match linked project."
             exit 0


### PR DESCRIPTION
…
## Summary

Prettier was run on `/tmp/...` paths in the Supabase types verification steps, so it never picked up the repo `.prettierrc` and defaulted to different quote/style rules than local `pnpm exec prettier --write`. That made `gen types` output fail the diff against `packages/supabase/src/lib/database.types.ts` even when the schema matched.

Add `--config .prettierrc` to the `prettier` invocations in `supabase-migrations.yml` (post-`db push` on `main`) and `supabase-db-types-pr.yml` (local stack on PRs).

References #11