### PR TITLE
docs: add episode template flows and standalone vitals (PRD, roadmap, user story)

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,9 +1,9 @@
 # ABStrack — Product Requirements Document
 
-**Version:** 1.1  
+**Version:** 1.2  
 **Author:** Sarah (NSCC SPRINT Scholar)  
 **Status:** Draft  
-**Last Updated:** March 2026
+**Last Updated:** April 2026
 
 ---
 
@@ -21,6 +21,7 @@
    - [Symptom Presets](#2-symptom-presets)
    - [Health Marker Presets](#3-health-marker-presets)
    - [Episode Logging](#4-episode-logging)
+   - [Episode & vitals flows (detailed user story)](user-stories/episode-and-health-marker-flows.md)
    - [General Wellness Logging](#5-general-wellness-logging)
    - [Food Diary](#6-food-diary)
    - [Caretaker Account](#7-caretaker-account)
@@ -417,6 +418,10 @@ Health marker presets allow the user to pre-configure the health measurements th
 - BACtrac Bluetooth API integration
 - Dexcom G7 CGM API integration
 
+#### Independence from episodes
+
+Health marker presets are **first-class** configuration: the user may maintain **multiple** named presets, reuse the same preset in different contexts, and use a preset **without** starting an episode (see [General Wellness Logging](#5-general-wellness-logging) and the [Episode & vitals flows](user-stories/episode-and-health-marker-flows.md) user story). During an episode, the app must still resolve **which** health marker preset applies when more than one exists—see **Episode Logging** below.
+
 ---
 
 ### 4. Episode Logging
@@ -429,13 +434,14 @@ An "episode" or "flare" is a discrete event where the user experiences ABS-relat
 
 - A prominent "I'm having an episode" button is available on the home screen.
 - The UI during an episode must be designed for impaired users: large text, large touch targets, minimal cognitive load, high contrast.
-- The user selects which symptom preset to use.
+- The user selects which **symptom preset** to use **and** which **health marker preset** to use for the post-symptom marker prompts. The product must **not** infer the health marker preset when the user has more than one—selection is explicit. **At episode start,** that explicit choice is **one episode template** (e.g. “ABS Episode”, “CVS Episode”) that references **both** presets; the user does **not** pick symptom and health marker presets separately during an episode. Pairing is configured in settings (when the user is well) by defining templates. Naming a symptom preset and a health marker preset the same display name does **not** link them; the **episode template** row does.
+- The episode record **must persist both** identifiers (`symptom_preset_id` and `health_marker_preset_id`) once the schema supports the latter—see implementation roadmap. This preserves auditability and correct history when reviewing past episodes.
 
 #### Episode Prompt Flow
 
 1. The app prompts through each symptom in the selected preset, one at a time.
 2. For video/photo symptoms, the camera is launched inline with instructions shown on screen.
-3. After all preset symptoms, the app prompts through health marker preset items.
+3. After all preset symptoms, the app prompts through the **selected** health marker preset’s items (same preset as recorded on the episode row once `health_marker_preset_id` exists in the schema).
 4. At the end of the preset prompts, the user is offered the option to **add additional symptoms or health markers** not in their preset (free text entry).
 5. The user can flag the episode type:
    - **ABS** (manually, or automatically suggested if BAC reading is above 0.00)
@@ -457,7 +463,7 @@ An "episode" or "flare" is a discrete event where the user experiences ABS-relat
 When not in an active episode, the user can:
 
 - Log a **"How are you feeling"** entry with a mood/wellness rating and optional notes.
-- Capture health markers at any time using their preset.
+- Capture health markers at any time using **a health marker preset only** (asymptomatic vitals)—no symptom preset and no episode template required; see [Episode & vitals flows](user-stories/episode-and-health-marker-flows.md).
 - Add ad-hoc symptoms without starting a full episode.
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -92,7 +92,7 @@
 - [ ] Prompt flow skeleton: step through symptoms one at a time, render correct input type per symptom
 - [ ] Episode data wired to Supabase: plaintext columns under RLS (no client-side field encryption)
 
-**Why this week:** The first half wraps up auth (config + server-mediated MFA verification). The second half lays episode logging foundation: schema for both preset IDs **and** templates, settings to define templates, then **I’m having an episode** → template picker → prompt skeleton.
+**Why this week:** The first half wraps up auth (config + server-mediated MFA verification). The second half lays episode logging foundation: schema for both preset IDs **and** templates, settings to define templates, then **I'm having an episode** → template picker → prompt skeleton.
 
 ---
 
@@ -252,7 +252,7 @@ graph TD
 
 ## Notes (constraints, not scope cuts)
 
-- **Episode + health marker presets:** Week 5 ships migrations for `episodes.health_marker_preset_id`, the **episode preset templates** table, template **settings** UI, and **I’m having an episode** → template picker → insert with both preset IDs. Week 6 completes the full prompt flow (symptoms + markers), wellness, and standalone vitals—see week checkboxes and [user story](user-stories/episode-and-health-marker-flows.md).
+- **Episode + health marker presets:** Week 5 ships migrations for `episodes.health_marker_preset_id`, the **episode preset templates** table, template **settings** UI, and **I'm having an episode** → template picker → insert with both preset IDs. Week 6 completes the full prompt flow (symptoms + markers), wellness, and standalone vitals—see week checkboxes and [user story](user-stories/episode-and-health-marker-flows.md).
 - **PowerSync + RLS consistency:** Sync Rules must mirror grant logic (patient / caretaker / practitioner). Treat RLS as authoritative for API access; validate rule changes in tests ([PRD](PRD.md) Architecture). Week 7 delivers online media upload and the offline queue + PowerSync work as listed in that week’s tasks.
 - **Practitioner MFA fail-closed:** Use an Edge Function (or equivalent) that verifies MFA before returning patient data; do not rely on JWT hooks alone if they can omit claims. This is part of Week 5’s practitioner MFA work, not a downgrade path.
 - **SQLCipher / offline queue:** Week 7 pairs media and offline sync. Device-bound encryption for queued blobs matches the PRD; it is separate from server-side PHI encryption and does not involve sharing keys between users.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -85,12 +85,14 @@
 
 **Second half (April 16-19, school finished):**
 
+- [ ] Database: migrations for (1) `episodes.health_marker_preset_id` (nullable FK to `health_marker_presets`, same-owner pattern as `symptom_preset_id`) and (2) **episode preset templates** table (bundle: one symptom preset + one health marker preset per template) + RLS; regenerate `database.types.ts` and clients per [SUPABASE_CLOUD_DEVELOPER.md](SUPABASE_CLOUD_DEVELOPER.md). Template rows must exist **before** the episode-start template picker can list choices ([PRD](PRD.md) §4, [user story](user-stories/episode-and-health-marker-flows.md))
+- [ ] **Settings:** UI to create/edit **episode templates** (pair a symptom preset with a health marker preset under one name, e.g. ABS vs CVS)—done when the user is well, so episode start stays one-tap
 - [ ] "I'm having an episode" button on home screen
-- [ ] Episode creation: select symptom preset, begin prompt flow
+- [ ] Episode start: user selects **one episode template** per session; insert episode with both `symptom_preset_id` and `health_marker_preset_id` resolved from that template ([user story](user-stories/episode-and-health-marker-flows.md))
 - [ ] Prompt flow skeleton: step through symptoms one at a time, render correct input type per symptom
 - [ ] Episode data wired to Supabase: plaintext columns under RLS (no client-side field encryption)
 
-**Why this week:** The first half wraps up auth (config + server-mediated MFA verification). The second half pivots to the most important feature once school pressure lifts.
+**Why this week:** The first half wraps up auth (config + server-mediated MFA verification). The second half lays episode logging foundation: schema for both preset IDs **and** templates, settings to define templates, then **I’m having an episode** → template picker → prompt skeleton.
 
 ---
 
@@ -102,7 +104,7 @@
 
 - [ ] Complete episode prompt flow:
   - All symptom input types functioning (yes/no, severity 1-5, free text)
-  - Health marker entry after symptoms
+  - Health marker entry **after** symptoms, using the **health marker preset** stored on the episode row (`health_marker_preset_id`) ([PRD](PRD.md) §4)
   - "Add additional symptoms/markers" free-text entry at end
   - Episode type selection (ABS / Other) with custom label
   - Episode notes
@@ -113,10 +115,9 @@
   - Food entry during episode prompt (at end of flow)
   - Free text note + meal tag (Breakfast/Lunch/Dinner/Snack/Other) + timestamp
   - Stored as plaintext in PostgreSQL under RLS (`food_diary_entries.food_note` per [PRD](PRD.md))
-- [ ] General wellness logging:
-  - "How are you feeling" mood/wellness entry with a notes field
-  - Ad-hoc symptom logging (without starting a full episode)
-  - Ad-hoc health marker capture
+- [ ] General wellness: "How are you feeling" mood/wellness entry with optional notes
+- [ ] Ad-hoc symptom logging without starting a full episode
+- [ ] **Standalone vitals:** home or wellness entry to log health markers using **one health marker preset only** (asymptomatic; no symptom preset, no episode)—separate from episode flow ([PRD](PRD.md) §5, [user story](user-stories/episode-and-health-marker-flows.md))
 
 ---
 
@@ -251,6 +252,7 @@ graph TD
 
 ## Notes (constraints, not scope cuts)
 
+- **Episode + health marker presets:** Week 5 ships migrations for `episodes.health_marker_preset_id`, the **episode preset templates** table, template **settings** UI, and **I’m having an episode** → template picker → insert with both preset IDs. Week 6 completes the full prompt flow (symptoms + markers), wellness, and standalone vitals—see week checkboxes and [user story](user-stories/episode-and-health-marker-flows.md).
 - **PowerSync + RLS consistency:** Sync Rules must mirror grant logic (patient / caretaker / practitioner). Treat RLS as authoritative for API access; validate rule changes in tests ([PRD](PRD.md) Architecture). Week 7 delivers online media upload and the offline queue + PowerSync work as listed in that week’s tasks.
 - **Practitioner MFA fail-closed:** Use an Edge Function (or equivalent) that verifies MFA before returning patient data; do not rely on JWT hooks alone if they can omit claims. This is part of Week 5’s practitioner MFA work, not a downgrade path.
 - **SQLCipher / offline queue:** Week 7 pairs media and offline sync. Device-bound encryption for queued blobs matches the PRD; it is separate from server-side PHI encryption and does not involve sharing keys between users.

--- a/docs/user-stories/episode-and-health-marker-flows.md
+++ b/docs/user-stories/episode-and-health-marker-flows.md
@@ -1,0 +1,93 @@
+# User story: Episode logging vs standalone vitals (symptom + health marker presets)
+
+**Status:** Draft (product intent; schedule on [ROADMAP.md](../ROADMAP.md) — **Week 5:** migrations (`health_marker_preset_id` + episode templates table), template settings UI, **I’m having an episode** + template picker; **Week 6:** full symptom + marker prompt flow, standalone vitals, food diary, wellness)  
+**Related PRD:** [PRD.md](../PRD.md) — §3 Health Marker Presets, §4 Episode Logging, §5 General Wellness Logging
+
+This document expands the **user-facing flows** for:
+
+1. Starting an **episode** when the user may be **cognitively impaired** — the UI must not dump many choices on them at once ([PRD](../PRD.md) impaired-user requirements).
+2. **Asymptomatic** use: the user only wants to **track vitals** using a health marker preset, with **no** symptom episode.
+
+The PRD states the **order** of prompts (symptoms first, then health markers). This story adds **how** pairing is chosen without overwhelming the user at episode start.
+
+---
+
+## Accessibility intent: one clear choice, then a linear flow
+
+Episode templates exist so that **configuration complexity** (symptom list + health marker list + how they pair) lives in **settings**, not at the moment someone taps **“I’m having an episode.”**
+
+At episode start, the experience is: **pick what kind of episode this is** using **one** large, high-contrast choice per row (e.g. **“ABS Episode”**, **“CVS Episode”**) — each label is an **episode template** that already points at the right symptom preset **and** health marker preset. After that single decision, the app runs **one linear prompt flow** (symptoms in order, then markers in order). There is **no** separate “pick symptom preset” and “pick health marker preset” step during an episode; pairing is **only** done ahead of time when editing templates in settings.
+
+---
+
+## Persona — Eric
+
+**Eric** lives with **ABS** and also has **an unknown vomiting condition**. He can feel the difference between:
+
+- An **ABS-related** flare (where BAC and ABS-specific markers matter to his workflow), and  
+- A **CVS-like** bout — vertigo, nausea, vomiting **without** it being an ABS episode for him.
+
+So Eric needs **more than one named episode type** at start — not more complexity on one screen. He should see a **short list of big buttons** (or an equally accessible control), e.g. **“ABS Episode”** and **“CVS Episode”**, each backed by its own episode template (different symptom lines, different marker lines, or both). One tap → into the combined flow.
+
+Eric also wants to log glucose or other markers on a **good day** without starting any episode — that is **standalone vitals** (Story B).
+
+---
+
+## Story A — Starting an episode (template-first)
+
+### One-time setup (in settings, when Eric is well)
+
+1. Eric (or a caretaker) builds **symptom presets** and **health marker presets** as separate lists — the data model keeps those concerns separate.
+2. Eric creates **episode templates** that **pair** one symptom preset with one health marker preset under a **single name** he will recognize when impaired:
+   - e.g. **“ABS Episode”** → symptom list A + marker list A  
+   - e.g. **“CVS Episode”** → symptom list B + marker list B (vertigo / nausea / vomiting focus, without implying ABS-specific markers he does not need for that path)
+
+Naming a symptom preset and a health marker preset the same string does **not** link them in the database; the **episode template** row is what ties them together.
+
+### When Eric is having an episode
+
+1. Eric taps **“I’m having an episode”** (large target, high contrast).
+2. Eric chooses **one episode template** — e.g. **“ABS Episode”** or **“CVS Episode”** — **one choice**, not a wizard of separate preset pickers.
+3. The app runs **all symptom prompts** for that template in order, then **all health marker prompts** in order, then extras / episode type / notes per [PRD](../PRD.md).
+
+### Outcome
+
+- Eric is not asked to assemble presets while impaired; he only picks **which kind of episode** this is, using labels he set up earlier.
+- The **episode record** still persists **which** symptom preset and **which** health marker preset were used (via the template resolution — see roadmap: `health_marker_preset_id` on `episodes`).
+
+---
+
+## Story B — Asymptomatic, “just checking vitals”
+
+### Setup
+
+- Eric maintains **health marker presets** (e.g. “Daily vitals”, “Post-meal glucose”) independent of any episode.
+
+### When Eric feels fine but wants numbers
+
+1. Eric taps something like **“Log vitals”** / **“Health markers”** from home (**not** “I’m having an episode”).
+2. Eric picks **one health marker preset** only.
+3. The app walks **only** those markers in preset order and saves readings **without** symptom prompts and **without** an episode template.
+
+### Outcome
+
+- The same health marker preset can appear inside an episode template (Story A) and **alone** (Story B).
+- Standalone vitals stay **first-class** — no requirement to link markers to symptoms for users who only need that path.
+
+---
+
+## Design principles (summary)
+
+| Principle | Detail |
+|-----------|--------|
+| **Minimal choices when impaired** | Episode start favors **one template choice** (or a very small list of named templates), not multiple preset pickers. |
+| **Independent preset lists in the DB** | Symptom presets and health marker presets remain separate editable lists; **templates** are how we pair them for logging without cognitive overload. |
+| **Explicit pairing** | The app must not guess; the **episode template** resolves which marker list goes with which symptom list. |
+| **Persist both IDs on the episode** | For auditability, the episode row should store both `symptom_preset_id` and `health_marker_preset_id` once the schema supports it. |
+| **Standalone vitals** | Separate entry point; health marker preset only. |
+
+---
+
+## Implementation note
+
+Database migrations, RLS, and typed client updates for `episodes.health_marker_preset_id` and for the **episode preset templates** (bundle) table are **not** specified in this user story file. Concrete tasks live as checkboxes under **[ROADMAP.md](../ROADMAP.md)** (episode template schema + picker in **Week 5**; full prompts and standalone vitals in **Week 6**).

--- a/docs/user-stories/episode-and-health-marker-flows.md
+++ b/docs/user-stories/episode-and-health-marker-flows.md
@@ -1,6 +1,6 @@
 # User story: Episode logging vs standalone vitals (symptom + health marker presets)
 
-**Status:** Draft (product intent; schedule on [ROADMAP.md](../ROADMAP.md) — **Week 5:** migrations (`health_marker_preset_id` + episode templates table), template settings UI, **I’m having an episode** + template picker; **Week 6:** full symptom + marker prompt flow, standalone vitals, food diary, wellness)  
+**Status:** Draft (product intent; schedule on [ROADMAP.md](../ROADMAP.md) — **Week 5:** migrations (`health_marker_preset_id` + episode templates table), template settings UI, **I'm having an episode** + template picker; **Week 6:** full symptom + marker prompt flow, standalone vitals, food diary, wellness)  
 **Related PRD:** [PRD.md](../PRD.md) — §3 Health Marker Presets, §4 Episode Logging, §5 General Wellness Logging
 
 This document expands the **user-facing flows** for:
@@ -14,7 +14,7 @@ The PRD states the **order** of prompts (symptoms first, then health markers). T
 
 ## Accessibility intent: one clear choice, then a linear flow
 
-Episode templates exist so that **configuration complexity** (symptom list + health marker list + how they pair) lives in **settings**, not at the moment someone taps **“I’m having an episode.”**
+Episode templates exist so that **configuration complexity** (symptom list + health marker list + how they pair) lives in **settings**, not at the moment someone taps **“I'm having an episode.”**
 
 At episode start, the experience is: **pick what kind of episode this is** using **one** large, high-contrast choice per row (e.g. **“ABS Episode”**, **“CVS Episode”**) — each label is an **episode template** that already points at the right symptom preset **and** health marker preset. After that single decision, the app runs **one linear prompt flow** (symptoms in order, then markers in order). There is **no** separate “pick symptom preset” and “pick health marker preset” step during an episode; pairing is **only** done ahead of time when editing templates in settings.
 
@@ -46,7 +46,7 @@ Naming a symptom preset and a health marker preset the same string does **not** 
 
 ### When Eric is having an episode
 
-1. Eric taps **“I’m having an episode”** (large target, high contrast).
+1. Eric taps **“I'm having an episode”** (large target, high contrast).
 2. Eric chooses **one episode template** — e.g. **“ABS Episode”** or **“CVS Episode”** — **one choice**, not a wizard of separate preset pickers.
 3. The app runs **all symptom prompts** for that template in order, then **all health marker prompts** in order, then extras / episode type / notes per [PRD](../PRD.md).
 
@@ -65,7 +65,7 @@ Naming a symptom preset and a health marker preset the same string does **not** 
 
 ### When Eric feels fine but wants numbers
 
-1. Eric taps something like **“Log vitals”** / **“Health markers”** from home (**not** “I’m having an episode”).
+1. Eric taps something like **“Log vitals”** / **“Health markers”** from home (**not** “I'm having an episode”).
 2. Eric picks **one health marker preset** only.
 3. The app walks **only** those markers in preset order and saves readings **without** symptom prompts and **without** an episode template.
 


### PR DESCRIPTION
Closes #64

## Summary

Adds and aligns documentation for **episode preset templates** (template-first episode start), **standalone vitals**, and **roadmap** placement—so product intent matches the data model (symptom presets + health marker presets paired via templates, not multiple pickers at episode start).

## Changes

- **`docs/PRD.md`** — §3–5: template-first episode start, both preset IDs on episodes, standalone vitals; TOC link to user story.
- **`docs/user-stories/episode-and-health-marker-flows.md`** — New user story: accessibility intent, Eric persona (ABS vs CVS-style episode types), Story A (episode) vs Story B (asymptomatic vitals), design principles.
- **`docs/ROADMAP.md`** — Week 5/6 tasks and Notes: migrations + template settings + template picker sequencing; removes duplicate template work; clarifies Week 5 vs Week 6 ownership.

## Why

Episode logging needs a single, accessible choice at **I’m having an episode**; pairing belongs in settings via **episode templates**. This PR captures that in the canonical docs before implementation PRs.

## How to review

- [ ] User story reads clearly for impaired-user / one-tap episode type selection.
- [ ] PRD and roadmap agree on template schema + settings before template picker.
- [ ] No conflicting “manual two-picker” product path.