### PR TITLE
feat(web): add symptom preset CRUD, reorder, and response-type configuration via shared preset data layer

### DIFF
--- a/apps/practitioner/next-env.d.ts
+++ b/apps/practitioner/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web-e2e/src/example.spec.ts
+++ b/apps/web-e2e/src/example.spec.ts
@@ -3,6 +3,6 @@ import { test, expect } from '@playwright/test';
 test('has title', async ({ page }) => {
   await page.goto('/');
 
-  // Expect h1 to contain a substring.
-  expect(await page.locator('h1').innerText()).toContain('Welcome');
+  // Signed-out home: h1 is "ABStrack". Signed-in: "Welcome to ABStrack". Both include the product name.
+  await expect(page.locator('h1')).toContainText('ABStrack');
 });

--- a/apps/web/src/app/(app)/presets/symptoms/[id]/page.tsx
+++ b/apps/web/src/app/(app)/presets/symptoms/[id]/page.tsx
@@ -1,0 +1,16 @@
+import { SymptomPresetEditorPage } from '@/components/symptom-presets/SymptomPresetEditorPage';
+
+type PageProps = {
+  params: Promise<{ id: string }>;
+};
+
+/**
+ * Edit one symptom preset: lines, response types, reorder.
+ *
+ * @param props - Next.js route params.
+ * @returns Editor route content.
+ */
+export default async function SymptomPresetDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  return <SymptomPresetEditorPage presetId={id} />;
+}

--- a/apps/web/src/app/(app)/presets/symptoms/[id]/page.tsx
+++ b/apps/web/src/app/(app)/presets/symptoms/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { SymptomPresetEditorPage } from '@/components/symptom-presets/SymptomPresetEditorPage';
 
 type PageProps = {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 };
 
 /**
@@ -10,7 +10,6 @@ type PageProps = {
  * @param props - Next.js route params.
  * @returns Editor route content.
  */
-export default async function SymptomPresetDetailPage({ params }: PageProps) {
-  const { id } = await params;
-  return <SymptomPresetEditorPage presetId={id} />;
+export default function SymptomPresetDetailPage({ params }: PageProps) {
+  return <SymptomPresetEditorPage presetId={params.id} />;
 }

--- a/apps/web/src/app/(app)/presets/symptoms/new/page.tsx
+++ b/apps/web/src/app/(app)/presets/symptoms/new/page.tsx
@@ -1,0 +1,10 @@
+import { SymptomPresetCreateForm } from '@/components/symptom-presets/SymptomPresetCreateForm';
+
+/**
+ * Create a new symptom preset (header only), then continue to the editor.
+ *
+ * @returns Create route content.
+ */
+export default function NewSymptomPresetPage() {
+  return <SymptomPresetCreateForm />;
+}

--- a/apps/web/src/app/(app)/presets/symptoms/page.tsx
+++ b/apps/web/src/app/(app)/presets/symptoms/page.tsx
@@ -1,15 +1,10 @@
-import { PageEmpty } from '@/components/page-states/PageEmpty';
+import { SymptomPresetsListPage } from '@/components/symptom-presets/SymptomPresetsListPage';
 
 /**
- * Symptom presets landing route. CRUD and Supabase wiring are out of scope for this shell.
+ * Symptom presets list: create, open editor, delete.
  *
- * @returns Placeholder empty state.
+ * @returns List route content.
  */
 export default function SymptomPresetsPage() {
-  return (
-    <PageEmpty
-      title="Symptom presets"
-      description="You have not created any symptom presets yet. When this feature is connected, you will define named lists of symptoms and response types for episode logging."
-    />
-  );
+  return <SymptomPresetsListPage />;
 }

--- a/apps/web/src/components/symptom-presets/ConfirmDialog.tsx
+++ b/apps/web/src/components/symptom-presets/ConfirmDialog.tsx
@@ -1,6 +1,26 @@
 'use client';
 
-import { useEffect, useId, useRef } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
+
+/**
+ * `HTMLDialogElement.close()` / `showModal()` throw `InvalidStateError` if the dialog
+ * is already closed / already open (HTML standard).
+ */
+function setDialogModalOpen(el: HTMLDialogElement, open: boolean): void {
+  if (open) {
+    if (!el.open) {
+      el.showModal();
+    }
+  } else if (el.open) {
+    el.close();
+  }
+}
+
+function closeDialogIfOpen(el: HTMLDialogElement | null): void {
+  if (el?.open) {
+    el.close();
+  }
+}
 
 export type ConfirmDialogProps = {
   /** When true, the native dialog is shown modally. */
@@ -13,18 +33,26 @@ export type ConfirmDialogProps = {
   confirmLabel: string;
   /** Label for dismiss (default: Cancel). */
   cancelLabel?: string;
+  /** Shown on the confirm button while {@link onConfirm} is in flight (default: “Please wait…”). */
+  confirmBusyLabel?: string;
   /**
    * Called when the user confirms. If this returns `false`, the dialog stays open
    * (e.g. the action failed and the user should retry or cancel).
    */
   onConfirm: () => void | false | Promise<void | false>;
-  /** Called when the dialog closes without confirming (cancel, Escape, backdrop). */
+  /**
+   * Called whenever the native `<dialog>` fires `close` — after a successful confirm
+   * (once `onConfirm` resolves), Cancel, Escape, backdrop click, or when the parent
+   * closes it by setting `open` to false. Use this to keep controlled `open` state in sync;
+   * do not assume the user dismissed without confirming.
+   */
   onClose: () => void;
 };
 
 /**
  * Accessible confirmation modal using the native `<dialog>` element with focus management
- * provided by the user agent.
+ * provided by the user agent. {@link ConfirmDialogProps.onClose} runs on every close, not
+ * only on dismiss.
  *
  * @param props - Dialog copy and handlers.
  * @returns A modal dialog element.
@@ -35,22 +63,28 @@ export function ConfirmDialog({
   description,
   confirmLabel,
   cancelLabel = 'Cancel',
+  confirmBusyLabel = 'Please wait…',
   onConfirm,
   onClose,
 }: ConfirmDialogProps) {
   const ref = useRef<HTMLDialogElement>(null);
+  const confirmInFlightRef = useRef(false);
   const titleId = useId();
+  const [confirming, setConfirming] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      confirmInFlightRef.current = false;
+      setConfirming(false);
+    }
+  }, [open]);
 
   useEffect(() => {
     const el = ref.current;
     if (!el) {
       return;
     }
-    if (open) {
-      el.showModal();
-    } else {
-      el.close();
-    }
+    setDialogModalOpen(el, open);
   }, [open]);
 
   useEffect(() => {
@@ -72,9 +106,13 @@ export function ConfirmDialog({
       ref={ref}
       className="max-w-md rounded-2xl border border-app-border/90 bg-app-surface p-6 text-app-ink shadow-xl backdrop:bg-black/40"
       aria-labelledby={titleId}
+      aria-busy={confirming}
       onCancel={(event) => {
         event.preventDefault();
-        ref.current?.close();
+        if (confirming) {
+          return;
+        }
+        closeDialogIfOpen(ref.current);
       }}
     >
       <div className="space-y-4">
@@ -87,27 +125,39 @@ export function ConfirmDialog({
         <div className="flex flex-wrap justify-end gap-3">
           <button
             type="button"
-            className="min-h-[44px] rounded-full border border-app-border bg-app-surface px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+            disabled={confirming}
+            className="min-h-[44px] rounded-full border border-app-border bg-app-surface px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-50"
             onClick={() => {
-              ref.current?.close();
+              closeDialogIfOpen(ref.current);
             }}
           >
             {cancelLabel}
           </button>
           <button
             type="button"
-            className="min-h-[44px] rounded-full bg-red-600 px-4 text-sm font-semibold text-white shadow-sm transition hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:bg-red-700 dark:hover:bg-red-600"
+            disabled={confirming}
+            className="min-h-[44px] rounded-full bg-red-600 px-4 text-sm font-semibold text-white shadow-sm transition hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-70 dark:bg-red-700 dark:hover:bg-red-600"
             onClick={() => {
               void (async () => {
-                const result = await Promise.resolve(onConfirm());
-                if (result === false) {
+                if (confirmInFlightRef.current) {
                   return;
                 }
-                ref.current?.close();
+                confirmInFlightRef.current = true;
+                setConfirming(true);
+                try {
+                  const result = await Promise.resolve(onConfirm());
+                  if (result === false) {
+                    return;
+                  }
+                  closeDialogIfOpen(ref.current);
+                } finally {
+                  confirmInFlightRef.current = false;
+                  setConfirming(false);
+                }
               })();
             }}
           >
-            {confirmLabel}
+            {confirming ? confirmBusyLabel : confirmLabel}
           </button>
         </div>
       </div>

--- a/apps/web/src/components/symptom-presets/ConfirmDialog.tsx
+++ b/apps/web/src/components/symptom-presets/ConfirmDialog.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useEffect, useId, useRef } from 'react';
+
+export type ConfirmDialogProps = {
+  /** When true, the native dialog is shown modally. */
+  open: boolean;
+  /** Dialog title (visible and referenced by `aria-labelledby`). */
+  title: string;
+  /** Optional supporting text below the title. */
+  description?: string;
+  /** Label for the destructive or primary confirm control. */
+  confirmLabel: string;
+  /** Label for dismiss (default: Cancel). */
+  cancelLabel?: string;
+  /**
+   * Called when the user confirms. If this returns `false`, the dialog stays open
+   * (e.g. the action failed and the user should retry or cancel).
+   */
+  onConfirm: () => void | false | Promise<void | false>;
+  /** Called when the dialog closes without confirming (cancel, Escape, backdrop). */
+  onClose: () => void;
+};
+
+/**
+ * Accessible confirmation modal using the native `<dialog>` element with focus management
+ * provided by the user agent.
+ *
+ * @param props - Dialog copy and handlers.
+ * @returns A modal dialog element.
+ */
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel = 'Cancel',
+  onConfirm,
+  onClose,
+}: ConfirmDialogProps) {
+  const ref = useRef<HTMLDialogElement>(null);
+  const titleId = useId();
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+    if (open) {
+      el.showModal();
+    } else {
+      el.close();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+    const handleClose = () => {
+      onClose();
+    };
+    el.addEventListener('close', handleClose);
+    return () => {
+      el.removeEventListener('close', handleClose);
+    };
+  }, [onClose]);
+
+  return (
+    <dialog
+      ref={ref}
+      className="max-w-md rounded-2xl border border-app-border/90 bg-app-surface p-6 text-app-ink shadow-xl backdrop:bg-black/40"
+      aria-labelledby={titleId}
+      onCancel={(event) => {
+        event.preventDefault();
+        ref.current?.close();
+      }}
+    >
+      <div className="space-y-4">
+        <h2 id={titleId} className="text-lg font-semibold">
+          {title}
+        </h2>
+        {description ? (
+          <p className="text-sm text-app-muted">{description}</p>
+        ) : null}
+        <div className="flex flex-wrap justify-end gap-3">
+          <button
+            type="button"
+            className="min-h-[44px] rounded-full border border-app-border bg-app-surface px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+            onClick={() => {
+              ref.current?.close();
+            }}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            className="min-h-[44px] rounded-full bg-red-600 px-4 text-sm font-semibold text-white shadow-sm transition hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:bg-red-700 dark:hover:bg-red-600"
+            onClick={() => {
+              void (async () => {
+                const result = await Promise.resolve(onConfirm());
+                if (result === false) {
+                  return;
+                }
+                ref.current?.close();
+              })();
+            }}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/apps/web/src/components/symptom-presets/SymptomPresetCreateForm.tsx
+++ b/apps/web/src/components/symptom-presets/SymptomPresetCreateForm.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { createSymptomPreset } from '@abstrack/supabase';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import { createBrowserClient } from '@/lib/supabase/browser-client';
+import { useAuth } from '@/lib/auth-provider';
+
+/**
+ * Form to create an empty symptom preset header, then navigate to the editor for lines.
+ *
+ * @returns Create preset page content.
+ */
+export function SymptomPresetCreateForm() {
+  const router = useRouter();
+  const { session, loading: authLoading } = useAuth();
+  const { announce } = useAnnounce();
+  const [name, setName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!session?.user.id) {
+      setError('You must be signed in to create a preset.');
+      return;
+    }
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError('Enter a name for this preset.');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    const supabase = createBrowserClient();
+    const result = await createSymptomPreset(supabase, {
+      user_id: session.user.id,
+      name: trimmed,
+    });
+    setSaving(false);
+    if (!result.ok) {
+      setError(result.error.message);
+      announce(result.error.message, { politeness: 'assertive' });
+      return;
+    }
+    announce('Preset created. Add symptoms below.', { politeness: 'polite' });
+    router.push(`/presets/symptoms/${result.data.id}`);
+  };
+
+  if (authLoading) {
+    return (
+      <div className="w-full space-y-4">
+        <p className="text-sm text-app-muted">Loading…</p>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div role="alert" className="text-sm text-red-700 dark:text-red-300">
+        You must be signed in to create a preset.
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full space-y-8">
+      <div>
+        <Link
+          href="/presets/symptoms"
+          className="text-sm font-medium text-app-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+        >
+          ← Back to symptom presets
+        </Link>
+        <h1 className="mt-4 text-2xl font-bold tracking-tight text-app-ink">
+          New symptom preset
+        </h1>
+        <p className="mt-1 text-sm text-app-muted">
+          Choose a name, then add symptoms and response types on the next
+          screen.
+        </p>
+      </div>
+
+      <form
+        onSubmit={(e) => {
+          void onSubmit(e);
+        }}
+        className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
+        noValidate
+      >
+        <div className="space-y-2">
+          <label
+            htmlFor="preset-name"
+            className="text-sm font-medium text-app-ink"
+          >
+            Preset name
+          </label>
+          <input
+            id="preset-name"
+            name="presetName"
+            type="text"
+            autoComplete="off"
+            required
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value);
+            }}
+            className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-bg px-3 text-app-ink shadow-inner outline-none transition placeholder:text-app-muted focus-visible:ring-2 focus-visible:ring-app-ring"
+            placeholder="e.g. Typical ABS episode"
+          />
+        </div>
+
+        {error ? (
+          <div
+            role="alert"
+            className="mt-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-800/60 dark:bg-red-950/35 dark:text-red-200"
+          >
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-8 flex flex-wrap gap-3">
+          <button
+            type="submit"
+            disabled={saving}
+            className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-app-primary px-5 text-sm font-semibold text-white shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60"
+          >
+            {saving ? 'Creating…' : 'Create and edit symptoms'}
+          </button>
+          <Link
+            href="/presets/symptoms"
+            className="inline-flex min-h-[44px] items-center justify-center rounded-full border border-app-border bg-app-bg px-5 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          >
+            Cancel
+          </Link>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/components/symptom-presets/SymptomPresetEditorPage.tsx
+++ b/apps/web/src/components/symptom-presets/SymptomPresetEditorPage.tsx
@@ -63,6 +63,8 @@ export function SymptomPresetEditorPage({
   const [newResponseType, setNewResponseType] =
     useState<SymptomResponseType>('yes_no');
   const [adding, setAdding] = useState(false);
+  /** True while `refreshQuiet` refetches preset lines (avoids reorder/edit against stale `lines`). */
+  const [linesSyncing, setLinesSyncing] = useState(false);
 
   const [pendingAction, setPendingAction] = useState(false);
   const [deletePresetOpen, setDeletePresetOpen] = useState(false);
@@ -102,7 +104,12 @@ export function SymptomPresetEditorPage({
   );
 
   const refreshQuiet = useCallback(async () => {
-    await refreshAll('quiet');
+    setLinesSyncing(true);
+    try {
+      await refreshAll('quiet');
+    } finally {
+      setLinesSyncing(false);
+    }
   }, [refreshAll]);
 
   useEffect(() => {
@@ -146,23 +153,26 @@ export function SymptomPresetEditorPage({
       return;
     }
     setAdding(true);
-    const supabase = createBrowserClient();
-    const sortOrder = computeNextSortOrder(lines);
-    const result = await createPresetSymptom(supabase, {
-      preset_id: presetId,
-      sort_order: sortOrder,
-      symptom_name: trimmed,
-      response_type: newResponseType,
-    });
-    setAdding(false);
-    if (!result.ok) {
-      announce(result.error.message, { politeness: 'assertive' });
-      return;
+    try {
+      const supabase = createBrowserClient();
+      const sortOrder = computeNextSortOrder(lines);
+      const result = await createPresetSymptom(supabase, {
+        preset_id: presetId,
+        sort_order: sortOrder,
+        symptom_name: trimmed,
+        response_type: newResponseType,
+      });
+      if (!result.ok) {
+        announce(result.error.message, { politeness: 'assertive' });
+        return;
+      }
+      setNewSymptomName('');
+      setNewResponseType('yes_no');
+      await refreshQuiet();
+      announce('Symptom added to preset.', { politeness: 'polite' });
+    } finally {
+      setAdding(false);
     }
-    setNewSymptomName('');
-    setNewResponseType('yes_no');
-    await refreshQuiet();
-    announce('Symptom added to preset.', { politeness: 'polite' });
   };
 
   const handleResponseTypeChange = async (
@@ -349,6 +359,8 @@ export function SymptomPresetEditorPage({
   }
 
   const datalistId = 'abs-symptom-suggestions';
+  const lineControlsLocked = pendingAction || adding || linesSyncing;
+  const addFormLocked = adding || linesSyncing;
 
   return (
     <div className="w-full space-y-8">
@@ -435,12 +447,13 @@ export function SymptomPresetEditorPage({
                 list={datalistId}
                 type="text"
                 value={newSymptomName}
+                disabled={addFormLocked}
                 onChange={(e) => {
                   setNewSymptomName(e.target.value);
                 }}
                 autoComplete="off"
                 placeholder="e.g. Vertigo or custom text"
-                className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-bg px-3 text-app-ink shadow-inner outline-none transition placeholder:text-app-muted focus-visible:ring-2 focus-visible:ring-app-ring"
+                className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-bg px-3 text-app-ink shadow-inner outline-none transition placeholder:text-app-muted focus-visible:ring-2 focus-visible:ring-app-ring disabled:opacity-60"
               />
             </div>
             <div className="space-y-2">
@@ -453,10 +466,11 @@ export function SymptomPresetEditorPage({
               <select
                 id="new-symptom-response"
                 value={newResponseType}
+                disabled={addFormLocked}
                 onChange={(e) => {
                   setNewResponseType(e.target.value as SymptomResponseType);
                 }}
-                className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-bg px-3 text-app-ink shadow-inner outline-none focus-visible:ring-2 focus-visible:ring-app-ring"
+                className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-bg px-3 text-app-ink shadow-inner outline-none focus-visible:ring-2 focus-visible:ring-app-ring disabled:opacity-60"
               >
                 {SYMPTOM_RESPONSE_TYPES.map((t) => (
                   <option key={t} value={t}>
@@ -468,10 +482,10 @@ export function SymptomPresetEditorPage({
           </div>
           <button
             type="submit"
-            disabled={adding || pendingAction}
+            disabled={addFormLocked || pendingAction}
             className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-app-primary px-5 text-sm font-semibold text-white shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60"
           >
-            {adding ? 'Adding…' : 'Add to preset'}
+            {adding ? 'Adding…' : linesSyncing ? 'Updating…' : 'Add to preset'}
           </button>
         </form>
       </section>
@@ -489,6 +503,12 @@ export function SymptomPresetEditorPage({
           order.
         </p>
 
+        {linesSyncing ? (
+          <p className="mt-4 text-sm text-app-muted" aria-live="polite">
+            Updating symptom list…
+          </p>
+        ) : null}
+
         {lines.length === 0 ? (
           <p className="mt-4 rounded-xl border border-dashed border-app-border/90 bg-app-bg/50 p-6 text-sm text-app-muted">
             No symptoms yet. Add at least one using the form above.
@@ -501,7 +521,7 @@ export function SymptomPresetEditorPage({
                 line={line}
                 index={index}
                 total={lines.length}
-                disabled={pendingAction}
+                disabled={lineControlsLocked}
                 onMove={(dir) => {
                   void handleMove(index, dir);
                 }}

--- a/apps/web/src/components/symptom-presets/SymptomPresetEditorPage.tsx
+++ b/apps/web/src/components/symptom-presets/SymptomPresetEditorPage.tsx
@@ -1,0 +1,704 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+import type {
+  PresetSymptomRow,
+  SymptomPresetRow,
+  SymptomResponseType,
+} from '@abstrack/types';
+import { SYMPTOM_RESPONSE_TYPES } from '@abstrack/types';
+import {
+  createPresetSymptom,
+  deletePresetSymptom,
+  deleteSymptomPreset,
+  getSymptomPresetById,
+  listPresetSymptomsForPreset,
+  reorderPresetSymptoms,
+  updatePresetSymptom,
+  updateSymptomPreset,
+} from '@abstrack/supabase';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import { createBrowserClient } from '@/lib/supabase/browser-client';
+import { useAuth } from '@/lib/auth-provider';
+import { ALL_ABS_SYMPTOM_SUGGESTIONS } from '@/lib/symptom-presets/abs-symptom-suggestions';
+import { getSymptomResponseTypeLabel } from '@/lib/symptom-presets/response-type-labels';
+import { ConfirmDialog } from './ConfirmDialog';
+
+export type SymptomPresetEditorPageProps = {
+  /** `symptom_presets.id` from the route. */
+  presetId: string;
+};
+
+function computeNextSortOrder(lines: PresetSymptomRow[]): number {
+  if (lines.length === 0) {
+    return 0;
+  }
+  return Math.max(...lines.map((l) => l.sort_order)) + 1;
+}
+
+/**
+ * Full editor for one symptom preset: rename header, add/reorder/edit/delete lines, response types.
+ *
+ * @param props - Route param wiring.
+ * @returns Editor UI.
+ */
+export function SymptomPresetEditorPage({
+  presetId,
+}: SymptomPresetEditorPageProps) {
+  const router = useRouter();
+  const { session, loading: authLoading } = useAuth();
+  const { announce } = useAnnounce();
+
+  const [preset, setPreset] = useState<SymptomPresetRow | null>(null);
+  const [lines, setLines] = useState<PresetSymptomRow[]>([]);
+  const [nameDraft, setNameDraft] = useState('');
+  const [pageStatus, setPageStatus] = useState<
+    'loading' | 'ready' | 'not_found' | 'error'
+  >('loading');
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [newSymptomName, setNewSymptomName] = useState('');
+  const [newResponseType, setNewResponseType] =
+    useState<SymptomResponseType>('yes_no');
+  const [adding, setAdding] = useState(false);
+
+  const [pendingAction, setPendingAction] = useState(false);
+  const [deletePresetOpen, setDeletePresetOpen] = useState(false);
+
+  const refreshAll = useCallback(
+    async (mode: 'full' | 'quiet' = 'full') => {
+      if (mode === 'full') {
+        setPageStatus('loading');
+      }
+      const supabase = createBrowserClient();
+      const [presetResult, linesResult] = await Promise.all([
+        getSymptomPresetById(supabase, presetId),
+        listPresetSymptomsForPreset(supabase, presetId),
+      ]);
+
+      if (!presetResult.ok) {
+        setPageStatus('error');
+        setLoadError(presetResult.error.message);
+        return;
+      }
+      if (!presetResult.data) {
+        setPageStatus('not_found');
+        return;
+      }
+      if (!linesResult.ok) {
+        setPageStatus('error');
+        setLoadError(linesResult.error.message);
+        return;
+      }
+
+      setPreset(presetResult.data);
+      setNameDraft(presetResult.data.name);
+      setLines(linesResult.data);
+      setPageStatus('ready');
+    },
+    [presetId],
+  );
+
+  const refreshQuiet = useCallback(async () => {
+    await refreshAll('quiet');
+  }, [refreshAll]);
+
+  useEffect(() => {
+    if (authLoading || !session) {
+      return;
+    }
+    void refreshAll();
+  }, [authLoading, session, refreshAll]);
+
+  const handleNameBlur = async () => {
+    if (!preset) {
+      return;
+    }
+    const trimmed = nameDraft.trim();
+    if (!trimmed || trimmed === preset.name) {
+      setNameDraft(preset.name);
+      return;
+    }
+    setPendingAction(true);
+    const supabase = createBrowserClient();
+    const result = await updateSymptomPreset(supabase, preset.id, {
+      name: trimmed,
+    });
+    setPendingAction(false);
+    if (!result.ok) {
+      announce(result.error.message, { politeness: 'assertive' });
+      setNameDraft(preset.name);
+      return;
+    }
+    setPreset(result.data);
+    announce('Preset name saved.', { politeness: 'polite' });
+  };
+
+  const handleAddSymptom = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = newSymptomName.trim();
+    if (!trimmed) {
+      announce('Enter a symptom name or pick a suggestion.', {
+        politeness: 'assertive',
+      });
+      return;
+    }
+    setAdding(true);
+    const supabase = createBrowserClient();
+    const sortOrder = computeNextSortOrder(lines);
+    const result = await createPresetSymptom(supabase, {
+      preset_id: presetId,
+      sort_order: sortOrder,
+      symptom_name: trimmed,
+      response_type: newResponseType,
+    });
+    setAdding(false);
+    if (!result.ok) {
+      announce(result.error.message, { politeness: 'assertive' });
+      return;
+    }
+    setNewSymptomName('');
+    setNewResponseType('yes_no');
+    await refreshQuiet();
+    announce('Symptom added to preset.', { politeness: 'polite' });
+  };
+
+  const handleResponseTypeChange = async (
+    line: PresetSymptomRow,
+    next: SymptomResponseType,
+  ) => {
+    if (line.response_type === next) {
+      return;
+    }
+    setPendingAction(true);
+    const supabase = createBrowserClient();
+    const result = await updatePresetSymptom(supabase, line.id, {
+      response_type: next,
+    });
+    setPendingAction(false);
+    if (!result.ok) {
+      announce(result.error.message, { politeness: 'assertive' });
+      await refreshQuiet();
+      return;
+    }
+    setLines((prev) => prev.map((l) => (l.id === line.id ? result.data : l)));
+    announce('Response type updated.', { politeness: 'polite' });
+  };
+
+  const handleSymptomNameBlur = async (
+    line: PresetSymptomRow,
+    draft: string,
+  ) => {
+    const trimmed = draft.trim();
+    if (!trimmed || trimmed === line.symptom_name) {
+      return;
+    }
+    setPendingAction(true);
+    const supabase = createBrowserClient();
+    const result = await updatePresetSymptom(supabase, line.id, {
+      symptom_name: trimmed,
+    });
+    setPendingAction(false);
+    if (!result.ok) {
+      announce(result.error.message, { politeness: 'assertive' });
+      await refreshQuiet();
+      return;
+    }
+    setLines((prev) => prev.map((l) => (l.id === line.id ? result.data : l)));
+    announce('Symptom name saved.', { politeness: 'polite' });
+  };
+
+  const handlePromptBlur = async (
+    line: PresetSymptomRow,
+    draft: string | null,
+  ) => {
+    const nextVal = draft?.trim() || null;
+    const prevVal = line.prompt_instruction?.trim() || null;
+    if (nextVal === prevVal) {
+      return;
+    }
+    setPendingAction(true);
+    const supabase = createBrowserClient();
+    const result = await updatePresetSymptom(supabase, line.id, {
+      prompt_instruction: nextVal,
+    });
+    setPendingAction(false);
+    if (!result.ok) {
+      announce(result.error.message, { politeness: 'assertive' });
+      await refreshQuiet();
+      return;
+    }
+    setLines((prev) => prev.map((l) => (l.id === line.id ? result.data : l)));
+    announce('Instruction saved.', { politeness: 'polite' });
+  };
+
+  const handleMove = async (index: number, direction: -1 | 1) => {
+    const nextIndex = index + direction;
+    if (nextIndex < 0 || nextIndex >= lines.length) {
+      return;
+    }
+    const orderedIds = lines.map((l) => l.id);
+    const [moved] = orderedIds.splice(index, 1);
+    orderedIds.splice(nextIndex, 0, moved);
+    setPendingAction(true);
+    const supabase = createBrowserClient();
+    const result = await reorderPresetSymptoms(supabase, presetId, orderedIds);
+    setPendingAction(false);
+    if (!result.ok) {
+      announce(result.error.message, { politeness: 'assertive' });
+      await refreshQuiet();
+      return;
+    }
+    await refreshQuiet();
+    announce('Symptom order updated.', { politeness: 'polite' });
+  };
+
+  const handleDeleteLine = async (line: PresetSymptomRow) => {
+    setPendingAction(true);
+    const supabase = createBrowserClient();
+    const result = await deletePresetSymptom(supabase, line.id);
+    setPendingAction(false);
+    if (!result.ok) {
+      announce(result.error.message, { politeness: 'assertive' });
+      return;
+    }
+    await refreshQuiet();
+    announce('Symptom removed from preset.', { politeness: 'polite' });
+  };
+
+  const handleDeletePreset = async (): Promise<void | false> => {
+    setPendingAction(true);
+    const supabase = createBrowserClient();
+    const result = await deleteSymptomPreset(supabase, presetId);
+    setPendingAction(false);
+    if (!result.ok) {
+      announce(result.error.message, { politeness: 'assertive' });
+      return false;
+    }
+    announce('Symptom preset deleted.', { politeness: 'polite' });
+    router.push('/presets/symptoms');
+  };
+
+  if (authLoading) {
+    return (
+      <div className="w-full space-y-4">
+        <p className="text-sm text-app-muted">Loading…</p>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div role="alert" className="text-sm text-red-700 dark:text-red-300">
+        You must be signed in to edit presets.
+      </div>
+    );
+  }
+
+  if (pageStatus === 'loading') {
+    return (
+      <div className="w-full space-y-4">
+        <p className="text-sm text-app-muted">Loading preset…</p>
+      </div>
+    );
+  }
+
+  if (pageStatus === 'not_found') {
+    return (
+      <div className="w-full space-y-4">
+        <h1 className="text-2xl font-bold text-app-ink">Preset not found</h1>
+        <p className="text-sm text-app-muted">
+          This preset may have been deleted or you may not have access.
+        </p>
+        <Link
+          href="/presets/symptoms"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-app-primary px-5 text-sm font-semibold text-white shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+        >
+          Back to symptom presets
+        </Link>
+      </div>
+    );
+  }
+
+  if (pageStatus === 'error' && loadError) {
+    return (
+      <div className="w-full space-y-4">
+        <div
+          role="alert"
+          className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-800/60 dark:bg-red-950/35 dark:text-red-200"
+        >
+          {loadError}
+        </div>
+        <button
+          type="button"
+          className="min-h-[44px] rounded-full border border-app-border bg-app-surface px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          onClick={() => {
+            void refreshAll();
+          }}
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  if (!preset) {
+    return null;
+  }
+
+  const datalistId = 'abs-symptom-suggestions';
+
+  return (
+    <div className="w-full space-y-8">
+      <div>
+        <Link
+          href="/presets/symptoms"
+          className="text-sm font-medium text-app-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+        >
+          ← Back to symptom presets
+        </Link>
+        <div className="mt-4 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0 flex-1 space-y-2">
+            <label htmlFor="edit-preset-name" className="sr-only">
+              Preset name
+            </label>
+            <input
+              id="edit-preset-name"
+              type="text"
+              value={nameDraft}
+              disabled={pendingAction}
+              onChange={(e) => {
+                setNameDraft(e.target.value);
+              }}
+              onBlur={() => {
+                void handleNameBlur();
+              }}
+              className="w-full border-b-2 border-transparent bg-transparent text-2xl font-bold tracking-tight text-app-ink outline-none transition focus-visible:border-app-primary focus-visible:ring-0 disabled:opacity-60"
+            />
+            <p className="text-sm text-app-muted">
+              Name your preset, then add symptoms in the order you want them
+              during an episode.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="inline-flex min-h-[44px] shrink-0 items-center justify-center rounded-full border border-red-200 bg-red-50 px-4 text-sm font-semibold text-red-800 shadow-sm transition hover:bg-red-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-200 dark:hover:bg-red-950/60"
+            disabled={pendingAction}
+            onClick={() => {
+              setDeletePresetOpen(true);
+            }}
+          >
+            Delete preset
+          </button>
+        </div>
+      </div>
+
+      <section
+        className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
+        aria-labelledby="add-symptom-heading"
+      >
+        <h2
+          id="add-symptom-heading"
+          className="text-lg font-semibold text-app-ink"
+        >
+          Add a symptom
+        </h2>
+        <p className="mt-1 text-sm text-app-muted">
+          Pick a common ABS symptom from suggestions or type your own. Choose
+          how each symptom should be captured when you log an episode (yes/no,
+          severity scale, free text, photo, or video). Per-symptom notes during
+          an episode are not part of this screen yet.
+        </p>
+        <datalist id={datalistId}>
+          {ALL_ABS_SYMPTOM_SUGGESTIONS.map((s) => (
+            <option key={s} value={s} />
+          ))}
+        </datalist>
+        <form
+          className="mt-6 space-y-4"
+          onSubmit={(e) => {
+            void handleAddSymptom(e);
+          }}
+        >
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <label
+                htmlFor="new-symptom-name"
+                className="text-sm font-medium text-app-ink"
+              >
+                Symptom name
+              </label>
+              <input
+                id="new-symptom-name"
+                list={datalistId}
+                type="text"
+                value={newSymptomName}
+                onChange={(e) => {
+                  setNewSymptomName(e.target.value);
+                }}
+                autoComplete="off"
+                placeholder="e.g. Vertigo or custom text"
+                className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-bg px-3 text-app-ink shadow-inner outline-none transition placeholder:text-app-muted focus-visible:ring-2 focus-visible:ring-app-ring"
+              />
+            </div>
+            <div className="space-y-2">
+              <label
+                htmlFor="new-symptom-response"
+                className="text-sm font-medium text-app-ink"
+              >
+                Response type
+              </label>
+              <select
+                id="new-symptom-response"
+                value={newResponseType}
+                onChange={(e) => {
+                  setNewResponseType(e.target.value as SymptomResponseType);
+                }}
+                className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-bg px-3 text-app-ink shadow-inner outline-none focus-visible:ring-2 focus-visible:ring-app-ring"
+              >
+                {SYMPTOM_RESPONSE_TYPES.map((t) => (
+                  <option key={t} value={t}>
+                    {getSymptomResponseTypeLabel(t)}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <button
+            type="submit"
+            disabled={adding || pendingAction}
+            className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-app-primary px-5 text-sm font-semibold text-white shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60"
+          >
+            {adding ? 'Adding…' : 'Add to preset'}
+          </button>
+        </form>
+      </section>
+
+      <section aria-labelledby="symptom-order-heading">
+        <h2
+          id="symptom-order-heading"
+          className="text-lg font-semibold text-app-ink"
+        >
+          Symptoms in order
+        </h2>
+        <p className="mt-1 text-sm text-app-muted">
+          Photo and video lines can include a short capture instruction (shown
+          in the episode flow). The app will prompt for each symptom in this
+          order.
+        </p>
+
+        {lines.length === 0 ? (
+          <p className="mt-4 rounded-xl border border-dashed border-app-border/90 bg-app-bg/50 p-6 text-sm text-app-muted">
+            No symptoms yet. Add at least one using the form above.
+          </p>
+        ) : (
+          <ol className="mt-6 space-y-4">
+            {lines.map((line, index) => (
+              <SymptomLineEditor
+                key={line.id}
+                line={line}
+                index={index}
+                total={lines.length}
+                disabled={pendingAction}
+                onMove={(dir) => {
+                  void handleMove(index, dir);
+                }}
+                onDelete={() => {
+                  void handleDeleteLine(line);
+                }}
+                onResponseTypeChange={(next) => {
+                  void handleResponseTypeChange(line, next);
+                }}
+                onNameBlur={(draft) => {
+                  void handleSymptomNameBlur(line, draft);
+                }}
+                onPromptBlur={(draft) => {
+                  void handlePromptBlur(line, draft);
+                }}
+              />
+            ))}
+          </ol>
+        )}
+      </section>
+
+      <ConfirmDialog
+        open={deletePresetOpen}
+        title="Delete this symptom preset?"
+        description={`“${preset.name}” and all of its symptoms will be removed. This cannot be undone.`}
+        confirmLabel="Delete preset"
+        cancelLabel="Keep editing"
+        onConfirm={() => handleDeletePreset()}
+        onClose={() => {
+          setDeletePresetOpen(false);
+        }}
+      />
+    </div>
+  );
+}
+
+type SymptomLineEditorProps = {
+  line: PresetSymptomRow;
+  index: number;
+  total: number;
+  disabled: boolean;
+  onMove: (direction: -1 | 1) => void;
+  onDelete: () => void;
+  onResponseTypeChange: (next: SymptomResponseType) => void;
+  onNameBlur: (draft: string) => void;
+  onPromptBlur: (draft: string | null) => void;
+};
+
+/**
+ * Single reorderable symptom row with inline name, response type, and optional
+ * photo/video capture instruction when relevant.
+ *
+ * @param props - Line data and callbacks.
+ * @returns List item with controls.
+ */
+function SymptomLineEditor({
+  line,
+  index,
+  total,
+  disabled,
+  onMove,
+  onDelete,
+  onResponseTypeChange,
+  onNameBlur,
+  onPromptBlur,
+}: SymptomLineEditorProps) {
+  const [nameDraft, setNameDraft] = useState(line.symptom_name);
+  const [promptDraft, setPromptDraft] = useState(line.prompt_instruction ?? '');
+
+  useEffect(() => {
+    setNameDraft(line.symptom_name);
+  }, [line.symptom_name]);
+
+  useEffect(() => {
+    setPromptDraft(line.prompt_instruction ?? '');
+  }, [line.prompt_instruction]);
+
+  const pos = index + 1;
+  const showMediaPrompt =
+    line.response_type === 'photo' || line.response_type === 'video';
+  const mediaHintId = `symptom-media-hint-${line.id}`;
+
+  return (
+    <li className="rounded-2xl border border-app-border/90 bg-app-bg/60 p-4 shadow-sm ring-1 ring-[color:var(--app-ring-slate)]">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+        <div
+          className="flex flex-1 flex-col gap-4"
+          aria-label={`Symptom ${pos} of ${total}`}
+        >
+          <div className="space-y-2">
+            <label
+              htmlFor={`symptom-name-${line.id}`}
+              className="text-sm font-medium text-app-ink"
+            >
+              Symptom {pos} — name
+            </label>
+            <input
+              id={`symptom-name-${line.id}`}
+              type="text"
+              value={nameDraft}
+              disabled={disabled}
+              onChange={(e) => {
+                setNameDraft(e.target.value);
+              }}
+              onBlur={() => {
+                onNameBlur(nameDraft);
+              }}
+              className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-surface px-3 text-app-ink shadow-inner outline-none transition focus-visible:ring-2 focus-visible:ring-app-ring disabled:opacity-60"
+            />
+          </div>
+          <div className="space-y-2">
+            <label
+              htmlFor={`symptom-response-${line.id}`}
+              className="text-sm font-medium text-app-ink"
+            >
+              Response type
+            </label>
+            <select
+              id={`symptom-response-${line.id}`}
+              value={line.response_type}
+              disabled={disabled}
+              onChange={(e) => {
+                onResponseTypeChange(e.target.value as SymptomResponseType);
+              }}
+              className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-surface px-3 text-app-ink shadow-inner outline-none focus-visible:ring-2 focus-visible:ring-app-ring disabled:opacity-60"
+            >
+              {SYMPTOM_RESPONSE_TYPES.map((t) => (
+                <option key={t} value={t}>
+                  {getSymptomResponseTypeLabel(t)}
+                </option>
+              ))}
+            </select>
+          </div>
+          {showMediaPrompt ? (
+            <div className="space-y-2">
+              <label
+                htmlFor={`symptom-prompt-${line.id}`}
+                className="text-sm font-medium text-app-ink"
+              >
+                Instruction during photo or video capture (optional)
+              </label>
+              <p id={mediaHintId} className="text-xs text-app-muted">
+                Shown when the episode flow asks for this photo or video.
+              </p>
+              <textarea
+                id={`symptom-prompt-${line.id}`}
+                aria-describedby={mediaHintId}
+                rows={2}
+                value={promptDraft}
+                disabled={disabled}
+                onChange={(e) => {
+                  setPromptDraft(e.target.value);
+                }}
+                onBlur={() => {
+                  onPromptBlur(promptDraft);
+                }}
+                placeholder='e.g. "Say: The early bird catches the worm"'
+                className="w-full rounded-lg border border-app-border bg-app-surface px-3 py-2 text-sm text-app-ink shadow-inner outline-none transition focus-visible:ring-2 focus-visible:ring-app-ring disabled:opacity-60"
+              />
+            </div>
+          ) : null}
+        </div>
+        <div className="flex flex-col gap-2 lg:w-44">
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={disabled || index === 0}
+              className="inline-flex min-h-[44px] flex-1 items-center justify-center rounded-full border border-app-border bg-app-surface px-3 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-40"
+              onClick={() => {
+                onMove(-1);
+              }}
+            >
+              Move up
+            </button>
+            <button
+              type="button"
+              disabled={disabled || index >= total - 1}
+              className="inline-flex min-h-[44px] flex-1 items-center justify-center rounded-full border border-app-border bg-app-surface px-3 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-40"
+              onClick={() => {
+                onMove(1);
+              }}
+            >
+              Move down
+            </button>
+          </div>
+          <button
+            type="button"
+            disabled={disabled}
+            className="inline-flex min-h-[44px] items-center justify-center rounded-full border border-red-200 bg-red-50 px-3 text-sm font-semibold text-red-800 shadow-sm transition hover:bg-red-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-200 dark:hover:bg-red-950/60"
+            onClick={() => {
+              onDelete();
+            }}
+          >
+            Remove symptom
+          </button>
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/apps/web/src/components/symptom-presets/SymptomPresetEditorPage.tsx
+++ b/apps/web/src/components/symptom-presets/SymptomPresetEditorPage.tsx
@@ -63,18 +63,33 @@ export function SymptomPresetEditorPage({
   const [newResponseType, setNewResponseType] =
     useState<SymptomResponseType>('yes_no');
   const [adding, setAdding] = useState(false);
-  /** True while `refreshQuiet` refetches preset lines (avoids reorder/edit against stale `lines`). */
+  /** True while `refreshQuiet` refetches lines only (does not reset the preset name draft). */
   const [linesSyncing, setLinesSyncing] = useState(false);
 
   const [pendingAction, setPendingAction] = useState(false);
   const [deletePresetOpen, setDeletePresetOpen] = useState(false);
+  const [deleteLineTarget, setDeleteLineTarget] =
+    useState<PresetSymptomRow | null>(null);
 
   const refreshAll = useCallback(
     async (mode: 'full' | 'quiet' = 'full') => {
-      if (mode === 'full') {
-        setPageStatus('loading');
-      }
       const supabase = createBrowserClient();
+
+      if (mode === 'quiet') {
+        const linesResult = await listPresetSymptomsForPreset(
+          supabase,
+          presetId,
+        );
+        if (!linesResult.ok) {
+          setPageStatus('error');
+          setLoadError(linesResult.error.message);
+          return;
+        }
+        setLines(linesResult.data);
+        return;
+      }
+
+      setPageStatus('loading');
       const [presetResult, linesResult] = await Promise.all([
         getSymptomPresetById(supabase, presetId),
         listPresetSymptomsForPreset(supabase, presetId),
@@ -265,17 +280,22 @@ export function SymptomPresetEditorPage({
     announce('Symptom order updated.', { politeness: 'polite' });
   };
 
-  const handleDeleteLine = async (line: PresetSymptomRow) => {
+  const handleDeleteLine = async (
+    line: PresetSymptomRow,
+  ): Promise<void | false> => {
     setPendingAction(true);
-    const supabase = createBrowserClient();
-    const result = await deletePresetSymptom(supabase, line.id);
-    setPendingAction(false);
-    if (!result.ok) {
-      announce(result.error.message, { politeness: 'assertive' });
-      return;
+    try {
+      const supabase = createBrowserClient();
+      const result = await deletePresetSymptom(supabase, line.id);
+      if (!result.ok) {
+        announce(result.error.message, { politeness: 'assertive' });
+        return false;
+      }
+      await refreshQuiet();
+      announce('Symptom removed from preset.', { politeness: 'polite' });
+    } finally {
+      setPendingAction(false);
     }
-    await refreshQuiet();
-    announce('Symptom removed from preset.', { politeness: 'polite' });
   };
 
   const handleDeletePreset = async (): Promise<void | false> => {
@@ -359,8 +379,10 @@ export function SymptomPresetEditorPage({
   }
 
   const datalistId = 'abs-symptom-suggestions';
-  const lineControlsLocked = pendingAction || adding || linesSyncing;
-  const addFormLocked = adding || linesSyncing;
+  const deleteDialogOpen = deletePresetOpen || deleteLineTarget !== null;
+  const lineControlsLocked =
+    pendingAction || adding || linesSyncing || deleteDialogOpen;
+  const addFormLocked = adding || linesSyncing || deleteDialogOpen;
 
   return (
     <div className="w-full space-y-8">
@@ -380,7 +402,7 @@ export function SymptomPresetEditorPage({
               id="edit-preset-name"
               type="text"
               value={nameDraft}
-              disabled={pendingAction}
+              disabled={pendingAction || deleteDialogOpen}
               onChange={(e) => {
                 setNameDraft(e.target.value);
               }}
@@ -397,7 +419,7 @@ export function SymptomPresetEditorPage({
           <button
             type="button"
             className="inline-flex min-h-[44px] shrink-0 items-center justify-center rounded-full border border-red-200 bg-red-50 px-4 text-sm font-semibold text-red-800 shadow-sm transition hover:bg-red-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-200 dark:hover:bg-red-950/60"
-            disabled={pendingAction}
+            disabled={pendingAction || deleteLineTarget !== null}
             onClick={() => {
               setDeletePresetOpen(true);
             }}
@@ -525,8 +547,8 @@ export function SymptomPresetEditorPage({
                 onMove={(dir) => {
                   void handleMove(index, dir);
                 }}
-                onDelete={() => {
-                  void handleDeleteLine(line);
+                onRequestRemove={() => {
+                  setDeleteLineTarget(line);
                 }}
                 onResponseTypeChange={(next) => {
                   void handleResponseTypeChange(line, next);
@@ -554,6 +576,28 @@ export function SymptomPresetEditorPage({
           setDeletePresetOpen(false);
         }}
       />
+
+      <ConfirmDialog
+        open={deleteLineTarget !== null}
+        title="Remove this symptom?"
+        description={
+          deleteLineTarget
+            ? `“${deleteLineTarget.symptom_name}” will be removed from this preset. This cannot be undone.`
+            : undefined
+        }
+        confirmLabel="Remove symptom"
+        cancelLabel="Keep symptom"
+        confirmBusyLabel="Removing…"
+        onConfirm={async () => {
+          if (!deleteLineTarget) {
+            return false;
+          }
+          return handleDeleteLine(deleteLineTarget);
+        }}
+        onClose={() => {
+          setDeleteLineTarget(null);
+        }}
+      />
     </div>
   );
 }
@@ -564,7 +608,8 @@ type SymptomLineEditorProps = {
   total: number;
   disabled: boolean;
   onMove: (direction: -1 | 1) => void;
-  onDelete: () => void;
+  /** User chose to remove this line; parent opens a confirmation dialog. */
+  onRequestRemove: () => void;
   onResponseTypeChange: (next: SymptomResponseType) => void;
   onNameBlur: (draft: string) => void;
   onPromptBlur: (draft: string | null) => void;
@@ -583,7 +628,7 @@ function SymptomLineEditor({
   total,
   disabled,
   onMove,
-  onDelete,
+  onRequestRemove,
   onResponseTypeChange,
   onNameBlur,
   onPromptBlur,
@@ -712,7 +757,7 @@ function SymptomLineEditor({
             disabled={disabled}
             className="inline-flex min-h-[44px] items-center justify-center rounded-full border border-red-200 bg-red-50 px-3 text-sm font-semibold text-red-800 shadow-sm transition hover:bg-red-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-200 dark:hover:bg-red-950/60"
             onClick={() => {
-              onDelete();
+              onRequestRemove();
             }}
           >
             Remove symptom

--- a/apps/web/src/components/symptom-presets/SymptomPresetsListPage.tsx
+++ b/apps/web/src/components/symptom-presets/SymptomPresetsListPage.tsx
@@ -10,7 +10,9 @@ import { useAuth } from '@/lib/auth-provider';
 import { ConfirmDialog } from './ConfirmDialog';
 
 /**
- * Authenticated list of symptom presets with navigation to create and edit routes, and delete.
+ * List of symptom presets with navigation to create and edit routes, and delete.
+ * When there is no session after auth finishes loading, shows sign-in instead of an
+ * endless loading state (e.g. after client-side sign-out).
  *
  * @returns Symptom presets management landing content.
  */
@@ -68,7 +70,37 @@ export function SymptomPresetsListPage() {
     }
   };
 
-  if (authLoading || (loadState === 'loading' && presets.length === 0)) {
+  if (authLoading) {
+    return (
+      <div className="w-full space-y-4">
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Symptom presets
+        </h1>
+        <p className="text-sm text-app-muted">Loading…</p>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="w-full space-y-4">
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Symptom presets
+        </h1>
+        <p className="text-sm text-app-muted" role="status">
+          You need to be signed in to view and manage symptom presets.
+        </p>
+        <Link
+          href="/login"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-app-primary px-5 text-sm font-semibold text-white shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+        >
+          Sign in
+        </Link>
+      </div>
+    );
+  }
+
+  if (loadState === 'loading' && presets.length === 0) {
     return (
       <div className="w-full space-y-4">
         <h1 className="text-2xl font-bold tracking-tight text-app-ink">

--- a/apps/web/src/components/symptom-presets/SymptomPresetsListPage.tsx
+++ b/apps/web/src/components/symptom-presets/SymptomPresetsListPage.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useState } from 'react';
+import type { SymptomPresetRow } from '@abstrack/types';
+import { deleteSymptomPreset, listSymptomPresets } from '@abstrack/supabase';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import { createBrowserClient } from '@/lib/supabase/browser-client';
+import { useAuth } from '@/lib/auth-provider';
+import { ConfirmDialog } from './ConfirmDialog';
+
+/**
+ * Authenticated list of symptom presets with navigation to create and edit routes, and delete.
+ *
+ * @returns Symptom presets management landing content.
+ */
+export function SymptomPresetsListPage() {
+  const { session, loading: authLoading } = useAuth();
+  const { announce } = useAnnounce();
+  const [presets, setPresets] = useState<SymptomPresetRow[]>([]);
+  const [loadState, setLoadState] = useState<'idle' | 'loading' | 'error'>(
+    'loading',
+  );
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const refresh = useCallback(async () => {
+    const supabase = createBrowserClient();
+    setLoadState('loading');
+    setLoadError(null);
+    const result = await listSymptomPresets(supabase);
+    if (!result.ok) {
+      setLoadState('error');
+      setLoadError(result.error.message);
+      return;
+    }
+    setPresets(result.data);
+    setLoadState('idle');
+  }, []);
+
+  useEffect(() => {
+    if (authLoading || !session) {
+      return;
+    }
+    void refresh();
+  }, [authLoading, session, refresh]);
+
+  const handleDeleteConfirm = async (): Promise<void | false> => {
+    if (!deleteTarget) {
+      return false;
+    }
+    setDeleting(true);
+    try {
+      const supabase = createBrowserClient();
+      const result = await deleteSymptomPreset(supabase, deleteTarget.id);
+      if (!result.ok) {
+        announce(result.error.message, { politeness: 'assertive' });
+        return false;
+      }
+      announce('Symptom preset deleted.', { politeness: 'polite' });
+      await refresh();
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  if (authLoading || (loadState === 'loading' && presets.length === 0)) {
+    return (
+      <div className="w-full space-y-4">
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Symptom presets
+        </h1>
+        <p className="text-sm text-app-muted">Loading presets…</p>
+      </div>
+    );
+  }
+
+  if (loadState === 'error' && loadError) {
+    return (
+      <div className="w-full space-y-4">
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Symptom presets
+        </h1>
+        <div
+          role="alert"
+          className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-800/60 dark:bg-red-950/35 dark:text-red-200"
+        >
+          {loadError}
+        </div>
+        <button
+          type="button"
+          className="min-h-[44px] rounded-full border border-app-border bg-app-surface px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          onClick={() => {
+            void refresh();
+          }}
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full space-y-8">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+            Symptom presets
+          </h1>
+          <p className="mt-1 text-sm text-app-muted">
+            Name each preset and define which symptoms to prompt during an
+            episode, in order, with how each one should be captured.
+          </p>
+        </div>
+        <Link
+          href="/presets/symptoms/new"
+          className="inline-flex min-h-[44px] shrink-0 items-center justify-center rounded-full bg-app-primary px-5 text-sm font-semibold text-white shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+        >
+          Create preset
+        </Link>
+      </div>
+
+      {presets.length === 0 ? (
+        <div className="rounded-2xl border border-app-border/90 bg-app-surface p-8 text-center shadow-soft ring-1 ring-[color:var(--app-ring-slate)]">
+          <p className="text-app-ink">
+            You have not created any symptom presets yet.
+          </p>
+          <p className="mt-2 text-sm text-app-muted">
+            Create a preset to choose symptom names, response types, and order
+            before you log an episode.
+          </p>
+          <Link
+            href="/presets/symptoms/new"
+            className="mt-6 inline-flex min-h-[44px] items-center justify-center rounded-full bg-app-primary px-5 text-sm font-semibold text-white shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          >
+            Create your first preset
+          </Link>
+        </div>
+      ) : (
+        <ul
+          className="divide-y divide-app-border/80 rounded-2xl border border-app-border/90 bg-app-surface shadow-soft ring-1 ring-[color:var(--app-ring-slate)]"
+          aria-label="Your symptom presets"
+        >
+          {presets.map((p) => (
+            <li
+              key={p.id}
+              className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div className="min-w-0">
+                <Link
+                  href={`/presets/symptoms/${p.id}`}
+                  className="block rounded-md text-base font-semibold text-app-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                >
+                  {p.name}
+                </Link>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Link
+                  href={`/presets/symptoms/${p.id}`}
+                  className="inline-flex min-h-[44px] items-center justify-center rounded-full border border-app-border bg-app-bg px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                >
+                  Edit
+                </Link>
+                <button
+                  type="button"
+                  className="inline-flex min-h-[44px] items-center justify-center rounded-full border border-red-200 bg-red-50 px-4 text-sm font-semibold text-red-800 shadow-sm transition hover:bg-red-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-200 dark:hover:bg-red-950/60"
+                  disabled={deleting}
+                  onClick={() => {
+                    setDeleteTarget({ id: p.id, name: p.name });
+                  }}
+                >
+                  Delete
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title="Delete this symptom preset?"
+        description={
+          deleteTarget
+            ? `“${deleteTarget.name}” will be removed. This cannot be undone.`
+            : undefined
+        }
+        confirmLabel="Delete preset"
+        cancelLabel="Keep preset"
+        onConfirm={() => handleDeleteConfirm()}
+        onClose={() => {
+          setDeleteTarget(null);
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/lib/symptom-presets/abs-symptom-suggestions.ts
+++ b/apps/web/src/lib/symptom-presets/abs-symptom-suggestions.ts
@@ -1,0 +1,31 @@
+/**
+ * PRD §2 “Common ABS Symptom Suggestions” and “Uncommon ABS Symptom Suggestions” — used to seed
+ * preset setup pick lists and datalist hints (web symptom preset management).
+ */
+
+/** Frequently suggested symptoms for ABS episode presets (PRD). */
+export const COMMON_ABS_SYMPTOM_SUGGESTIONS = [
+  'Nausea',
+  'Vomiting',
+  'Vertigo',
+  'Dizziness',
+  'Slurred speech',
+  'Brain fog / confusion',
+  'Fatigue',
+  'Headache',
+  'Mood changes',
+  'Anxiety',
+] as const;
+
+/** Less common suggestions still relevant to ABS presentations (PRD). */
+export const UNCOMMON_ABS_SYMPTOM_SUGGESTIONS = [
+  'Hemiparesis',
+  'Facial drooping',
+  'Feelings of impending doom',
+] as const;
+
+/** All built-in suggestion strings for datalist / quick-pick UIs. */
+export const ALL_ABS_SYMPTOM_SUGGESTIONS: readonly string[] = [
+  ...COMMON_ABS_SYMPTOM_SUGGESTIONS,
+  ...UNCOMMON_ABS_SYMPTOM_SUGGESTIONS,
+];

--- a/apps/web/src/lib/symptom-presets/response-type-labels.spec.ts
+++ b/apps/web/src/lib/symptom-presets/response-type-labels.spec.ts
@@ -1,0 +1,10 @@
+import { SYMPTOM_RESPONSE_TYPES } from '@abstrack/types';
+import { getSymptomResponseTypeLabel } from './response-type-labels';
+
+describe('getSymptomResponseTypeLabel', () => {
+  it('returns a non-empty label for every SymptomResponseType', () => {
+    for (const t of SYMPTOM_RESPONSE_TYPES) {
+      expect(getSymptomResponseTypeLabel(t).length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/web/src/lib/symptom-presets/response-type-labels.ts
+++ b/apps/web/src/lib/symptom-presets/response-type-labels.ts
@@ -1,0 +1,19 @@
+import type { SymptomResponseType } from '@abstrack/types';
+
+const LABELS: Record<SymptomResponseType, string> = {
+  yes_no: 'Yes / No',
+  severity_scale: 'Severity (1–5)',
+  free_text: 'Free text',
+  photo: 'Photo',
+  video: 'Video',
+};
+
+/**
+ * Short labels for each {@link SymptomResponseType} value in management UIs.
+ *
+ * @param type - Stored `preset_symptoms.response_type` value.
+ * @returns Human-readable label for selects and summaries.
+ */
+export function getSymptomResponseTypeLabel(type: SymptomResponseType): string {
+  return LABELS[type];
+}


### PR DESCRIPTION
Closes #47

## Summary

Adds full **web** management for **symptom presets**: list, create, edit, delete, symptom reorder (persisted via `reorder_preset_symptoms`), and per-line **response type** configuration (yes/no, severity 1–5, free text, photo, video). Uses only the **`@abstrack/supabase` preset helpers**—no direct table access in route/screen code.

## Details

- **Routes:** `/presets/symptoms`, `/presets/symptoms/new`, `/presets/symptoms/[id]`
- **UX:** PRD-aligned ABS symptom suggestions via datalist; custom names supported; photo/video **capture instruction** field only when response type is photo or video
- **A11y:** Labels, focusable controls (~44px targets), `useAnnounce` for save/delete feedback, native `<dialog>` for destructive confirms
- **Out of scope (unchanged):** mobile symptom presets, health marker presets, episode-time per-symptom notes (separate future work)

## How to test

1. Sign in → **Symptom presets** → create preset → add lines, change response types, reorder, refresh
2. Confirm delete (preset + line) and list updates
3. Quick keyboard/tab pass and optional screen reader smoke (see `docs/A11Y.md`)

## Checklist

- [ ] Lint / tests / build green for touched packages