### PR TITLE
feat(a11y): add live announcer stack, docs, and resilient auth session bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,18 @@ Do **not** add **`week_`** (or other week-number-style prefixes) to **code, iden
 
 This workspace has **MCP servers** (for example Context7 for library and framework docs, Nx, Supabase, Next.js devtools, and the in-editor browser). **Use them** to pull **current** documentation and API details instead of relying only on training data. That helps avoid **deprecated** patterns, outdated APIs, and wrong version-specific behavior.
 
+## Accessibility & screen readers
+
+ABStrack is **accessibility-first** (see **[docs/PRD.md](docs/PRD.md)**). Treat **screen reader**, **keyboard**, and **large-target** support as **default requirements** for interactive UI—not a polish pass at the end.
+
+- **Conventions:** Follow **[docs/A11Y.md](docs/A11Y.md)** for live announcements, forms, dialogs, and charts.
+- **User & practitioner web:** Root layouts mount `LiveAnnouncerProvider` (via `LiveAnnouncerRoot`). In client components, use **`useAnnounce()`** from **`@abstrack/ui/a11y-web`** (or the same exports from `@abstrack/ui` where the full package is already used) for transient status (polite vs assertive per `docs/A11Y.md`). Prefer **`@abstrack/ui/a11y-web`** in Next.js when you only need announcements, to avoid pulling the React Native–based UI barrel into server/client graphs unnecessarily.
+- **Mobile:** Use **`announce()`** from `@abstrack/ui/native` for short spoken feedback; use **`accessibilityLabel`**, **`accessibilityRole`**, **`accessibilityState`**, and **`accessibilityLiveRegion`** (Android) as appropriate for persistent UI.
+- **Semantics:** Prefer native HTML semantics and labels; use ARIA only when semantics are missing or insufficient. Do not rely on **color alone** for meaning.
+- **Dynamic feedback:** Ensure important changes are available to assistive tech (live regions / `announce`), not only visually.
+- **Charts:** Avoid visual-only insights; provide a **text summary** or structured alternative for chart data where the PRD calls for charts.
+- **Verification:** When changing UI, keep **eslint** / **axe** checks green where they apply; call out **manual** screen reader smoke tests for new critical flows when automation cannot cover them.
+
 ## Documentation (Typedoc / JSDoc)
 
 **Typedoc** is used for API documentation. Maintain it as you work:

--- a/apps/practitioner/next-env.d.ts
+++ b/apps/practitioner/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/practitioner/package.json
+++ b/apps/practitioner/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@abstrack/supabase": "workspace:*",
+    "@abstrack/ui": "workspace:*",
     "next": "~16.0.1",
     "react": "19.1.0",
     "react-dom": "19.1.0"

--- a/apps/practitioner/src/app/layout.tsx
+++ b/apps/practitioner/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import './global.css';
+import { LiveAnnouncerRoot } from '../components/a11y/LiveAnnouncerRoot';
 
 export const metadata = {
   title: 'Welcome to practitioner',
@@ -13,7 +14,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <main>{children}</main>
+        <LiveAnnouncerRoot>
+          <main>{children}</main>
+        </LiveAnnouncerRoot>
       </body>
     </html>
   );

--- a/apps/practitioner/src/components/a11y/LiveAnnouncerRoot.tsx
+++ b/apps/practitioner/src/components/a11y/LiveAnnouncerRoot.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { LiveAnnouncerProvider } from '@abstrack/ui/a11y-web';
+import type { ReactNode } from 'react';
+
+/**
+ * Client boundary that mounts `LiveAnnouncerProvider` from `@abstrack/ui/a11y-web` for the practitioner web app.
+ *
+ * @param props - React children.
+ * @returns Provider wrapping children.
+ */
+export function LiveAnnouncerRoot({ children }: { children: ReactNode }) {
+  return <LiveAnnouncerProvider>{children}</LiveAnnouncerProvider>;
+}

--- a/apps/practitioner/tsconfig.json
+++ b/apps/practitioner/tsconfig.json
@@ -50,6 +50,9 @@
   ],
   "references": [
     {
+      "path": "../../packages/ui"
+    },
+    {
       "path": "../../packages/supabase"
     }
   ]

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import Script from 'next/script';
 import { ThemeMenu } from '../components/theme/ThemeMenu';
 import { ThemeProvider } from '../components/theme/ThemeProvider';
 import { THEME_INIT_SCRIPT } from '../lib/theme-init-script';
+import { LiveAnnouncerRoot } from '../components/a11y/LiveAnnouncerRoot';
 import { AuthProvider } from '../lib/auth-provider';
 
 const fontSans = Plus_Jakarta_Sans({
@@ -34,7 +35,9 @@ export default function RootLayout({
               <ThemeMenu />
             </div>
           </div>
-          <AuthProvider>{children}</AuthProvider>
+          <AuthProvider>
+            <LiveAnnouncerRoot>{children}</LiveAnnouncerRoot>
+          </AuthProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/apps/web/src/components/a11y/LiveAnnouncerRoot.tsx
+++ b/apps/web/src/components/a11y/LiveAnnouncerRoot.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { LiveAnnouncerProvider } from '@abstrack/ui/a11y-web';
+import type { ReactNode } from 'react';
+
+/**
+ * Client boundary that mounts `LiveAnnouncerProvider` from `@abstrack/ui/a11y-web` for the user web app
+ * so `useAnnounce()` is available under the root layout.
+ *
+ * @param props - React children.
+ * @returns Provider wrapping children.
+ */
+export function LiveAnnouncerRoot({ children }: { children: ReactNode }) {
+  return <LiveAnnouncerProvider>{children}</LiveAnnouncerProvider>;
+}

--- a/apps/web/src/lib/auth-provider.spec.tsx
+++ b/apps/web/src/lib/auth-provider.spec.tsx
@@ -2,6 +2,7 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import { AuthProvider, useAuth } from './auth-provider';
 
 const getSessionMock = jest.fn();
+const signOutMock = jest.fn().mockResolvedValue({ error: null });
 const onAuthStateChangeMock = jest.fn();
 const unsubscribeMock = jest.fn();
 
@@ -16,6 +17,7 @@ jest.mock('./supabase/browser-client', () => ({
   createBrowserClient: () => ({
     auth: {
       getSession: (...args: unknown[]) => getSessionMock(...args),
+      signOut: (...args: unknown[]) => signOutMock(...args),
       onAuthStateChange: (handler: typeof authStateChangeHandler) => {
         authStateChangeHandler = handler;
         return onAuthStateChangeMock(handler);
@@ -125,5 +127,28 @@ describe('AuthProvider', () => {
     unmount();
 
     expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears invalid refresh tokens via signOut and still finishes loading', async () => {
+    getSessionMock.mockResolvedValue({
+      data: { session: null },
+      error: {
+        code: 'refresh_token_not_found',
+        message: 'Invalid Refresh Token: Refresh Token Not Found',
+      },
+    });
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(readAuthState().loading).toBe(false);
+    });
+
+    expect(signOutMock).toHaveBeenCalledTimes(1);
+    expect(readAuthState().userId).toBeNull();
   });
 });

--- a/apps/web/src/lib/auth-provider.tsx
+++ b/apps/web/src/lib/auth-provider.tsx
@@ -41,9 +41,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     // Get initial session and always clear loading, even on failure.
     const initializeSession = async () => {
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
       try {
-        const timeout = new Promise<never>((_, reject) => {
-          setTimeout(() => {
+        const timeoutPromise = new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => {
             reject(new Error('session_bootstrap_timeout'));
           }, SESSION_BOOTSTRAP_TIMEOUT_MS);
         });
@@ -51,21 +52,22 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         const {
           data: { session: nextSession },
           error,
-        } = await Promise.race([supabase.auth.getSession(), timeout]).catch(
-          async (raceError: unknown) => {
-            if (
-              raceError instanceof Error &&
-              raceError.message === 'session_bootstrap_timeout'
-            ) {
-              console.warn(
-                'Auth session bootstrap timed out; clearing local session',
-              );
-              await supabase.auth.signOut();
-              return { data: { session: null }, error: null };
-            }
-            throw raceError;
-          },
-        );
+        } = await Promise.race([
+          supabase.auth.getSession(),
+          timeoutPromise,
+        ]).catch(async (raceError: unknown) => {
+          if (
+            raceError instanceof Error &&
+            raceError.message === 'session_bootstrap_timeout'
+          ) {
+            console.warn(
+              'Auth session bootstrap timed out; clearing local session',
+            );
+            await supabase.auth.signOut();
+            return { data: { session: null }, error: null };
+          }
+          throw raceError;
+        });
 
         if (error) {
           console.error('Failed to load auth session', error);
@@ -87,6 +89,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           await supabase.auth.signOut();
         }
       } finally {
+        if (timeoutId !== undefined) {
+          clearTimeout(timeoutId);
+        }
         if (mounted) {
           setLoading(false);
         }

--- a/apps/web/src/lib/auth-provider.tsx
+++ b/apps/web/src/lib/auth-provider.tsx
@@ -10,6 +10,27 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | null>(null);
 
+/** Avoid infinite loading if `getSession` never settles (e.g. bad refresh cookie edge cases). */
+const SESSION_BOOTSTRAP_TIMEOUT_MS = 8_000;
+
+function isRefreshTokenFailure(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+  const e = error as { code?: string; message?: string };
+  if (e.code === 'refresh_token_not_found') {
+    return true;
+  }
+  if (
+    typeof e.message === 'string' &&
+    /refresh token/i.test(e.message) &&
+    /invalid|not found|revoked|expired/i.test(e.message)
+  ) {
+    return true;
+  }
+  return false;
+}
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [session, setSession] = useState<AuthContextType['session']>(null);
   const [loading, setLoading] = useState(true);
@@ -21,13 +42,36 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     // Get initial session and always clear loading, even on failure.
     const initializeSession = async () => {
       try {
+        const timeout = new Promise<never>((_, reject) => {
+          setTimeout(() => {
+            reject(new Error('session_bootstrap_timeout'));
+          }, SESSION_BOOTSTRAP_TIMEOUT_MS);
+        });
+
         const {
-          data: { session },
+          data: { session: nextSession },
           error,
-        } = await supabase.auth.getSession();
+        } = await Promise.race([supabase.auth.getSession(), timeout]).catch(
+          async (raceError: unknown) => {
+            if (
+              raceError instanceof Error &&
+              raceError.message === 'session_bootstrap_timeout'
+            ) {
+              console.warn(
+                'Auth session bootstrap timed out; clearing local session',
+              );
+              await supabase.auth.signOut();
+              return { data: { session: null }, error: null };
+            }
+            throw raceError;
+          },
+        );
 
         if (error) {
           console.error('Failed to load auth session', error);
+          if (isRefreshTokenFailure(error)) {
+            await supabase.auth.signOut();
+          }
           if (mounted) {
             setSession(null);
           }
@@ -35,10 +79,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
 
         if (mounted) {
-          setSession(session);
+          setSession(nextSession);
         }
       } catch (error) {
         console.error('Failed to load auth session', error);
+        if (isRefreshTokenFailure(error)) {
+          await supabase.auth.signOut();
+        }
       } finally {
         if (mounted) {
           setLoading(false);

--- a/docs/A11Y.md
+++ b/docs/A11Y.md
@@ -1,0 +1,40 @@
+# Accessibility & screen readers (ABStrack)
+
+This document is the **baseline** for assistive technology support across the user web app (`apps/web`), practitioner web app (`apps/practitioner`), and mobile app (`apps/mobile`). ABStrack is **accessibility-first** (see [`docs/PRD.md`](PRD.md)): many users log symptoms while impaired; feedback must work for **screen readers**, **keyboard**, and **large touch targets**, not only visually.
+
+## Platform summary
+
+| Surface                 | Transient announcements                                                | Persistent content / forms                                                                                                |
+| ----------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| User & practitioner web | `LiveAnnouncerProvider` + `useAnnounce()` from `@abstrack/ui/a11y-web` | Semantic HTML, labels, `aria-*`, focus management                                                                         |
+| Mobile (React Native)   | `announce()` from `@abstrack/ui/native`                                | `accessibilityLabel`, `accessibilityHint`, `accessibilityRole`, `accessibilityState`, `accessibilityLiveRegion` (Android) |
+
+## Web: live regions
+
+1. **Mount once** near the document root: both Next.js apps wrap the tree with `LiveAnnouncerRoot` (see `apps/web/src/components/a11y/LiveAnnouncerRoot.tsx` and `apps/practitioner/src/components/a11y/LiveAnnouncerRoot.tsx`), which renders `LiveAnnouncerProvider` from **`@abstrack/ui/a11y-web`** (a DOM-only entry so practitioner apps do not bundle the full React Native UI barrel).
+2. In **client components**, call `const { announce } = useAnnounce()` (also from `@abstrack/ui/a11y-web`) and use:
+   - **`polite` (default):** confirmations, “Saved”, non-urgent status — maps to `role="status"` / `aria-live="polite"`.
+   - **`assertive`:** urgent errors, session loss — maps to `role="alert"` / `aria-live="assertive"`. **Use sparingly** so users are not interrupted constantly.
+
+Empty or whitespace-only messages are ignored.
+
+## Mobile: announcements
+
+Import **`announce`** from `@abstrack/ui/native` for short, transient feedback (e.g. after save). React Native routes this through `AccessibilityInfo.announceForAccessibility`. The `politeness` option is accepted for API parity with web; platform queueing differs by OS.
+
+For content that **stays on screen**, prefer explicit roles and labels on `View` / `Text` rather than only `announce`. Use **`accessibilityLiveRegion`** on Android for regions whose text updates; pair with **`announce`** on iOS when the change might not be noticed without a spoken cue.
+
+## Forms, dialogs, navigation
+
+- **Forms:** Every control needs an accessible name (visible label, `aria-label`, or `aria-labelledby`). Errors must be perceivable: associate `aria-describedby` / `aria-invalid` on web; on native use `accessibilityState` and clear error text.
+- **Dialogs:** Focus should move into the dialog when it opens and return to the trigger (or a sensible element) when it closes. The shared `Dialog` in `@abstrack/ui` uses React Native `Modal`; verify web behavior as features land.
+- **Charts (PRD):** Do not rely on color or shape alone. Provide a **textual summary**, table, or screen-reader-friendly description for chart data—especially for practitioner and patient dashboards.
+
+## Automated checks
+
+- Playwright **axe** suites (`@a11y` tags) run against key pages; extend coverage as flows grow.
+- New UI should keep **eslint** (including `eslint-plugin-jsx-a11y` where enabled) clean and add **unit tests** for critical announcement or labeling behavior when practical.
+
+## Manual smoke tests
+
+For new flows, briefly verify with **VoiceOver** (iOS), **TalkBack** (Android), and desktop **NVDA**, **JAWS**, or **VoiceOver** (macOS) on representative screens.

--- a/docs/A11Y.md
+++ b/docs/A11Y.md
@@ -4,10 +4,11 @@ This document is the **baseline** for assistive technology support across the us
 
 ## Platform summary
 
-| Surface                 | Transient announcements                                                | Persistent content / forms                                                                                                |
-| ----------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| User & practitioner web | `LiveAnnouncerProvider` + `useAnnounce()` from `@abstrack/ui/a11y-web` | Semantic HTML, labels, `aria-*`, focus management                                                                         |
-| Mobile (React Native)   | `announce()` from `@abstrack/ui/native`                                | `accessibilityLabel`, `accessibilityHint`, `accessibilityRole`, `accessibilityState`, `accessibilityLiveRegion` (Android) |
+<!-- prettier-ignore -->
+| Surface | Transient announcements | Persistent content / forms |
+| --- | --- | --- |
+| User & practitioner web | `LiveAnnouncerProvider` + `useAnnounce()` from `@abstrack/ui/a11y-web` | Semantic HTML, labels, `aria-*`, focus management |
+| Mobile (React Native) | `announce()` from `@abstrack/ui/native` | `accessibilityLabel`, `accessibilityHint`, `accessibilityRole`, `accessibilityState`, `accessibilityLiveRegion` (Android) |
 
 ## Web: live regions
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,6 +42,14 @@ export default [
       '**/*.mjs',
     ],
     // Override or add rules here
-    rules: {},
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+        },
+      ],
+    },
   },
 ];

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,6 +14,12 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./a11y-web": {
+      "@abstrack/source": "./src/a11y-web.ts",
+      "types": "./dist/a11y-web.d.ts",
+      "import": "./dist/a11y-web.js",
+      "default": "./dist/a11y-web.js"
+    },
     "./native": {
       "@abstrack/source": "./src/native.ts",
       "types": "./dist/native.d.ts",

--- a/packages/ui/src/a11y-web.ts
+++ b/packages/ui/src/a11y-web.ts
@@ -1,0 +1,7 @@
+/**
+ * Web-only entry: live announcer and types without pulling React Native from the main `@abstrack/ui` barrel.
+ * Use this from Next.js apps (especially `apps/practitioner`) for `LiveAnnouncerProvider` / `useAnnounce`.
+ */
+
+export * from './lib/a11y/types.js';
+export * from './lib/a11y/LiveAnnouncer.js';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,3 +1,5 @@
+export * from './lib/a11y/types.js';
+export * from './lib/a11y/LiveAnnouncer.js';
 export * from './lib/constants.js';
 export * from './lib/Button.js';
 export * from './lib/Input.js';

--- a/packages/ui/src/lib/a11y/LiveAnnouncer.spec.tsx
+++ b/packages/ui/src/lib/a11y/LiveAnnouncer.spec.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { LiveAnnouncerProvider, useAnnounce } from './LiveAnnouncer.js';
+
+describe('LiveAnnouncerProvider', () => {
+  it('renders polite and assertive live regions', () => {
+    render(
+      <LiveAnnouncerProvider>
+        <span>App</span>
+      </LiveAnnouncerProvider>,
+    );
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('updates polite region text when announce runs', () => {
+    function Demo() {
+      const { announce } = useAnnounce();
+      return (
+        <button type="button" onClick={() => announce('Saved profile')}>
+          Save
+        </button>
+      );
+    }
+
+    render(
+      <LiveAnnouncerProvider>
+        <Demo />
+      </LiveAnnouncerProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(screen.getByRole('status')).toHaveTextContent('Saved profile');
+  });
+
+  it('routes assertive announcements to the alert region', () => {
+    function Demo() {
+      const { announce } = useAnnounce();
+      return (
+        <button
+          type="button"
+          onClick={() =>
+            announce('Session expired', { politeness: 'assertive' })
+          }
+        >
+          Warn
+        </button>
+      );
+    }
+
+    render(
+      <LiveAnnouncerProvider>
+        <Demo />
+      </LiveAnnouncerProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Warn' }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Session expired');
+  });
+
+  it('ignores empty or whitespace-only messages', () => {
+    function Demo() {
+      const { announce } = useAnnounce();
+      return (
+        <button type="button" onClick={() => announce('   ')}>
+          Go
+        </button>
+      );
+    }
+
+    render(
+      <LiveAnnouncerProvider>
+        <Demo />
+      </LiveAnnouncerProvider>,
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent('');
+  });
+});
+
+describe('useAnnounce', () => {
+  it('throws outside LiveAnnouncerProvider', () => {
+    function Bad() {
+      useAnnounce();
+      return null;
+    }
+
+    expect(() => render(<Bad />)).toThrow(/LiveAnnouncerProvider/);
+  });
+});

--- a/packages/ui/src/lib/a11y/LiveAnnouncer.spec.tsx
+++ b/packages/ui/src/lib/a11y/LiveAnnouncer.spec.tsx
@@ -64,9 +64,14 @@ describe('LiveAnnouncerProvider', () => {
     function Demo() {
       const { announce } = useAnnounce();
       return (
-        <button type="button" onClick={() => announce('   ')}>
-          Go
-        </button>
+        <>
+          <button type="button" onClick={() => announce('Prior message')}>
+            Set prior
+          </button>
+          <button type="button" onClick={() => announce('   ')}>
+            Whitespace only
+          </button>
+        </>
       );
     }
 
@@ -76,7 +81,13 @@ describe('LiveAnnouncerProvider', () => {
       </LiveAnnouncerProvider>,
     );
 
-    expect(screen.getByRole('status')).toHaveTextContent('');
+    fireEvent.click(screen.getByRole('button', { name: 'Set prior' }));
+    expect(screen.getByRole('status')).toHaveTextContent('Prior message');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Whitespace only' }));
+
+    expect(screen.getByRole('status')).toHaveTextContent('Prior message');
+    expect(screen.getByRole('alert')).toHaveTextContent('');
   });
 });
 

--- a/packages/ui/src/lib/a11y/LiveAnnouncer.tsx
+++ b/packages/ui/src/lib/a11y/LiveAnnouncer.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+import type { AnnounceOptions, AnnouncePoliteness } from './types.js';
+
+const VISUALLY_HIDDEN: CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+};
+
+type LiveMessage = {
+  text: string;
+  seq: number;
+};
+
+export type AnnounceContextValue = {
+  /**
+   * Queues text for screen readers via ARIA live regions (polite or assertive).
+   *
+   * @param message - Plain-language message; empty strings are ignored.
+   * @param options - Optional `politeness` (default `polite`).
+   */
+  announce: (message: string, options?: AnnounceOptions) => void;
+};
+
+const AnnounceContext = createContext<AnnounceContextValue | null>(null);
+
+/**
+ * Provides two visually hidden live regions (`status` + `alert`) for screen reader
+ * announcements in browser environments (Next.js user/practitioner web apps).
+ * Mount once near the document root; use {@link useAnnounce} in client components.
+ *
+ * @param props - React children to wrap.
+ * @returns Provider with polite and assertive live regions appended after children.
+ */
+export function LiveAnnouncerProvider({ children }: { children: ReactNode }) {
+  const [polite, setPolite] = useState<LiveMessage>({ text: '', seq: 0 });
+  const [assertive, setAssertive] = useState<LiveMessage>({ text: '', seq: 0 });
+
+  const announce = useCallback((message: string, options?: AnnounceOptions) => {
+    const trimmed = message.trim();
+    if (!trimmed) {
+      return;
+    }
+    const politeness: AnnouncePoliteness = options?.politeness ?? 'polite';
+    if (politeness === 'assertive') {
+      setAssertive((prev) => ({ text: trimmed, seq: prev.seq + 1 }));
+    } else {
+      setPolite((prev) => ({ text: trimmed, seq: prev.seq + 1 }));
+    }
+  }, []);
+
+  const value = useMemo(() => ({ announce }), [announce]);
+
+  return (
+    <AnnounceContext.Provider value={value}>
+      {children}
+      <div
+        key={`polite-${polite.seq}`}
+        aria-live="polite"
+        aria-relevant="additions text"
+        aria-atomic="true"
+        role="status"
+        style={VISUALLY_HIDDEN}
+      >
+        {polite.text}
+      </div>
+      <div
+        key={`assertive-${assertive.seq}`}
+        aria-live="assertive"
+        aria-atomic="true"
+        role="alert"
+        style={VISUALLY_HIDDEN}
+      >
+        {assertive.text}
+      </div>
+    </AnnounceContext.Provider>
+  );
+}
+
+/**
+ * Returns the announce function from the nearest {@link LiveAnnouncerProvider}.
+ *
+ * @returns Context value with `announce`.
+ * @throws Error if used outside {@link LiveAnnouncerProvider}.
+ */
+export function useAnnounce(): AnnounceContextValue {
+  const ctx = useContext(AnnounceContext);
+  if (!ctx) {
+    throw new Error(
+      'useAnnounce must be used within a LiveAnnouncerProvider. Wrap the app root (see docs/A11Y.md).',
+    );
+  }
+  return ctx;
+}

--- a/packages/ui/src/lib/a11y/announceNative.spec.ts
+++ b/packages/ui/src/lib/a11y/announceNative.spec.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { announce } from './announceNative.js';
+
+const mockAnnounce = vi.fn();
+
+vi.mock('react-native', () => ({
+  AccessibilityInfo: {
+    announceForAccessibility: (msg: string) => mockAnnounce(msg),
+  },
+}));
+
+describe('announce (native)', () => {
+  beforeEach(() => {
+    mockAnnounce.mockClear();
+  });
+
+  it('calls AccessibilityInfo.announceForAccessibility with trimmed text', () => {
+    announce('  Profile saved  ');
+    expect(mockAnnounce).toHaveBeenCalledWith('Profile saved');
+  });
+
+  it('does not announce whitespace-only messages', () => {
+    announce('   ');
+    expect(mockAnnounce).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/lib/a11y/announceNative.spec.ts
+++ b/packages/ui/src/lib/a11y/announceNative.spec.ts
@@ -1,13 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { announce } from './announceNative.js';
 
-const mockAnnounce = vi.fn();
+const { mockAnnounce } = vi.hoisted(() => ({
+  mockAnnounce: vi.fn(),
+}));
 
 vi.mock('react-native', () => ({
   AccessibilityInfo: {
-    announceForAccessibility: (msg: string) => mockAnnounce(msg),
+    announceForAccessibility: mockAnnounce,
   },
 }));
+
+import { announce } from './announceNative.js';
 
 describe('announce (native)', () => {
   beforeEach(() => {

--- a/packages/ui/src/lib/a11y/announceNative.ts
+++ b/packages/ui/src/lib/a11y/announceNative.ts
@@ -1,0 +1,24 @@
+import { AccessibilityInfo } from 'react-native';
+import type { AnnounceOptions } from './types.js';
+
+/**
+ * Announces a short message to assistive technologies (VoiceOver, TalkBack).
+ * Prefer this for transient feedback (save confirmation, validation).
+ * For text that stays on screen, use `accessibilityLabel` / `accessibilityLiveRegion`
+ * on the relevant `View` where appropriate.
+ *
+ * `politeness` is accepted for API parity with web {@link useAnnounce}; React Native
+ * does not expose the same queue semantics on all platforms—both values use
+ * `AccessibilityInfo.announceForAccessibility`.
+ *
+ * @param message - Message to announce; whitespace-only strings are ignored.
+ * @param options - Optional settings (e.g. `politeness` for parity with web).
+ */
+export function announce(message: string, options?: AnnounceOptions): void {
+  void options;
+  const trimmed = message.trim();
+  if (!trimmed) {
+    return;
+  }
+  void AccessibilityInfo.announceForAccessibility(trimmed);
+}

--- a/packages/ui/src/lib/a11y/announceNative.ts
+++ b/packages/ui/src/lib/a11y/announceNative.ts
@@ -12,10 +12,9 @@ import type { AnnounceOptions } from './types.js';
  * `AccessibilityInfo.announceForAccessibility`.
  *
  * @param message - Message to announce; whitespace-only strings are ignored.
- * @param options - Optional settings (e.g. `politeness` for parity with web).
+ * @param _options - Optional settings (e.g. `politeness` for parity with web); not used on RN yet.
  */
-export function announce(message: string, options?: AnnounceOptions): void {
-  void options;
+export function announce(message: string, _options?: AnnounceOptions): void {
   const trimmed = message.trim();
   if (!trimmed) {
     return;

--- a/packages/ui/src/lib/a11y/types.ts
+++ b/packages/ui/src/lib/a11y/types.ts
@@ -1,0 +1,14 @@
+/**
+ * Priority for assistive-technology announcements.
+ *
+ * - `polite`: interrupt after current speech (default for saves, confirmations).
+ * - `assertive`: interrupt immediately (errors, urgent session issues)—use sparingly.
+ */
+export type AnnouncePoliteness = 'polite' | 'assertive';
+
+/**
+ * Options for {@link announce} (native) and {@link useAnnounce} (web).
+ */
+export type AnnounceOptions = {
+  politeness?: AnnouncePoliteness;
+};

--- a/packages/ui/src/native.ts
+++ b/packages/ui/src/native.ts
@@ -2,6 +2,8 @@
  * React Native–safe entry: shared layout shell and design tokens without DOM-only hooks.
  */
 
+export * from './lib/a11y/types.js';
+export * from './lib/a11y/announceNative.js';
 export * from './lib/constants.js';
 export * from './lib/NavigationShell.js';
 export {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,6 +337,9 @@ importers:
       '@abstrack/supabase':
         specifier: workspace:*
         version: link:../../packages/supabase
+      '@abstrack/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       next:
         specifier: ~16.0.1
         version: 16.0.11(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.97.3)


### PR DESCRIPTION
Closes #57

## Summary

Adds an early accessibility baseline for screen readers across web and mobile, documents conventions for agents and contributors, and hardens the user web app’s auth bootstrap when session refresh fails.

## Changes

### Accessibility

- **`docs/A11Y.md`** — When to use polite vs assertive announcements, web vs React Native patterns, forms/dialogs/charts notes, and testing expectations.
- **`AGENTS.md`** — New section instructing coding agents to treat screen reader support as a default requirement, with pointers to `docs/A11Y.md`.
- **`@abstrack/ui`**
  - `LiveAnnouncerProvider` / `useAnnounce()` — ARIA live regions (`status` + `alert`) for transient feedback in browsers.
  - **`@abstrack/ui/a11y-web`** — DOM-only entry so Next.js apps (especially practitioner) don’t pull the full React Native UI barrel into Turbopack.
  - `announce()` on **`@abstrack/ui/native`** — `AccessibilityInfo.announceForAccessibility` for short spoken feedback on mobile.
  - Unit tests for the live announcer and native `announce`.
- **Apps** — `LiveAnnouncerRoot` wired in **`apps/web`** and **`apps/practitioner`** root layouts; `LiveAnnouncerRoot` wraps **route `children` only**, inside `AuthProvider` on web.

### Auth (user web)

- **`AuthProvider`** — `getSession` bootstrap wrapped with a timeout; on invalid/missing refresh token (or timeout), **`signOut()`** clears stale client state so the home page doesn’t spin forever.
- **Tests** — Coverage for refresh-token failure path.

## How to test

- `pnpm exec nx test @abstrack/ui` and `pnpm exec nx test web` (auth-provider tests).
- `pnpm exec nx run-many -t build -p web,practitioner`.
- Manual: `pnpm web` — confirm `/` and `/login` render; optional check with VoiceOver/NVDA that a client component using `useAnnounce()` speaks updates.