### PR TITLE
Mobile preset tabs + web-aligned light/dark theming, auth placeholders, and tab icons

### DIFF
--- a/apps/mobile/global.css
+++ b/apps/mobile/global.css
@@ -1,3 +1,63 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/**
+ * Semantic app colors (space-separated RGB channels). Aligned with `apps/web/src/app/global.css`.
+ *
+ * Web toggles dark via `html.dark` + `darkMode: 'class'`. Mobile uses `@media (prefers-color-scheme: dark)`
+ * on `:root` so `tailwind.config.js` `colors.app.*` utilities follow system appearance (same as
+ * `AppThemeProvider` / Expo `userInterfaceStyle: automatic`). Use `bg-app-bg`, not `dark:bg-app-bg`,
+ * for these tokens—they already respond to light/dark.
+ */
+@layer base {
+  :root {
+    --app-bg: 244 247 251;
+    --app-surface: 255 255 255;
+    --app-border: 226 232 240;
+    --app-muted: 100 116 139;
+    --app-ink: 15 23 42;
+    --app-primary: 29 78 216;
+    --app-primary-soft: 219 234 254;
+    --app-ring: 37 99 235;
+    --app-header-bg: rgba(255, 255, 255, 0.92);
+    --app-header-border: rgba(226, 232, 240, 0.95);
+    --app-nav-hover-bg: #f1f5f9;
+    --app-ring-slate: rgba(15, 23, 42, 0.06);
+    --app-gradient: linear-gradient(
+      180deg,
+      #f1f5f9 0%,
+      #f8fafc 45%,
+      #f1f5f9 100%
+    );
+    --app-shadow-soft:
+      0 1px 2px rgba(15, 23, 42, 0.04), 0 8px 24px -4px rgba(15, 23, 42, 0.08);
+    --app-shadow-header: 0 1px 0 rgba(15, 23, 42, 0.06);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --app-bg: 15 23 42;
+      --app-surface: 30 41 59;
+      --app-border: 51 65 85;
+      --app-muted: 148 163 184;
+      --app-ink: 241 245 249;
+      --app-primary: 96 165 250;
+      --app-primary-soft: 37 99 235;
+      --app-ring: 147 197 253;
+      --app-header-bg: rgba(15, 23, 42, 0.92);
+      --app-header-border: rgba(51, 65, 85, 0.95);
+      --app-nav-hover-bg: #334155;
+      --app-ring-slate: rgba(241, 245, 249, 0.08);
+      --app-gradient: linear-gradient(
+        180deg,
+        #0f172a 0%,
+        #1e293b 45%,
+        #0f172a 100%
+      );
+      --app-shadow-soft:
+        0 1px 2px rgba(0, 0, 0, 0.25), 0 8px 24px -4px rgba(0, 0, 0, 0.35);
+      --app-shadow-header: 0 1px 0 rgba(0, 0, 0, 0.35);
+    }
+  }
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -8,8 +8,11 @@
     "ios": "expo run:ios"
   },
   "dependencies": {
+    "@abstrack/ui": "workspace:*",
     "@abstrack/supabase": "workspace:*",
+    "@react-navigation/bottom-tabs": "*",
     "@expo/metro-config": "*",
+    "@expo/vector-icons": "*",
     "@react-navigation/native": "*",
     "@react-navigation/native-stack": "*",
     "@testing-library/react-native": "*",
@@ -23,6 +26,7 @@
     "metro-config": "*",
     "metro-resolver": "*",
     "nativewind": "^4.2.3",
+    "react-native-css-interop": "0.2.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",

--- a/apps/mobile/src/app/App.spec.tsx
+++ b/apps/mobile/src/app/App.spec.tsx
@@ -473,6 +473,48 @@ describe('mobile auth state sync', () => {
     expect(signOut).toHaveBeenCalledTimes(1);
   });
 
+  test('navigates to symptom and health marker preset screens from tabs', async () => {
+    const signedInSession = {
+      access_token: 'access',
+      refresh_token: 'refresh',
+      token_type: 'bearer',
+      expires_in: 3600,
+      expires_at: 9999999999,
+      user: { id: 'user-1' },
+    } as unknown as Session;
+
+    const mockClient = {
+      auth: {
+        getSession: jest.fn(async () => ({
+          data: { session: signedInSession },
+        })),
+        signOut: jest.fn(async () => ({ error: null })),
+        onAuthStateChange: jest.fn(() => ({
+          data: {
+            subscription: {
+              unsubscribe: jest.fn(),
+            },
+          },
+        })),
+      },
+    } as unknown as AbstrackSupabaseClient;
+
+    jest.mocked(SecureStore.getItemAsync).mockResolvedValue('false');
+    jest.mocked(getMobileSupabaseClient).mockReturnValue(mockClient);
+
+    const { findByText, findByLabelText, findByTestId } = render(<App />);
+
+    expect(await findByText('Welcome to ABStrack')).toBeTruthy();
+
+    fireEvent.press(await findByLabelText('Symptom presets'));
+    expect(await findByTestId('symptom-presets-placeholder')).toBeTruthy();
+
+    fireEvent.press(await findByLabelText('Health marker presets'));
+    expect(
+      await findByTestId('health-marker-presets-placeholder'),
+    ).toBeTruthy();
+  });
+
   test('exposes the re-authentication toggle in settings', async () => {
     const signedInSession = {
       access_token: 'access',

--- a/apps/mobile/src/app/App.tsx
+++ b/apps/mobile/src/app/App.tsx
@@ -9,6 +9,7 @@ import { getMobileSupabaseClient } from '../lib/supabase-wiring';
 import { AppProviders } from './components/AppProviders';
 import { ForgotPasswordScreen } from './screens/ForgotPasswordScreen';
 import { MainTabNavigator } from './navigation/MainTabNavigator';
+import type { MainStackParamList } from './navigation/types';
 import { LoginScreen } from './screens/LoginScreen';
 import { SettingsScreen } from './screens/SettingsScreen';
 import { SignupScreen } from './screens/SignupScreen';
@@ -21,11 +22,6 @@ type AuthStackParamList = {
   Signup: undefined;
   ForgotPassword: undefined;
   UpdatePassword: undefined;
-};
-
-type MainStackParamList = {
-  MainTabs: undefined;
-  Settings: undefined;
 };
 
 const AuthStack = createNativeStackNavigator<AuthStackParamList>();

--- a/apps/mobile/src/app/App.tsx
+++ b/apps/mobile/src/app/App.tsx
@@ -1,20 +1,20 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator } from 'react-native';
-import { AppState } from 'react-native';
-import { Linking } from 'react-native';
+import { ActivityIndicator, AppState, Linking, View } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { StatusBar } from 'expo-status-bar';
 import type { Session } from '@abstrack/supabase';
 import { getMobileSupabaseClient } from '../lib/supabase-wiring';
 import { AppProviders } from './components/AppProviders';
 import { ForgotPasswordScreen } from './screens/ForgotPasswordScreen';
-import { HomeScreen } from './screens/HomeScreen';
+import { MainTabNavigator } from './navigation/MainTabNavigator';
 import { LoginScreen } from './screens/LoginScreen';
 import { SettingsScreen } from './screens/SettingsScreen';
 import { SignupScreen } from './screens/SignupScreen';
 import { UpdatePasswordScreen } from './screens/UpdatePasswordScreen';
 import { getRequireReauthOnOpenPreference } from './reauth-preference';
+import { useAppTheme } from './theme/AppThemeContext';
 
 type AuthStackParamList = {
   Login: undefined;
@@ -24,7 +24,7 @@ type AuthStackParamList = {
 };
 
 type MainStackParamList = {
-  Home: undefined;
+  MainTabs: undefined;
   Settings: undefined;
 };
 
@@ -77,7 +77,21 @@ function getRecoveryErrorMessage(params: URLSearchParams): string | null {
   return null;
 }
 
+/**
+ * Root component: session bootstrap and navigation. Theme follows system appearance by default.
+ *
+ * @returns Application tree.
+ */
 export function App() {
+  return (
+    <AppProviders>
+      <AppBootstrap />
+    </AppProviders>
+  );
+}
+
+function AppBootstrap() {
+  const { colors, navigationTheme, statusBarStyle } = useAppTheme();
   const mobileSupabase = useMemo(() => getMobileSupabaseClient(), []);
   const [session, setSession] = useState<Session | null>(null);
   const [initializing, setInitializing] = useState(true);
@@ -86,6 +100,16 @@ export function App() {
   const [recoveryError, setRecoveryError] = useState<string | null>(null);
   const recoveryFlowActiveRef = useRef(false);
   const authRouteRef = useRef<AuthRoute>('Login');
+
+  const stackScreenOptions = useMemo(
+    () => ({
+      headerStyle: { backgroundColor: colors.surface },
+      headerTintColor: colors.primary,
+      headerTitleStyle: { color: colors.ink, fontWeight: '600' as const },
+      contentStyle: { backgroundColor: colors.bg },
+    }),
+    [colors],
+  );
 
   useEffect(() => {
     let mounted = true;
@@ -272,7 +296,7 @@ export function App() {
 
   const authStack = useMemo(
     () => (
-      <AuthStack.Navigator>
+      <AuthStack.Navigator screenOptions={stackScreenOptions}>
         {authRoute === 'Login' ? (
           <AuthStack.Screen name="Login" options={{ title: 'Login' }}>
             {() => (
@@ -329,37 +353,42 @@ export function App() {
         ) : null}
       </AuthStack.Navigator>
     ),
-    [authRoute, recoveryError],
+    [authRoute, recoveryError, stackScreenOptions],
   );
 
   const showAuthStack = !session || recoveryFlowActive;
 
   if (initializing) {
     return (
-      <AppProviders>
-        <SafeAreaView className="flex-1 items-center justify-center">
-          <ActivityIndicator size="large" />
+      <View style={{ flex: 1, backgroundColor: colors.bg }}>
+        <StatusBar style={statusBarStyle} />
+        <SafeAreaView
+          style={{
+            flex: 1,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: colors.bg,
+          }}
+        >
+          <ActivityIndicator size="large" color={colors.primary} />
         </SafeAreaView>
-      </AppProviders>
+      </View>
     );
   }
 
   return (
-    <AppProviders>
-      <NavigationContainer>
+    <View style={{ flex: 1, backgroundColor: colors.bg }}>
+      <StatusBar style={statusBarStyle} />
+      <NavigationContainer theme={navigationTheme}>
         {showAuthStack ? (
           authStack
         ) : (
-          <MainStack.Navigator>
-            <MainStack.Screen name="Home" options={{ title: 'Home' }}>
-              {({ navigation }) => (
-                <HomeScreen
-                  onGoToSettings={() => {
-                    navigation.navigate('Settings');
-                  }}
-                />
-              )}
-            </MainStack.Screen>
+          <MainStack.Navigator screenOptions={stackScreenOptions}>
+            <MainStack.Screen
+              name="MainTabs"
+              component={MainTabNavigator}
+              options={{ headerShown: false }}
+            />
             <MainStack.Screen
               name="Settings"
               component={SettingsScreen}
@@ -368,7 +397,7 @@ export function App() {
           </MainStack.Navigator>
         )}
       </NavigationContainer>
-    </AppProviders>
+    </View>
   );
 }
 

--- a/apps/mobile/src/app/components/AppNavigationShell.tsx
+++ b/apps/mobile/src/app/components/AppNavigationShell.tsx
@@ -5,7 +5,7 @@ import { NavigationShell } from '@abstrack/ui/native';
 import { useAppTheme } from '../theme/AppThemeContext';
 
 export type AppNavigationShellProps = {
-  /** Visible screen title (also used for accessibility on the header region). */
+  /** Visible screen title; header semantics come from {@link NavigationShell}'s header container. */
   title: string;
   children: React.ReactNode;
 };
@@ -41,7 +41,6 @@ export function AppNavigationShell({
         header={
           <Text
             style={[shellStyles.headerTitle, { color: colors.ink }]}
-            accessibilityRole="header"
             maxFontSizeMultiplier={2}
           >
             {title}

--- a/apps/mobile/src/app/components/AppNavigationShell.tsx
+++ b/apps/mobile/src/app/components/AppNavigationShell.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { NavigationShell } from '@abstrack/ui/native';
+import { useAppTheme } from '../theme/AppThemeContext';
+
+export type AppNavigationShellProps = {
+  /** Visible screen title (also used for accessibility on the header region). */
+  title: string;
+  children: React.ReactNode;
+};
+
+/**
+ * Authenticated-area layout: safe area (above bottom tab bar), {@link NavigationShell}
+ * header with title, and main content. Uses shared `@abstrack/ui` chrome with web-aligned colors.
+ *
+ * @param props - Title and main subtree.
+ * @returns Shell-wrapped screen content.
+ */
+export function AppNavigationShell({
+  title,
+  children,
+}: AppNavigationShellProps) {
+  const { colors } = useAppTheme();
+
+  return (
+    <SafeAreaView
+      style={[shellStyles.safeArea, { backgroundColor: colors.bg }]}
+      edges={['top', 'left', 'right']}
+    >
+      <NavigationShell
+        style={[shellStyles.shellRoot, { backgroundColor: colors.bg }]}
+        headerStyle={[
+          shellStyles.headerChrome,
+          {
+            backgroundColor: colors.surface,
+            borderBottomColor: colors.border,
+          },
+        ]}
+        mainStyle={{ backgroundColor: colors.bg }}
+        header={
+          <Text
+            style={[shellStyles.headerTitle, { color: colors.ink }]}
+            accessibilityRole="header"
+            maxFontSizeMultiplier={2}
+          >
+            {title}
+          </Text>
+        }
+      >
+        {children}
+      </NavigationShell>
+    </SafeAreaView>
+  );
+}
+
+const shellStyles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+  },
+  shellRoot: {
+    flex: 1,
+  },
+  headerChrome: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerTitle: {
+    fontSize: 20,
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/src/app/components/AppProviders.tsx
+++ b/apps/mobile/src/app/components/AppProviders.tsx
@@ -1,6 +1,17 @@
 import React from 'react';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { AppThemeProvider } from '../theme/AppThemeContext';
 
+/**
+ * Global providers: safe area and app theme (system light/dark by default).
+ *
+ * @param props - React children.
+ * @returns Provider tree.
+ */
 export function AppProviders({ children }: { children: React.ReactNode }) {
-  return <SafeAreaProvider>{children}</SafeAreaProvider>;
+  return (
+    <SafeAreaProvider>
+      <AppThemeProvider>{children}</AppThemeProvider>
+    </SafeAreaProvider>
+  );
 }

--- a/apps/mobile/src/app/components/AsyncScreenContainer.tsx
+++ b/apps/mobile/src/app/components/AsyncScreenContainer.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { MIN_TOUCH_TARGET_DP } from '@abstrack/ui/native';
+import { useAppTheme } from '../theme/AppThemeContext';
+
+/**
+ * Async UI phase for preset (and similar) screens before data is wired.
+ */
+export type AsyncScreenStatus = 'loading' | 'error' | 'ready';
+
+export type AsyncScreenContainerProps = {
+  /** Current phase; drives which subtree renders. */
+  status: AsyncScreenStatus;
+  /** Announced while loading (spinner). */
+  loadingAccessibilityLabel?: string;
+  /** Short heading when `status` is `error`. */
+  errorTitle?: string;
+  /** Detail when `status` is `error`. */
+  errorMessage?: string;
+  /** Optional retry when `status` is `error` (large touch target). */
+  onRetry?: () => void;
+  children: React.ReactNode;
+};
+
+/**
+ * Centered loading and error regions for async screens; passes through `children` when `ready`.
+ * Intended for preset scaffolds until Supabase wiring exists.
+ *
+ * @param props - Status, optional error copy, and main content.
+ * @returns Loading spinner, error panel, or children.
+ */
+export function AsyncScreenContainer({
+  status,
+  loadingAccessibilityLabel = 'Loading',
+  errorTitle = 'Something went wrong',
+  errorMessage = 'We could not load this screen. Check your connection and try again.',
+  onRetry,
+  children,
+}: AsyncScreenContainerProps) {
+  const { colors } = useAppTheme();
+
+  if (status === 'loading') {
+    return (
+      <View
+        style={asyncStyles.centered}
+        accessibilityLabel={loadingAccessibilityLabel}
+        accessibilityRole="progressbar"
+      >
+        <ActivityIndicator size="large" color={colors.primary} />
+      </View>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <View style={asyncStyles.centered} accessibilityRole="alert">
+        <Text
+          style={[asyncStyles.errorTitle, { color: colors.ink }]}
+          maxFontSizeMultiplier={2}
+        >
+          {errorTitle}
+        </Text>
+        <Text
+          style={[asyncStyles.errorBody, { color: colors.muted }]}
+          maxFontSizeMultiplier={2}
+        >
+          {errorMessage}
+        </Text>
+        {onRetry ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Try again"
+            onPress={onRetry}
+            style={({ pressed }) => [
+              asyncStyles.retryButton,
+              { backgroundColor: colors.primary },
+              pressed ? asyncStyles.retryButtonPressed : null,
+            ]}
+          >
+            <Text style={[asyncStyles.retryLabel, { color: colors.onPrimary }]}>
+              Try again
+            </Text>
+          </Pressable>
+        ) : null}
+      </View>
+    );
+  }
+
+  return <View style={asyncStyles.readyRoot}>{children}</View>;
+}
+
+const asyncStyles = StyleSheet.create({
+  readyRoot: {
+    flex: 1,
+  },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+    gap: 12,
+  },
+  errorTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  errorBody: {
+    fontSize: 16,
+    textAlign: 'center',
+  },
+  retryButton: {
+    marginTop: 8,
+    minHeight: MIN_TOUCH_TARGET_DP,
+    minWidth: MIN_TOUCH_TARGET_DP * 3,
+    paddingHorizontal: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 10,
+  },
+  retryButtonPressed: {
+    opacity: 0.85,
+  },
+  retryLabel: {
+    fontSize: 17,
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/src/app/components/AuthForm.tsx
+++ b/apps/mobile/src/app/components/AuthForm.tsx
@@ -1,7 +1,8 @@
 import React, { useRef } from 'react';
 import { Pressable, Text, TextInput, View } from 'react-native';
 import { ScreenShell } from './ScreenShell';
-import { styles } from '../styles';
+import { useAppStyles } from '../styles';
+import { useAppTheme } from '../theme/AppThemeContext';
 
 export type AuthFormProps = {
   title: string;
@@ -44,6 +45,8 @@ export function AuthForm({
   onAlternateAction,
   onTertiaryAction,
 }: AuthFormProps) {
+  const styles = useAppStyles();
+  const { colors } = useAppTheme();
   const passwordInputRef = useRef<TextInput>(null);
   const primaryDisabled = loading || Boolean(submitDisabled);
   const handleSubmit = () => {
@@ -67,6 +70,7 @@ export function AuthForm({
         value={email}
         onChangeText={onEmailChange}
         placeholder="you@example.com"
+        placeholderTextColor={colors.inputPlaceholder}
         style={styles.input}
         accessibilityLabel="Email address"
         accessibilityHint="Enter your account email"
@@ -86,6 +90,7 @@ export function AuthForm({
         value={password}
         onChangeText={onPasswordChange}
         placeholder="Password"
+        placeholderTextColor={colors.inputPlaceholder}
         style={styles.input}
         accessibilityLabel="Password"
         accessibilityHint="Enter your account password"

--- a/apps/mobile/src/app/components/ScreenShell.tsx
+++ b/apps/mobile/src/app/components/ScreenShell.tsx
@@ -1,17 +1,52 @@
 import React from 'react';
-import { View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useAppTheme } from '../theme/AppThemeContext';
 
 /**
- * Auth and form screens: safe area, centered layout, card surface.
- * Styled with NativeWind (`className`) for shared Tailwind usage across the app.
+ * Auth and form screens: safe area, centered layout, card surface aligned with web app shell.
+ *
+ * @param props - Child content inside the card.
+ * @returns Themed shell layout.
  */
 export function ScreenShell({ children }: { children: React.ReactNode }) {
+  const { colors } = useAppTheme();
+
   return (
-    <SafeAreaView className="flex-1 justify-center bg-[#f4f7fb] p-4">
-      <View className="gap-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+    <SafeAreaView
+      style={[styles.outer, { backgroundColor: colors.bg }]}
+      edges={['top', 'left', 'right', 'bottom']}
+    >
+      <View
+        style={[
+          styles.card,
+          {
+            backgroundColor: colors.surface,
+            borderColor: colors.border,
+            shadowColor: colors.shadow,
+            shadowOpacity: colors.shadowOpacity,
+          },
+        ]}
+      >
         {children}
       </View>
     </SafeAreaView>
   );
 }
+
+const styles = StyleSheet.create({
+  outer: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 16,
+  },
+  card: {
+    gap: 12,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 16,
+    shadowOffset: { width: 0, height: 1 },
+    shadowRadius: 4,
+    elevation: 2,
+  },
+});

--- a/apps/mobile/src/app/navigation/MainTabNavigator.tsx
+++ b/apps/mobile/src/app/navigation/MainTabNavigator.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { Ionicons } from '@expo/vector-icons';
+import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
+import { HomeScreen } from '../screens/HomeScreen';
+import { HealthMarkerPresetsScreen } from '../screens/HealthMarkerPresetsScreen';
+import { SymptomPresetsScreen } from '../screens/SymptomPresetsScreen';
+import { useAppTheme } from '../theme/AppThemeContext';
+import type { MainTabParamList } from './types';
+
+const Tab = createBottomTabNavigator<MainTabParamList>();
+
+type IonName = React.ComponentProps<typeof Ionicons>['name'];
+
+/**
+ * @param name - Ionicons glyph name.
+ * @returns Tab bar icon render function for React Navigation.
+ */
+function tabBarIonIcon(name: IonName) {
+  return function TabBarIon({ color, size }: { color: string; size: number }) {
+    return <Ionicons name={name} size={size} color={color} />;
+  };
+}
+
+/**
+ * Primary signed-in navigation: home plus preset entry points with a bottom tab bar sized for
+ * comfortable touch targets.
+ *
+ * @returns Tab navigator element.
+ */
+export function MainTabNavigator() {
+  const { colors } = useAppTheme();
+
+  return (
+    <Tab.Navigator
+      screenOptions={{
+        headerShown: false,
+        tabBarActiveTintColor: colors.primary,
+        tabBarInactiveTintColor: colors.muted,
+        tabBarLabelPosition: 'below-icon',
+        tabBarShowLabel: true,
+        tabBarStyle: {
+          paddingTop: 4,
+          paddingBottom: 6,
+          minHeight: COMFORTABLE_TOUCH_TARGET_DP + 28,
+          backgroundColor: colors.surface,
+          borderTopColor: colors.border,
+          borderTopWidth: StyleSheet.hairlineWidth,
+        },
+        tabBarItemStyle: {
+          paddingVertical: 4,
+        },
+      }}
+    >
+      <Tab.Screen
+        name="Home"
+        options={{
+          tabBarLabel: 'Home',
+          tabBarAccessibilityLabel: 'Home',
+          tabBarIcon: tabBarIonIcon('home-outline'),
+        }}
+      >
+        {({ navigation }) => (
+          <HomeScreen
+            onGoToSettings={() => {
+              navigation.getParent()?.navigate('Settings');
+            }}
+          />
+        )}
+      </Tab.Screen>
+      <Tab.Screen
+        name="SymptomPresets"
+        component={SymptomPresetsScreen}
+        options={{
+          tabBarLabel: 'Symptoms',
+          tabBarAccessibilityLabel: 'Symptom presets',
+          tabBarIcon: tabBarIonIcon('medkit-outline'),
+        }}
+      />
+      <Tab.Screen
+        name="HealthMarkerPresets"
+        component={HealthMarkerPresetsScreen}
+        options={{
+          tabBarLabel: 'Markers',
+          tabBarAccessibilityLabel: 'Health marker presets',
+          tabBarIcon: tabBarIonIcon('pulse-outline'),
+        }}
+      />
+    </Tab.Navigator>
+  );
+}

--- a/apps/mobile/src/app/navigation/MainTabNavigator.tsx
+++ b/apps/mobile/src/app/navigation/MainTabNavigator.tsx
@@ -1,15 +1,36 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
 import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
 import { HomeScreen } from '../screens/HomeScreen';
 import { HealthMarkerPresetsScreen } from '../screens/HealthMarkerPresetsScreen';
 import { SymptomPresetsScreen } from '../screens/SymptomPresetsScreen';
 import { useAppTheme } from '../theme/AppThemeContext';
-import type { MainTabParamList } from './types';
+import type { MainStackParamList, MainTabParamList } from './types';
 
 const Tab = createBottomTabNavigator<MainTabParamList>();
+
+/**
+ * Home tab lives under {@link MainStackParamList} `MainTabs`; opens stack `Settings`.
+ * Invariant: tab navigator is always nested in that stack — missing parent is a programmer error.
+ *
+ * @param navigation - Home tab navigation object.
+ */
+function navigateFromHomeTabToSettings(
+  navigation: BottomTabNavigationProp<MainTabParamList, 'Home'>,
+) {
+  const stackNavigation =
+    navigation.getParent<NativeStackNavigationProp<MainStackParamList>>();
+  if (stackNavigation == null) {
+    throw new Error(
+      'MainTabNavigator: expected native stack parent (MainStack) to open Settings.',
+    );
+  }
+  stackNavigation.navigate('Settings');
+}
 
 type IonName = React.ComponentProps<typeof Ionicons>['name'];
 
@@ -64,7 +85,7 @@ export function MainTabNavigator() {
         {({ navigation }) => (
           <HomeScreen
             onGoToSettings={() => {
-              navigation.getParent()?.navigate('Settings');
+              navigateFromHomeTabToSettings(navigation);
             }}
           />
         )}

--- a/apps/mobile/src/app/navigation/types.ts
+++ b/apps/mobile/src/app/navigation/types.ts
@@ -1,0 +1,14 @@
+/**
+ * Param lists for authenticated mobile navigation (tabs + stack overlays).
+ */
+
+export type MainTabParamList = {
+  Home: undefined;
+  SymptomPresets: undefined;
+  HealthMarkerPresets: undefined;
+};
+
+export type MainStackParamList = {
+  MainTabs: undefined;
+  Settings: undefined;
+};

--- a/apps/mobile/src/app/screens/ForgotPasswordScreen.tsx
+++ b/apps/mobile/src/app/screens/ForgotPasswordScreen.tsx
@@ -4,7 +4,8 @@ import { resetPasswordForEmail } from '@abstrack/supabase';
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { mapAuthError } from '../auth-helpers';
 import { ScreenShell } from '../components/ScreenShell';
-import { styles } from '../styles';
+import { useAppStyles } from '../styles';
+import { useAppTheme } from '../theme/AppThemeContext';
 
 const MOBILE_RESET_REDIRECT_URL = 'abstrack:///update-password';
 
@@ -13,6 +14,8 @@ export function ForgotPasswordScreen({
 }: {
   onGoToLogin: () => void;
 }) {
+  const styles = useAppStyles();
+  const { colors } = useAppTheme();
   const [email, setEmail] = useState('');
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -75,6 +78,7 @@ export function ForgotPasswordScreen({
         value={email}
         onChangeText={setEmail}
         placeholder="you@example.com"
+        placeholderTextColor={colors.inputPlaceholder}
         style={styles.input}
         accessibilityLabel="Email address"
         accessibilityHint="Enter your account email"

--- a/apps/mobile/src/app/screens/HealthMarkerPresetsScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPresetsScreen.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { AppNavigationShell } from '../components/AppNavigationShell';
+import { AsyncScreenContainer } from '../components/AsyncScreenContainer';
+import { useAppTheme } from '../theme/AppThemeContext';
+
+/**
+ * Health marker presets landing screen. CRUD and Supabase wiring are out of scope; shows
+ * placeholder content with async loading/error containers ready for future data.
+ *
+ * @returns Screen scaffold.
+ */
+export function HealthMarkerPresetsScreen() {
+  const { colors } = useAppTheme();
+
+  return (
+    <AppNavigationShell title="Health marker presets">
+      <AsyncScreenContainer status="ready">
+        <ScrollView
+          contentContainerStyle={markerStyles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View
+            style={[
+              markerStyles.panel,
+              {
+                borderColor: colors.border,
+                backgroundColor: colors.surface,
+              },
+            ]}
+          >
+            <Text
+              style={[markerStyles.lead, { color: colors.muted }]}
+              maxFontSizeMultiplier={2}
+              testID="health-marker-presets-placeholder"
+            >
+              You have not created any health marker presets yet. When this
+              feature is connected, you will configure the markers you track
+              alongside episodes.
+            </Text>
+          </View>
+        </ScrollView>
+      </AsyncScreenContainer>
+    </AppNavigationShell>
+  );
+}
+
+const markerStyles = StyleSheet.create({
+  scrollContent: {
+    flexGrow: 1,
+    padding: 16,
+  },
+  panel: {
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 16,
+  },
+  lead: {
+    fontSize: 16,
+    lineHeight: 24,
+  },
+});

--- a/apps/mobile/src/app/screens/HomeScreen.tsx
+++ b/apps/mobile/src/app/screens/HomeScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Pressable, Text, View } from 'react-native';
+import { Pressable, ScrollView, Text, View } from 'react-native';
 import {
   getAuthUser,
   healthCheckProfilesLimit1,
@@ -7,8 +7,8 @@ import {
 } from '@abstrack/supabase';
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { mapAuthError } from '../auth-helpers';
-import { ScreenShell } from '../components/ScreenShell';
-import { styles } from '../styles';
+import { AppNavigationShell } from '../components/AppNavigationShell';
+import { useAppStyles } from '../styles';
 
 interface HealthCheckResult {
   success: boolean;
@@ -21,6 +21,7 @@ type HomeScreenProps = {
 };
 
 export function HomeScreen({ onGoToSettings }: HomeScreenProps) {
+  const styles = useAppStyles();
   const isTestEnv =
     typeof process !== 'undefined' && process.env.NODE_ENV === 'test';
   const showHealthCheck = __DEV__ && !isTestEnv;
@@ -120,91 +121,98 @@ export function HomeScreen({ onGoToSettings }: HomeScreenProps) {
   };
 
   return (
-    <ScreenShell>
-      <Text style={styles.title} testID="main-home-title">
-        Welcome to ABStrack
-      </Text>
+    <AppNavigationShell title="Home">
+      <ScrollView
+        contentContainerStyle={styles.homeScrollContent}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View style={styles.card}>
+          <Text style={styles.title} testID="main-home-title">
+            Welcome to ABStrack
+          </Text>
 
-      {/* Health Check Status - only render once result is available */}
-      {showHealthCheck && healthCheck && (
-        <View
-          style={[
-            styles.healthCheckContainer,
-            healthCheck.success
-              ? styles.healthCheckContainerSuccess
-              : styles.healthCheckContainerFailure,
-          ]}
-        >
-          <Text
-            style={[
-              styles.healthCheckTitleText,
-              healthCheck.success
-                ? styles.healthCheckTitleTextSuccess
-                : styles.healthCheckTitleTextFailure,
-            ]}
-          >
-            {healthCheck.success
-              ? '✓ Health Check Passed'
-              : '✗ Health Check Failed'}
-          </Text>
-          <Text
-            style={[
-              styles.healthCheckBodyText,
-              healthCheck.success
-                ? styles.healthCheckBodyTextSuccess
-                : styles.healthCheckBodyTextFailure,
-            ]}
-          >
-            {healthCheck.message}
-          </Text>
-          {healthCheck.error && (
-            <Text
+          {/* Health Check Status - only render once result is available */}
+          {showHealthCheck && healthCheck && (
+            <View
               style={[
-                styles.healthCheckErrorText,
+                styles.healthCheckContainer,
                 healthCheck.success
-                  ? styles.healthCheckErrorTextSuccess
-                  : styles.healthCheckErrorTextFailure,
+                  ? styles.healthCheckContainerSuccess
+                  : styles.healthCheckContainerFailure,
               ]}
             >
-              Error: {healthCheck.error}
-            </Text>
+              <Text
+                style={[
+                  styles.healthCheckTitleText,
+                  healthCheck.success
+                    ? styles.healthCheckTitleTextSuccess
+                    : styles.healthCheckTitleTextFailure,
+                ]}
+              >
+                {healthCheck.success
+                  ? '✓ Health Check Passed'
+                  : '✗ Health Check Failed'}
+              </Text>
+              <Text
+                style={[
+                  styles.healthCheckBodyText,
+                  healthCheck.success
+                    ? styles.healthCheckBodyTextSuccess
+                    : styles.healthCheckBodyTextFailure,
+                ]}
+              >
+                {healthCheck.message}
+              </Text>
+              {healthCheck.error && (
+                <Text
+                  style={[
+                    styles.healthCheckErrorText,
+                    healthCheck.success
+                      ? styles.healthCheckErrorTextSuccess
+                      : styles.healthCheckErrorTextFailure,
+                  ]}
+                >
+                  Error: {healthCheck.error}
+                </Text>
+              )}
+            </View>
           )}
+
+          <Text style={styles.bodyText}>You are signed in.</Text>
+          {signOutError ? (
+            <Text style={styles.errorText} accessibilityRole="alert">
+              {signOutError}
+            </Text>
+          ) : null}
+          <View style={styles.spacer} />
+
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Go to settings"
+            onPress={onGoToSettings}
+            style={styles.secondaryButton}
+          >
+            <Text style={styles.secondaryButtonText}>Settings</Text>
+          </Pressable>
+
+          <View style={styles.spacer} />
+
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={signOutBusy ? 'Signing out...' : 'Sign out'}
+            onPress={handleSignOut}
+            disabled={signOutBusy}
+            style={[
+              styles.primaryButton,
+              signOutBusy ? styles.primaryButtonDisabled : null,
+            ]}
+          >
+            <Text style={styles.primaryButtonText}>
+              {signOutBusy ? 'Signing out...' : 'Sign out'}
+            </Text>
+          </Pressable>
         </View>
-      )}
-
-      <Text style={styles.bodyText}>You are signed in.</Text>
-      {signOutError ? (
-        <Text style={styles.errorText} accessibilityRole="alert">
-          {signOutError}
-        </Text>
-      ) : null}
-      <View style={styles.spacer} />
-
-      <Pressable
-        accessibilityRole="button"
-        accessibilityLabel="Go to settings"
-        onPress={onGoToSettings}
-        style={styles.secondaryButton}
-      >
-        <Text style={styles.secondaryButtonText}>Settings</Text>
-      </Pressable>
-
-      <View style={styles.spacer} />
-
-      <Pressable
-        accessibilityRole="button"
-        accessibilityLabel={signOutBusy ? 'Signing out...' : 'Sign out'}
-        onPress={handleSignOut}
-        disabled={signOutBusy}
-        style={[
-          styles.primaryButton,
-          signOutBusy ? styles.primaryButtonDisabled : null,
-        ]}
-      >
-        <Text style={styles.primaryButtonText}>
-          {signOutBusy ? 'Signing out...' : 'Sign out'}
-        </Text>
-      </Pressable>
-    </ScreenShell>
+      </ScrollView>
+    </AppNavigationShell>
   );
 }

--- a/apps/mobile/src/app/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/app/screens/SettingsScreen.tsx
@@ -5,9 +5,12 @@ import {
   setRequireReauthOnOpenPreference,
 } from '../reauth-preference';
 import { ScreenShell } from '../components/ScreenShell';
-import { styles } from '../styles';
+import { useAppStyles } from '../styles';
+import { useAppTheme } from '../theme/AppThemeContext';
 
 export function SettingsScreen() {
+  const styles = useAppStyles();
+  const { colors } = useAppTheme();
   const isMountedRef = useRef(true);
   const [requireReauth, setRequireReauth] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -82,6 +85,7 @@ export function SettingsScreen() {
           value={requireReauth}
           onValueChange={onTogglePreference}
           disabled={loading || saving}
+          trackColor={{ false: colors.border, true: colors.primary }}
         />
       </View>
       {errorMessage ? (

--- a/apps/mobile/src/app/screens/SymptomPresetsScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPresetsScreen.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { AppNavigationShell } from '../components/AppNavigationShell';
+import { AsyncScreenContainer } from '../components/AsyncScreenContainer';
+import { useAppTheme } from '../theme/AppThemeContext';
+
+/**
+ * Symptom presets landing screen. CRUD and Supabase wiring are out of scope; shows placeholder
+ * content with async loading/error containers ready for future data.
+ *
+ * @returns Screen scaffold.
+ */
+export function SymptomPresetsScreen() {
+  const { colors } = useAppTheme();
+
+  return (
+    <AppNavigationShell title="Symptom presets">
+      <AsyncScreenContainer status="ready">
+        <ScrollView
+          contentContainerStyle={symptomStyles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View
+            style={[
+              symptomStyles.panel,
+              {
+                borderColor: colors.border,
+                backgroundColor: colors.surface,
+              },
+            ]}
+          >
+            <Text
+              style={[symptomStyles.lead, { color: colors.muted }]}
+              maxFontSizeMultiplier={2}
+              testID="symptom-presets-placeholder"
+            >
+              You have not created any symptom presets yet. When this feature is
+              connected, you will define named lists of symptoms and response
+              types for episode logging.
+            </Text>
+          </View>
+        </ScrollView>
+      </AsyncScreenContainer>
+    </AppNavigationShell>
+  );
+}
+
+const symptomStyles = StyleSheet.create({
+  scrollContent: {
+    flexGrow: 1,
+    padding: 16,
+  },
+  panel: {
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 16,
+  },
+  lead: {
+    fontSize: 16,
+    lineHeight: 24,
+  },
+});

--- a/apps/mobile/src/app/screens/UpdatePasswordScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/UpdatePasswordScreen.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { fireEvent, render } from '@testing-library/react-native';
 
+import { AppThemeProvider } from '../theme/AppThemeContext';
 import { UpdatePasswordScreen } from './UpdatePasswordScreen';
 
 jest.mock('../../lib/supabase-wiring', () => ({
@@ -12,11 +13,13 @@ describe('UpdatePasswordScreen', () => {
     const onGoToLogin = jest.fn();
 
     const { getByLabelText, getByText } = render(
-      <UpdatePasswordScreen
-        recoveryError="This reset link is invalid or expired. Request a new one."
-        onGoToLogin={onGoToLogin}
-        onPasswordUpdated={jest.fn()}
-      />,
+      <AppThemeProvider>
+        <UpdatePasswordScreen
+          recoveryError="This reset link is invalid or expired. Request a new one."
+          onGoToLogin={onGoToLogin}
+          onPasswordUpdated={jest.fn()}
+        />
+      </AppThemeProvider>,
     );
 
     const updateButton = getByLabelText('Update password');

--- a/apps/mobile/src/app/screens/UpdatePasswordScreen.tsx
+++ b/apps/mobile/src/app/screens/UpdatePasswordScreen.tsx
@@ -4,7 +4,8 @@ import { signOut, updatePassword } from '@abstrack/supabase';
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { mapAuthError, validateSignupPassword } from '../auth-helpers';
 import { ScreenShell } from '../components/ScreenShell';
-import { styles } from '../styles';
+import { useAppStyles } from '../styles';
+import { useAppTheme } from '../theme/AppThemeContext';
 
 export function UpdatePasswordScreen({
   recoveryError,
@@ -15,6 +16,8 @@ export function UpdatePasswordScreen({
   onGoToLogin: () => void;
   onPasswordUpdated: () => void;
 }) {
+  const styles = useAppStyles();
+  const { colors } = useAppTheme();
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [loading, setLoading] = useState(false);
@@ -104,6 +107,7 @@ export function UpdatePasswordScreen({
         value={password}
         onChangeText={setPassword}
         placeholder="New password"
+        placeholderTextColor={colors.inputPlaceholder}
         style={styles.input}
         accessibilityLabel="New password"
         testID="update-password-new"
@@ -119,6 +123,7 @@ export function UpdatePasswordScreen({
         value={confirmPassword}
         onChangeText={setConfirmPassword}
         placeholder="Confirm new password"
+        placeholderTextColor={colors.inputPlaceholder}
         style={styles.input}
         accessibilityLabel="Confirm new password"
         testID="update-password-confirm"

--- a/apps/mobile/src/app/styles.ts
+++ b/apps/mobile/src/app/styles.ts
@@ -1,156 +1,188 @@
+import { useMemo } from 'react';
 import { StyleSheet } from 'react-native';
+import type { AppThemeColors } from './theme/app-colors';
+import { useAppTheme } from './theme/AppThemeContext';
 
-export const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#f4f7fb',
-    justifyContent: 'center',
-    padding: 16,
-  },
-  loadingContainer: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  card: {
-    backgroundColor: '#ffffff',
-    borderRadius: 12,
-    padding: 16,
-    gap: 12,
-    shadowColor: '#000000',
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.1,
-    shadowRadius: 4,
-    elevation: 2,
-  },
-  title: {
-    fontSize: 22,
-    fontWeight: '600',
-  },
-  labelText: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#0f172a',
-  },
-  bodyText: {
-    fontSize: 16,
-    color: '#334155',
-  },
-  input: {
-    borderWidth: 1,
-    borderColor: '#cbd5e1',
-    borderRadius: 8,
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-    fontSize: 16,
-    minHeight: 52,
-  },
-  errorText: {
-    color: '#b91c1c',
-    fontSize: 14,
-  },
-  infoText: {
-    color: '#1d4ed8',
-    fontSize: 14,
-  },
-  primaryButton: {
-    backgroundColor: '#1d4ed8',
-    borderRadius: 10,
-    minHeight: 52,
-    paddingHorizontal: 16,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  primaryButtonDisabled: {
-    opacity: 0.6,
-  },
-  primaryButtonText: {
-    color: '#ffffff',
-    fontSize: 18,
-    fontWeight: '700',
-  },
-  secondaryButton: {
-    borderRadius: 10,
-    borderWidth: 1,
-    borderColor: '#1d4ed8',
-    minHeight: 52,
-    paddingHorizontal: 16,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#ffffff',
-  },
-  secondaryButtonText: {
-    color: '#1d4ed8',
-    fontSize: 17,
-    fontWeight: '600',
-    textAlign: 'center',
-  },
-  tertiaryButton: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    minHeight: 32,
-  },
-  tertiaryButtonText: {
-    color: '#1d4ed8',
-    fontSize: 15,
-    fontWeight: '500',
-    textAlign: 'center',
-  },
-  spacer: {
-    height: 8,
-  },
-  settingRow: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    gap: 12,
-  },
-  settingTextBlock: {
-    flex: 1,
-    gap: 6,
-  },
-  healthCheckContainer: {
-    marginVertical: 12,
-    padding: 12,
-    borderRadius: 8,
-    borderWidth: 1,
-  },
-  healthCheckContainerSuccess: {
-    borderColor: '#16a34a',
-    backgroundColor: '#f0fdf4',
-  },
-  healthCheckContainerFailure: {
-    borderColor: '#dc2626',
-    backgroundColor: '#fef2f2',
-  },
-  healthCheckTitleText: {
-    fontSize: 14,
-    fontWeight: '600',
-    marginBottom: 4,
-  },
-  healthCheckTitleTextSuccess: {
-    color: '#15803d',
-  },
-  healthCheckTitleTextFailure: {
-    color: '#991b1b',
-  },
-  healthCheckBodyText: {
-    fontSize: 12,
-  },
-  healthCheckBodyTextSuccess: {
-    color: '#166534',
-  },
-  healthCheckBodyTextFailure: {
-    color: '#7f1d1d',
-  },
-  healthCheckErrorText: {
-    fontSize: 10,
-    marginTop: 8,
-    fontFamily: 'monospace',
-  },
-  healthCheckErrorTextSuccess: {
-    color: '#166534',
-  },
-  healthCheckErrorTextFailure: {
-    color: '#7f1d1d',
-  },
-});
+/**
+ * Builds authenticated and auth form styles from semantic app colors (web `global.css` parity).
+ *
+ * @param colors - Palette for the active color scheme.
+ * @returns StyleSheet map used across screens.
+ */
+export function createAppStyles(colors: AppThemeColors) {
+  return StyleSheet.create({
+    homeScrollContent: {
+      flexGrow: 1,
+      padding: 16,
+      justifyContent: 'center',
+    },
+    container: {
+      flex: 1,
+      backgroundColor: colors.bg,
+      justifyContent: 'center',
+      padding: 16,
+    },
+    loadingContainer: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: colors.bg,
+    },
+    card: {
+      backgroundColor: colors.surface,
+      borderRadius: 12,
+      padding: 16,
+      gap: 12,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: colors.border,
+      shadowColor: colors.shadow,
+      shadowOffset: { width: 0, height: 1 },
+      shadowOpacity: colors.shadowOpacity,
+      shadowRadius: 4,
+      elevation: 2,
+    },
+    title: {
+      fontSize: 22,
+      fontWeight: '600',
+      color: colors.ink,
+    },
+    labelText: {
+      fontSize: 16,
+      fontWeight: '600',
+      color: colors.ink,
+    },
+    bodyText: {
+      fontSize: 16,
+      color: colors.muted,
+    },
+    input: {
+      borderWidth: 1,
+      borderColor: colors.border,
+      borderRadius: 8,
+      paddingHorizontal: 12,
+      paddingVertical: 10,
+      fontSize: 16,
+      minHeight: 52,
+      color: colors.ink,
+      backgroundColor: colors.surface,
+    },
+    errorText: {
+      color: colors.error,
+      fontSize: 14,
+    },
+    infoText: {
+      color: colors.info,
+      fontSize: 14,
+    },
+    primaryButton: {
+      backgroundColor: colors.primary,
+      borderRadius: 10,
+      minHeight: 52,
+      paddingHorizontal: 16,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    primaryButtonDisabled: {
+      opacity: 0.6,
+    },
+    primaryButtonText: {
+      color: colors.onPrimary,
+      fontSize: 18,
+      fontWeight: '700',
+    },
+    secondaryButton: {
+      borderRadius: 10,
+      borderWidth: 1,
+      borderColor: colors.primary,
+      minHeight: 52,
+      paddingHorizontal: 16,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: colors.surface,
+    },
+    secondaryButtonText: {
+      color: colors.primary,
+      fontSize: 17,
+      fontWeight: '600',
+      textAlign: 'center',
+    },
+    tertiaryButton: {
+      alignItems: 'center',
+      justifyContent: 'center',
+      minHeight: 32,
+    },
+    tertiaryButtonText: {
+      color: colors.primary,
+      fontSize: 15,
+      fontWeight: '500',
+      textAlign: 'center',
+    },
+    spacer: {
+      height: 8,
+    },
+    settingRow: {
+      alignItems: 'center',
+      flexDirection: 'row',
+      gap: 12,
+    },
+    settingTextBlock: {
+      flex: 1,
+      gap: 6,
+    },
+    healthCheckContainer: {
+      marginVertical: 12,
+      padding: 12,
+      borderRadius: 8,
+      borderWidth: 1,
+    },
+    healthCheckContainerSuccess: {
+      borderColor: colors.healthSuccessBorder,
+      backgroundColor: colors.healthSuccessBg,
+    },
+    healthCheckContainerFailure: {
+      borderColor: colors.healthFailureBorder,
+      backgroundColor: colors.healthFailureBg,
+    },
+    healthCheckTitleText: {
+      fontSize: 14,
+      fontWeight: '600',
+      marginBottom: 4,
+    },
+    healthCheckTitleTextSuccess: {
+      color: colors.healthSuccessTitle,
+    },
+    healthCheckTitleTextFailure: {
+      color: colors.healthFailureTitle,
+    },
+    healthCheckBodyText: {
+      fontSize: 12,
+    },
+    healthCheckBodyTextSuccess: {
+      color: colors.healthSuccessBody,
+    },
+    healthCheckBodyTextFailure: {
+      color: colors.healthFailureBody,
+    },
+    healthCheckErrorText: {
+      fontSize: 10,
+      marginTop: 8,
+      fontFamily: 'monospace',
+    },
+    healthCheckErrorTextSuccess: {
+      color: colors.healthSuccessBody,
+    },
+    healthCheckErrorTextFailure: {
+      color: colors.healthFailureBody,
+    },
+  });
+}
+
+/**
+ * Hook returning memoized styles for the active {@link useAppTheme} palette.
+ *
+ * @returns Styles keyed like the former static `styles` export.
+ */
+export function useAppStyles() {
+  const { colors } = useAppTheme();
+  return useMemo(() => createAppStyles(colors), [colors]);
+}

--- a/apps/mobile/src/app/theme/AppThemeContext.tsx
+++ b/apps/mobile/src/app/theme/AppThemeContext.tsx
@@ -46,8 +46,8 @@ function buildNavigationTheme(
 }
 
 /**
- * Provides semantic colors from the active color scheme (defaults to system via
- * {@link useColorScheme}).
+ * Provides semantic colors from the active color scheme (follows system appearance via React Native's
+ * {@link https://reactnative.dev/docs/usecolorscheme | useColorScheme}).
  *
  * @param props - React children.
  * @returns Context provider.

--- a/apps/mobile/src/app/theme/AppThemeContext.tsx
+++ b/apps/mobile/src/app/theme/AppThemeContext.tsx
@@ -1,0 +1,85 @@
+import React, { createContext, useContext, useMemo } from 'react';
+import { useColorScheme as useRNColorScheme } from 'react-native';
+import {
+  DarkTheme,
+  DefaultTheme,
+  type Theme as NavigationTheme,
+} from '@react-navigation/native';
+import {
+  darkAppColors,
+  lightAppColors,
+  type AppThemeColors,
+} from './app-colors';
+
+export type AppColorScheme = 'light' | 'dark';
+
+export type AppThemeContextValue = {
+  /** Resolved appearance (`null` from RN is treated as light). */
+  colorScheme: AppColorScheme;
+  colors: AppThemeColors;
+  /** React Navigation container theme (cards, headers, tab chrome). */
+  navigationTheme: NavigationTheme;
+  /** Expo StatusBar style: dark icons on light bg, light icons on dark bg. */
+  statusBarStyle: 'light' | 'dark';
+};
+
+const AppThemeContext = createContext<AppThemeContextValue | null>(null);
+
+function buildNavigationTheme(
+  colors: AppThemeColors,
+  scheme: AppColorScheme,
+): NavigationTheme {
+  const base = scheme === 'dark' ? DarkTheme : DefaultTheme;
+  return {
+    ...base,
+    dark: scheme === 'dark',
+    colors: {
+      ...base.colors,
+      primary: colors.primary,
+      background: colors.bg,
+      card: colors.surface,
+      text: colors.ink,
+      border: colors.border,
+      notification: colors.primary,
+    },
+  };
+}
+
+/**
+ * Provides semantic colors from the active color scheme (defaults to system via
+ * {@link useColorScheme}).
+ *
+ * @param props - React children.
+ * @returns Context provider.
+ */
+export function AppThemeProvider({ children }: { children: React.ReactNode }) {
+  const rnScheme = useRNColorScheme();
+  const colorScheme: AppColorScheme = rnScheme === 'dark' ? 'dark' : 'light';
+  const colors = colorScheme === 'dark' ? darkAppColors : lightAppColors;
+
+  const value = useMemo((): AppThemeContextValue => {
+    return {
+      colorScheme,
+      colors,
+      navigationTheme: buildNavigationTheme(colors, colorScheme),
+      statusBarStyle: colorScheme === 'dark' ? 'light' : 'dark',
+    };
+  }, [colorScheme, colors]);
+
+  return (
+    <AppThemeContext.Provider value={value}>
+      {children}
+    </AppThemeContext.Provider>
+  );
+}
+
+/**
+ * @returns Active app theme (system-driven until a manual preference exists).
+ */
+export function useAppTheme(): AppThemeContextValue {
+  const ctx = useContext(AppThemeContext);
+  if (!ctx) {
+    throw new Error('useAppTheme must be used within AppThemeProvider');
+  }
+  return ctx;
+}

--- a/apps/mobile/src/app/theme/app-colors.ts
+++ b/apps/mobile/src/app/theme/app-colors.ts
@@ -10,6 +10,11 @@ export type AppThemeColors = {
   muted: string;
   ink: string;
   primary: string;
+  /**
+   * Opaque fill for `--app-primary-soft` RGB channels (same as web/mobile `global.css`).
+   * For translucent chips or overlays, set opacity on the view or use a separate alpha at the call site
+   * (web uses utilities like `bg-app-primary-soft/28` instead of baking alpha into the token).
+   */
   primarySoft: string;
   primaryOnSoft: string;
   onPrimary: string;
@@ -63,7 +68,7 @@ export const darkAppColors: AppThemeColors = {
   muted: '#94a3b8',
   ink: '#f1f5f9',
   primary: '#60a5fa',
-  primarySoft: 'rgba(37, 99, 235, 0.35)',
+  primarySoft: '#2563eb',
   primaryOnSoft: '#93c5fd',
   onPrimary: '#0f172a',
   error: '#f87171',

--- a/apps/mobile/src/app/theme/app-colors.ts
+++ b/apps/mobile/src/app/theme/app-colors.ts
@@ -1,0 +1,82 @@
+/**
+ * Semantic colors aligned with `apps/web/src/app/global.css` (`--app-*` RGB tokens).
+ * Used for React Native `StyleSheet` theming; manual preference will plug into the same shape later.
+ */
+export type AppThemeColors = {
+  bg: string;
+  surface: string;
+  border: string;
+  muted: string;
+  ink: string;
+  primary: string;
+  primarySoft: string;
+  primaryOnSoft: string;
+  onPrimary: string;
+  error: string;
+  info: string;
+  /** TextInput placeholder: visible on `surface`, dimmer than {@link ink} labels. */
+  inputPlaceholder: string;
+  /** Shadow color for elevated cards (iOS). */
+  shadow: string;
+  shadowOpacity: number;
+  healthSuccessBg: string;
+  healthSuccessBorder: string;
+  healthSuccessTitle: string;
+  healthSuccessBody: string;
+  healthFailureBg: string;
+  healthFailureBorder: string;
+  healthFailureTitle: string;
+  healthFailureBody: string;
+};
+
+export const lightAppColors: AppThemeColors = {
+  bg: '#f4f7fb',
+  surface: '#ffffff',
+  border: '#e2e8f0',
+  muted: '#64748b',
+  ink: '#0f172a',
+  primary: '#1d4ed8',
+  primarySoft: '#dbeafe',
+  primaryOnSoft: '#1d4ed8',
+  onPrimary: '#ffffff',
+  error: '#b91c1c',
+  info: '#1d4ed8',
+  inputPlaceholder: '#64748b',
+  shadow: '#0f172a',
+  shadowOpacity: 0.08,
+  healthSuccessBg: '#f0fdf4',
+  healthSuccessBorder: '#16a34a',
+  healthSuccessTitle: '#15803d',
+  healthSuccessBody: '#166534',
+  healthFailureBg: '#fef2f2',
+  healthFailureBorder: '#dc2626',
+  healthFailureTitle: '#991b1b',
+  healthFailureBody: '#7f1d1d',
+};
+
+/** Mirrors `html.dark` in global.css. */
+export const darkAppColors: AppThemeColors = {
+  bg: '#0f172a',
+  surface: '#1e293b',
+  border: '#334155',
+  muted: '#94a3b8',
+  ink: '#f1f5f9',
+  primary: '#60a5fa',
+  primarySoft: 'rgba(37, 99, 235, 0.35)',
+  primaryOnSoft: '#93c5fd',
+  onPrimary: '#0f172a',
+  error: '#f87171',
+  info: '#60a5fa',
+  /** Dimmer than {@link ink} titles; between previous slate-300 and full {@link muted}. */
+  inputPlaceholder: '#9ca3af',
+  shadow: '#000000',
+  shadowOpacity: 0.35,
+  healthSuccessBg: 'rgba(22, 101, 52, 0.35)',
+  healthSuccessBorder: '#22c55e',
+  healthSuccessTitle: '#86efac',
+  healthSuccessBody: '#bbf7d0',
+  healthFailureBg: 'rgba(185, 28, 28, 0.35)',
+  healthFailureBorder: '#f87171',
+  healthFailureTitle: '#fecaca',
+  healthFailureBody: '#fecaca',
+};

--- a/apps/mobile/src/app/theme/app-colors.ts
+++ b/apps/mobile/src/app/theme/app-colors.ts
@@ -1,6 +1,7 @@
 /**
- * Semantic colors aligned with `apps/web/src/app/global.css` (`--app-*` RGB tokens).
- * Used for React Native `StyleSheet` theming; manual preference will plug into the same shape later.
+ * Semantic colors aligned with web (`apps/web/src/app/global.css`) and mobile NativeWind
+ * (`apps/mobile/global.css` CSS variables for `className`). Keep light/dark hex values in sync
+ * with those `--app-*` channels when they change.
  */
 export type AppThemeColors = {
   bg: string;

--- a/apps/mobile/tailwind.config.js
+++ b/apps/mobile/tailwind.config.js
@@ -2,24 +2,42 @@
 module.exports = {
   content: ['./index.js', './src/**/*.{js,jsx,ts,tsx}'],
   presets: [require('nativewind/preset')],
+  /**
+   * `media` enables Tailwind `dark:` utilities from OS preference. Semantic `app.*` colors do not
+   * rely on `dark:`—they use CSS variables in `global.css` that already switch under
+   * `prefers-color-scheme: dark` (parallel to web’s `html.dark` + class strategy).
+   */
   darkMode: 'media',
   theme: {
     extend: {
       colors: {
         /**
-         * Semantic tokens aligned with `apps/web` (`global.css` / `tailwind.config.js`).
-         * Prefer `useAppTheme()` + StyleSheet for RN screens; use these for `className` where useful.
+         * Semantic tokens: RGB channels live in `global.css` (`:root` + dark media query).
+         * Opacity modifiers use `rgb(var(--app-*) / <alpha-value>)` like web.
+         * Prefer `useAppTheme()` + StyleSheet for screens; use `className` utilities where NativeWind fits.
          */
         app: {
-          bg: '#f4f7fb',
-          surface: '#ffffff',
-          border: '#e2e8f0',
-          muted: '#64748b',
-          ink: '#0f172a',
-          primary: '#1d4ed8',
-          'primary-soft': '#dbeafe',
-          ring: '#2563eb',
+          bg: 'rgb(var(--app-bg) / <alpha-value>)',
+          surface: 'rgb(var(--app-surface) / <alpha-value>)',
+          border: 'rgb(var(--app-border) / <alpha-value>)',
+          muted: 'rgb(var(--app-muted) / <alpha-value>)',
+          ink: 'rgb(var(--app-ink) / <alpha-value>)',
+          primary: 'rgb(var(--app-primary) / <alpha-value>)',
+          'primary-soft': 'rgb(var(--app-primary-soft) / <alpha-value>)',
+          ring: 'rgb(var(--app-ring) / <alpha-value>)',
         },
+      },
+      ringOffsetColor: {
+        app: {
+          bg: 'rgb(var(--app-bg) / <alpha-value>)',
+        },
+      },
+      boxShadow: {
+        soft: 'var(--app-shadow-soft)',
+        header: 'var(--app-shadow-header)',
+      },
+      backgroundImage: {
+        'app-gradient': 'var(--app-gradient)',
       },
     },
   },

--- a/apps/mobile/tailwind.config.js
+++ b/apps/mobile/tailwind.config.js
@@ -2,8 +2,26 @@
 module.exports = {
   content: ['./index.js', './src/**/*.{js,jsx,ts,tsx}'],
   presets: [require('nativewind/preset')],
+  darkMode: 'media',
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        /**
+         * Semantic tokens aligned with `apps/web` (`global.css` / `tailwind.config.js`).
+         * Prefer `useAppTheme()` + StyleSheet for RN screens; use these for `className` where useful.
+         */
+        app: {
+          bg: '#f4f7fb',
+          surface: '#ffffff',
+          border: '#e2e8f0',
+          muted: '#64748b',
+          ink: '#0f172a',
+          primary: '#1d4ed8',
+          'primary-soft': '#dbeafe',
+          ring: '#2563eb',
+        },
+      },
+    },
   },
   plugins: [],
 };

--- a/apps/mobile/tsconfig.app.json
+++ b/apps/mobile/tsconfig.app.json
@@ -46,6 +46,9 @@
   "references": [
     {
       "path": "../../packages/supabase/tsconfig.lib.json"
+    },
+    {
+      "path": "../../packages/ui/tsconfig.lib.json"
     }
   ]
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,6 +13,12 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./native": {
+      "@abstrack/source": "./src/native.ts",
+      "types": "./dist/native.d.ts",
+      "import": "./dist/native.js",
+      "default": "./dist/native.js"
     }
   },
   "peerDependencies": {

--- a/packages/ui/src/native.ts
+++ b/packages/ui/src/native.ts
@@ -1,0 +1,11 @@
+/**
+ * React Native–safe entry: shared layout shell and design tokens without DOM-only hooks.
+ */
+
+export * from './lib/constants.js';
+export * from './lib/NavigationShell.js';
+export {
+  defaultPalette,
+  highContrastPalette,
+  type UiPalette,
+} from './lib/styles/theme.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,9 +234,18 @@ importers:
       '@abstrack/supabase':
         specifier: workspace:*
         version: link:../../packages/supabase
+      '@abstrack/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@expo/metro-config':
         specifier: '*'
         version: 54.0.14(expo@54.0.33)
+      '@expo/vector-icons':
+        specifier: '*'
+        version: 15.1.1(expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@react-navigation/bottom-tabs':
+        specifier: '*'
+        version: 7.15.9(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@react-navigation/native':
         specifier: '*'
         version: 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -285,6 +294,9 @@ importers:
       react-native:
         specifier: 0.81.5
         version: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+      react-native-css-interop:
+        specifier: 0.2.3
+        version: 0.2.3(d24f11dbc2a9123b6c6039fb3b3d0720)
       react-native-reanimated:
         specifier: ~4.1.7
         version: 4.1.7(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -4236,6 +4248,18 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@react-navigation/bottom-tabs@7.15.9':
+    resolution:
+      {
+        integrity: sha512-Ou28A1aZLj5wiFQ3F93aIsrI4NCwn3IJzkkjNo9KLFXsc0Yks+UqrVaFlffHFLsrbajuGRG/OQpnMA1ljayY5Q==,
+      }
+    peerDependencies:
+      '@react-navigation/native': ^7.2.2
+      react: '>= 18.2.0'
+      react-native: '*'
+      react-native-safe-area-context: '>= 4.0.0'
+      react-native-screens: '>= 4.0.0'
 
   '@react-navigation/core@7.17.2':
     resolution:
@@ -20211,6 +20235,19 @@ snapshots:
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.17
+
+  '@react-navigation/bottom-tabs@7.15.9(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@react-navigation/elements': 2.9.14(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@react-navigation/native': 7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      color: 4.2.3
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-screens: 4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      sf-symbols-typescript: 2.2.0
+    transitivePeerDependencies:
+      - '@react-native-masked-view/masked-view'
 
   '@react-navigation/core@7.17.2(react@19.1.0)':
     dependencies:


### PR DESCRIPTION
Closes #45

## Summary

Adds authenticated mobile navigation to symptom and health marker preset scaffolds, aligns shell and chrome with the web app’s semantic palette (light/dark, system default), and fixes NativeWind/Metro resolution for `react-native-css-interop`.

## What changed

- **Navigation:** Bottom tabs (`Home`, `Symptoms`, `Markers`) plus stack `Settings`; home uses parent navigation to open settings.
- **Preset screens:** `SymptomPresetsScreen` and `HealthMarkerPresetsScreen` with placeholder copy (no CRUD/Supabase). Shared **`AsyncScreenContainer`** for loading and error states (ready by default).
- **Shell:** **`AppNavigationShell`** wraps `@abstrack/ui` **`NavigationShell`**; added **`@abstrack/ui/native`** entry so mobile avoids DOM-only hooks.
- **Theming:** **`AppThemeProvider`** + **`app-colors`** tokens aligned with `apps/web` `global.css`; **`useAppStyles`** / **`useAppTheme`** across auth and main flows; **`NavigationContainer`** + **`StatusBar`** follow scheme; tab bar and inputs themed.
- **Dependencies:** `react-native-css-interop` (Metro), `@react-navigation/bottom-tabs`, `@expo/vector-icons` (tab icons).
- **UX:** `placeholderTextColor` from theme; dark-mode placeholder hierarchy vs titles; tab bar Ionicons (`home-outline`, `medkit-outline`, `pulse-outline`).

## Testing

- `nx lint mobile`, `nx test mobile`, `tsc -p apps/mobile/tsconfig.app.json`

## Notes

- Manual light/dark override in settings is future work; system appearance is default (`userInterfaceStyle: automatic` in Expo).