### PR TITLE
feat(supabase): enforce practitioner AAL2 for patient-data RLS and add MFA audit edge function

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -78,8 +78,8 @@
 
 **First half (April 13-15, school ending):**
 
-- [ ] TOTP setup flow for practitioners via Supabase Auth MFA API (mandatory for practitioners)
-- [ ] Practitioner MFA **fail-closed** per [PRD](PRD.md): RLS and/or **Edge Function** (or equivalent) verifies MFA via Auth APIs before patient-data reads; hooks alone must not be the sole control if they can fail open
+- [x] TOTP setup flow for practitioners via Supabase Auth MFA API (mandatory for practitioners)
+- [x] Practitioner MFA **fail-closed** per [PRD](PRD.md): RLS and/or **Edge Function** (or equivalent) verifies MFA via Auth APIs before patient-data reads; hooks alone must not be the sole control if they can fail open
 - [ ] JWT claims / role metadata for routing; practitioner patient-data access must satisfy MFA rules in policy or server path
 - [ ] Frontend MFA gating in practitioner app (no patient routes until MFA verified)
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -368,6 +368,11 @@ deno_version = 2
 # [edge_runtime.secrets]
 # secret_key = "env(SECRET_VALUE)"
 
+# Practitioner MFA audit: validates JWT + profile in-handler; writes access_log on AAL failure (403).
+# verify_jwt false so OPTIONS preflight succeeds; POST still requires a valid Bearer session.
+[functions.practitioner-mfa-auth-audit]
+verify_jwt = false
+
 [analytics]
 enabled = true
 port = 54327

--- a/supabase/functions/practitioner-mfa-auth-audit/index.ts
+++ b/supabase/functions/practitioner-mfa-auth-audit/index.ts
@@ -126,6 +126,8 @@ function parsePatientUserIdField(value: unknown): PatientUserIdField {
  * `practitioner_access` row for this practitioner and candidate patient. That row’s
  * `patient_user_id` FK to `auth.users` already implies the user exists, so no Auth Admin lookup is
  * needed. Returns null when absent or on lookup error (fail closed on attribution).
+ * SELECT uses the service-role client; `practitioner_access_service_role_select` RLS policy allows
+ * this read when `service_role` is not BYPASSRLS (see migration).
  *
  * @param admin - Service-role Supabase client.
  * @param practitionerUserId - Authenticated practitioner (`sub`).

--- a/supabase/functions/practitioner-mfa-auth-audit/index.ts
+++ b/supabase/functions/practitioner-mfa-auth-audit/index.ts
@@ -50,7 +50,9 @@ const WWW_AUTHENTICATE_INVALID_JWT =
  *
  * @param wwwAuthenticate - Full `WWW-Authenticate` field value.
  */
-function unauthorizedJsonHeaders(wwwAuthenticate: string): Record<string, string> {
+function unauthorizedJsonHeaders(
+  wwwAuthenticate: string,
+): Record<string, string> {
   return {
     ...CORS_HEADERS,
     'Content-Type': 'application/json',

--- a/supabase/functions/practitioner-mfa-auth-audit/index.ts
+++ b/supabase/functions/practitioner-mfa-auth-audit/index.ts
@@ -9,14 +9,15 @@
  * HTTP contract (callers should handle each):
  * - **204** — `profiles.app_role` is `practitioner` and JWT `aal` is `aal2` (nothing to audit).
  * - **403** — practitioner and `aal` is not `aal2`; `access_log` row inserted (`auth_failure`).
- * - **200** + `{ ok: true, audited: false, reason: "not_practitioner" }` — authenticated user is
- *   not a practitioner; MFA audit does not apply (distinct from 204 so clients can detect wrong
- *   role or mis-scoped calls).
+ * - **200** + `{ ok: true, audited: false, reason: "not_practitioner" }` — profile row exists and
+ *   `app_role` is not `practitioner`; MFA audit does not apply (distinct from 204 so clients can
+ *   detect wrong role or mis-scoped calls).
  * - **400** — invalid optional `patient_user_id` in JSON body (malformed UUID).
  * - **401** — missing/invalid Bearer session or JWT payload; includes `WWW-Authenticate: Bearer`
  *   (RFC 6750) for OAuth2-style challenge detection.
  * - **405** — not POST; includes `Allow: POST, OPTIONS` (RFC 9110).
- * - **500** — server misconfiguration or unexpected DB failure on insert.
+ * - **500** — e.g. `server_misconfigured`, `profile_lookup_failed`, `profile_missing` (no `profiles`
+ *   row for the session user), or `audit_write_failed` on insert.
  *
  * Deploy: `pnpm dlx supabase functions deploy practitioner-mfa-auth-audit` (secrets from project).
  */
@@ -214,7 +215,21 @@ Deno.serve(async (req: Request) => {
     });
   }
 
-  if (profile?.app_role !== 'practitioner') {
+  if (profile == null) {
+    return new Response(
+      JSON.stringify({
+        error: 'profile_missing',
+        message:
+          'No profile exists for this authenticated user; cannot evaluate practitioner MFA audit.',
+      }),
+      {
+        status: 500,
+        headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+      },
+    );
+  }
+
+  if (profile.app_role !== 'practitioner') {
     return new Response(
       JSON.stringify({ ok: true, audited: false, reason: 'not_practitioner' }),
       {

--- a/supabase/functions/practitioner-mfa-auth-audit/index.ts
+++ b/supabase/functions/practitioner-mfa-auth-audit/index.ts
@@ -10,7 +10,7 @@
  */
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
-import { createClient } from 'jsr:@supabase/supabase-js@2';
+import { createClient, type SupabaseClient } from 'jsr:@supabase/supabase-js@2';
 import { decodeJwt } from 'npm:jose@5';
 
 /** Matches Supabase Edge CORS guidance (authorization + apikey for supabase-js). */
@@ -24,11 +24,79 @@ const CORS_HEADERS: Record<string, string> = {
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-function parseOptionalPatientId(value: unknown): string | null {
-  if (typeof value !== 'string' || !UUID_RE.test(value)) {
+/** Parsed `patient_user_id` body field: omitted, syntactically invalid, or valid UUID string. */
+type PatientUserIdField =
+  | { kind: 'absent' }
+  | { kind: 'invalid'; message: string }
+  | { kind: 'valid'; uuid: string };
+
+/**
+ * Interprets the optional JSON `patient_user_id` for audit context.
+ *
+ * @param value - Raw `body.patient_user_id` value.
+ * @returns Absent if omitted/null/empty, invalid if wrong type or not a UUID string, else valid.
+ */
+function parsePatientUserIdField(value: unknown): PatientUserIdField {
+  if (value === undefined || value === null) {
+    return { kind: 'absent' };
+  }
+  if (typeof value !== 'string') {
+    return {
+      kind: 'invalid',
+      message: 'patient_user_id must be a string UUID when provided.',
+    };
+  }
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    return { kind: 'absent' };
+  }
+  if (!UUID_RE.test(trimmed)) {
+    return {
+      kind: 'invalid',
+      message: 'patient_user_id must be a valid UUID.',
+    };
+  }
+  return { kind: 'valid', uuid: trimmed };
+}
+
+/**
+ * Resolves whether a patient id may be stored on `access_log`: user must exist in Auth and share an
+ * active practitioner grant; otherwise returns null to satisfy FK and avoid bogus attribution.
+ *
+ * @param admin - Service-role Supabase client.
+ * @param practitionerUserId - Authenticated practitioner (`sub`).
+ * @param field - Parsed body field (only `valid` carries a UUID to resolve).
+ * @returns `patient_user_id` for insert or null.
+ */
+async function resolveAuditPatientUserId(
+  admin: SupabaseClient,
+  practitionerUserId: string,
+  field: PatientUserIdField,
+): Promise<string | null> {
+  if (field.kind !== 'valid') {
     return null;
   }
-  return value;
+  const candidate = field.uuid;
+
+  const { data: authData, error: authErr } =
+    await admin.auth.admin.getUserById(candidate);
+  if (authErr || !authData?.user) {
+    return null;
+  }
+
+  const { data: grant, error: grantErr } = await admin
+    .from('practitioner_access')
+    .select('patient_user_id')
+    .eq('practitioner_user_id', practitionerUserId)
+    .eq('patient_user_id', candidate)
+    .is('revoked_at', null)
+    .maybeSingle();
+
+  if (grantErr || !grant) {
+    return null;
+  }
+
+  return candidate;
 }
 
 Deno.serve(async (req: Request) => {
@@ -62,12 +130,11 @@ Deno.serve(async (req: Request) => {
     });
   }
 
-  let patientUserId: string | null = null;
+  let body: { patient_user_id?: unknown };
   try {
-    const body = (await req.json()) as { patient_user_id?: unknown };
-    patientUserId = parseOptionalPatientId(body?.patient_user_id);
+    body = (await req.json()) as { patient_user_id?: unknown };
   } catch {
-    /* empty body */
+    body = {};
   }
 
   const admin = createClient(supabaseUrl, serviceKey, {
@@ -105,6 +172,26 @@ Deno.serve(async (req: Request) => {
     );
   }
 
+  const patientField = parsePatientUserIdField(body?.patient_user_id);
+  if (patientField.kind === 'invalid') {
+    return new Response(
+      JSON.stringify({
+        error: 'invalid_patient_user_id',
+        message: patientField.message,
+      }),
+      {
+        status: 400,
+        headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+      },
+    );
+  }
+
+  const resolvedPatientUserId = await resolveAuditPatientUserId(
+    admin,
+    userData.user.id,
+    patientField,
+  );
+
   let aal: string | undefined;
   try {
     const claims = decodeJwt(token) as { aal?: string };
@@ -126,7 +213,7 @@ Deno.serve(async (req: Request) => {
   const { error: insertErr } = await admin.from('access_log').insert({
     actor_user_id: userData.user.id,
     actor_role: 'practitioner',
-    patient_user_id: patientUserId,
+    patient_user_id: resolvedPatientUserId,
     action: 'auth_failure',
     resource_type: 'practitioner_mfa_assurance',
     resource_id: null,

--- a/supabase/functions/practitioner-mfa-auth-audit/index.ts
+++ b/supabase/functions/practitioner-mfa-auth-audit/index.ts
@@ -13,8 +13,9 @@
  *   not a practitioner; MFA audit does not apply (distinct from 204 so clients can detect wrong
  *   role or mis-scoped calls).
  * - **400** — invalid optional `patient_user_id` in JSON body (malformed UUID).
- * - **401** — missing/invalid Bearer session or JWT payload.
- * - **405** — not POST.
+ * - **401** — missing/invalid Bearer session or JWT payload; includes `WWW-Authenticate: Bearer`
+ *   (RFC 6750) for OAuth2-style challenge detection.
+ * - **405** — not POST; includes `Allow: POST, OPTIONS` (RFC 9110).
  * - **500** — server misconfiguration or unexpected DB failure on insert.
  *
  * Deploy: `pnpm dlx supabase functions deploy practitioner-mfa-auth-audit` (secrets from project).
@@ -31,6 +32,32 @@ const CORS_HEADERS: Record<string, string> = {
     'authorization, x-client-info, apikey, content-type',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
 };
+
+/** RFC 9110: 405 responses list allowed methods on this resource. */
+const ALLOW_POST_OPTIONS = 'POST, OPTIONS';
+
+/** RFC 6750 `WWW-Authenticate` values; `invalid_token` when a Bearer token was sent but rejected. */
+const WWW_AUTHENTICATE_BEARER = 'Bearer';
+
+const WWW_AUTHENTICATE_INVALID_TOKEN =
+  'Bearer error="invalid_token", error_description="Session could not be validated"';
+
+const WWW_AUTHENTICATE_INVALID_JWT =
+  'Bearer error="invalid_token", error_description="Access token payload could not be read"';
+
+/**
+ * JSON 401 response headers including Bearer challenge (RFC 6750) and CORS expose for browsers.
+ *
+ * @param wwwAuthenticate - Full `WWW-Authenticate` field value.
+ */
+function unauthorizedJsonHeaders(wwwAuthenticate: string): Record<string, string> {
+  return {
+    ...CORS_HEADERS,
+    'Content-Type': 'application/json',
+    'WWW-Authenticate': wwwAuthenticate,
+    'Access-Control-Expose-Headers': 'WWW-Authenticate',
+  };
+}
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -135,7 +162,11 @@ Deno.serve(async (req: Request) => {
   if (req.method !== 'POST') {
     return new Response(JSON.stringify({ error: 'method_not_allowed' }), {
       status: 405,
-      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+      headers: {
+        ...CORS_HEADERS,
+        'Content-Type': 'application/json',
+        Allow: ALLOW_POST_OPTIONS,
+      },
     });
   }
 
@@ -143,7 +174,7 @@ Deno.serve(async (req: Request) => {
   if (token == null) {
     return new Response(JSON.stringify({ error: 'missing_authorization' }), {
       status: 401,
-      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+      headers: unauthorizedJsonHeaders(WWW_AUTHENTICATE_BEARER),
     });
   }
   const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
@@ -164,7 +195,7 @@ Deno.serve(async (req: Request) => {
   if (userErr || !userData.user) {
     return new Response(JSON.stringify({ error: 'invalid_session' }), {
       status: 401,
-      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+      headers: unauthorizedJsonHeaders(WWW_AUTHENTICATE_INVALID_TOKEN),
     });
   }
 
@@ -198,7 +229,7 @@ Deno.serve(async (req: Request) => {
   } catch {
     return new Response(JSON.stringify({ error: 'invalid_jwt_payload' }), {
       status: 401,
-      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+      headers: unauthorizedJsonHeaders(WWW_AUTHENTICATE_INVALID_JWT),
     });
   }
 

--- a/supabase/functions/practitioner-mfa-auth-audit/index.ts
+++ b/supabase/functions/practitioner-mfa-auth-audit/index.ts
@@ -92,8 +92,10 @@ function parsePatientUserIdField(value: unknown): PatientUserIdField {
 }
 
 /**
- * Resolves whether a patient id may be stored on `access_log`: user must exist in Auth and share an
- * active practitioner grant; otherwise returns null to satisfy FK and avoid bogus attribution.
+ * Resolves whether a patient id may be stored on `access_log`: requires an active
+ * `practitioner_access` row for this practitioner and candidate patient. That row’s
+ * `patient_user_id` FK to `auth.users` already implies the user exists, so no Auth Admin lookup is
+ * needed. Returns null when absent or on lookup error (fail closed on attribution).
  *
  * @param admin - Service-role Supabase client.
  * @param practitionerUserId - Authenticated practitioner (`sub`).
@@ -109,12 +111,6 @@ async function resolveAuditPatientUserId(
     return null;
   }
   const candidate = field.uuid;
-
-  const { data: authData, error: authErr } =
-    await admin.auth.admin.getUserById(candidate);
-  if (authErr || !authData?.user) {
-    return null;
-  }
 
   const { data: grant, error: grantErr } = await admin
     .from('practitioner_access')
@@ -160,13 +156,6 @@ Deno.serve(async (req: Request) => {
     });
   }
 
-  let body: { patient_user_id?: unknown };
-  try {
-    body = (await req.json()) as { patient_user_id?: unknown };
-  } catch {
-    body = {};
-  }
-
   const admin = createClient(supabaseUrl, serviceKey, {
     auth: { autoRefreshToken: false, persistSession: false },
   });
@@ -202,6 +191,32 @@ Deno.serve(async (req: Request) => {
     );
   }
 
+  let aal: string | undefined;
+  try {
+    const claims = decodeJwt(token) as { aal?: string };
+    aal = claims.aal;
+  } catch {
+    return new Response(JSON.stringify({ error: 'invalid_jwt_payload' }), {
+      status: 401,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (aal === 'aal2') {
+    return new Response(null, {
+      status: 204,
+      headers: CORS_HEADERS,
+    });
+  }
+
+  // Below: audit insert only — defer body read and grant lookup until we know MFA failed.
+  let body: { patient_user_id?: unknown };
+  try {
+    body = (await req.json()) as { patient_user_id?: unknown };
+  } catch {
+    body = {};
+  }
+
   const patientField = parsePatientUserIdField(body?.patient_user_id);
   if (patientField.kind === 'invalid') {
     return new Response(
@@ -221,24 +236,6 @@ Deno.serve(async (req: Request) => {
     userData.user.id,
     patientField,
   );
-
-  let aal: string | undefined;
-  try {
-    const claims = decodeJwt(token) as { aal?: string };
-    aal = claims.aal;
-  } catch {
-    return new Response(JSON.stringify({ error: 'invalid_jwt_payload' }), {
-      status: 401,
-      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
-    });
-  }
-
-  if (aal === 'aal2') {
-    return new Response(null, {
-      status: 204,
-      headers: CORS_HEADERS,
-    });
-  }
 
   const { error: insertErr } = await admin.from('access_log').insert({
     actor_user_id: userData.user.id,

--- a/supabase/functions/practitioner-mfa-auth-audit/index.ts
+++ b/supabase/functions/practitioner-mfa-auth-audit/index.ts
@@ -1,0 +1,154 @@
+/**
+ * Server-side MFA assurance audit for practitioners (Supabase Edge Function).
+ *
+ * Verifies the caller JWT (AAL claim) and profile role, then either returns success or writes an
+ * `access_log` row with `action = auth_failure` and HTTP 403 when MFA assurance is missing.
+ * RLS on PHI tables remains the primary enforcement; this function provides an append-only audit
+ * path in a separate transaction (RLS denial via RAISE does not persist `access_log` rows).
+ *
+ * Deploy: `pnpm dlx supabase functions deploy practitioner-mfa-auth-audit` (secrets from project).
+ */
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+import { decodeJwt } from 'npm:jose@5';
+
+/** Matches Supabase Edge CORS guidance (authorization + apikey for supabase-js). */
+const CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers':
+    'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function parseOptionalPatientId(value: unknown): string | null {
+  if (typeof value !== 'string' || !UUID_RE.test(value)) {
+    return null;
+  }
+  return value;
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: CORS_HEADERS });
+  }
+
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'method_not_allowed' }), {
+      status: 405,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    return new Response(JSON.stringify({ error: 'missing_authorization' }), {
+      status: 401,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+
+  const token = authHeader.replace(/^Bearer\s+/i, '').trim();
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+
+  if (!supabaseUrl || !serviceKey) {
+    return new Response(JSON.stringify({ error: 'server_misconfigured' }), {
+      status: 500,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+
+  let patientUserId: string | null = null;
+  try {
+    const body = (await req.json()) as { patient_user_id?: unknown };
+    patientUserId = parseOptionalPatientId(body?.patient_user_id);
+  } catch {
+    /* empty body */
+  }
+
+  const admin = createClient(supabaseUrl, serviceKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const { data: userData, error: userErr } = await admin.auth.getUser(token);
+  if (userErr || !userData.user) {
+    return new Response(JSON.stringify({ error: 'invalid_session' }), {
+      status: 401,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+
+  const { data: profile, error: profileErr } = await admin
+    .from('profiles')
+    .select('app_role')
+    .eq('id', userData.user.id)
+    .maybeSingle();
+
+  if (profileErr) {
+    return new Response(JSON.stringify({ error: 'profile_lookup_failed' }), {
+      status: 500,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (profile?.app_role !== 'practitioner') {
+    return new Response(
+      JSON.stringify({ ok: true, audited: false, reason: 'not_practitioner' }),
+      {
+        status: 200,
+        headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+      },
+    );
+  }
+
+  let aal: string | undefined;
+  try {
+    const claims = decodeJwt(token) as { aal?: string };
+    aal = claims.aal;
+  } catch {
+    return new Response(JSON.stringify({ error: 'invalid_jwt_payload' }), {
+      status: 401,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (aal === 'aal2') {
+    return new Response(null, {
+      status: 204,
+      headers: CORS_HEADERS,
+    });
+  }
+
+  const { error: insertErr } = await admin.from('access_log').insert({
+    actor_user_id: userData.user.id,
+    actor_role: 'practitioner',
+    patient_user_id: patientUserId,
+    action: 'auth_failure',
+    resource_type: 'practitioner_mfa_assurance',
+    resource_id: null,
+  });
+
+  if (insertErr) {
+    console.error('access_log insert failed', insertErr);
+    return new Response(JSON.stringify({ error: 'audit_write_failed' }), {
+      status: 500,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    });
+  }
+
+  return new Response(
+    JSON.stringify({
+      error: 'mfa_assurance_required',
+      message:
+        'Practitioner session must have MFA assurance (AAL2) to access patient data.',
+    }),
+    {
+      status: 403,
+      headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+    },
+  );
+});

--- a/supabase/functions/practitioner-mfa-auth-audit/index.ts
+++ b/supabase/functions/practitioner-mfa-auth-audit/index.ts
@@ -6,6 +6,17 @@
  * RLS on PHI tables remains the primary enforcement; this function provides an append-only audit
  * path in a separate transaction (RLS denial via RAISE does not persist `access_log` rows).
  *
+ * HTTP contract (callers should handle each):
+ * - **204** — `profiles.app_role` is `practitioner` and JWT `aal` is `aal2` (nothing to audit).
+ * - **403** — practitioner and `aal` is not `aal2`; `access_log` row inserted (`auth_failure`).
+ * - **200** + `{ ok: true, audited: false, reason: "not_practitioner" }` — authenticated user is
+ *   not a practitioner; MFA audit does not apply (distinct from 204 so clients can detect wrong
+ *   role or mis-scoped calls).
+ * - **400** — invalid optional `patient_user_id` in JSON body (malformed UUID).
+ * - **401** — missing/invalid Bearer session or JWT payload.
+ * - **405** — not POST.
+ * - **500** — server misconfiguration or unexpected DB failure on insert.
+ *
  * Deploy: `pnpm dlx supabase functions deploy practitioner-mfa-auth-audit` (secrets from project).
  */
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
@@ -23,6 +34,27 @@ const CORS_HEADERS: Record<string, string> = {
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/** RFC 9110: auth scheme is case-insensitive; capture token after one or more spaces. */
+const BEARER_AUTH_RE = /^\s*Bearer\s+(.*)$/i;
+
+/**
+ * Parses a Bearer token from the `Authorization` header (case-insensitive scheme).
+ *
+ * @param authorization - Raw `Authorization` header value, or null if absent.
+ * @returns The token string, or null if missing, empty, or not a Bearer credential.
+ */
+function parseBearerToken(authorization: string | null): string | null {
+  if (authorization == null || authorization === '') {
+    return null;
+  }
+  const m = authorization.match(BEARER_AUTH_RE);
+  if (!m) {
+    return null;
+  }
+  const raw = m[1]?.trim() ?? '';
+  return raw.length > 0 ? raw : null;
+}
 
 /** Parsed `patient_user_id` body field: omitted, syntactically invalid, or valid UUID string. */
 type PatientUserIdField =
@@ -111,15 +143,13 @@ Deno.serve(async (req: Request) => {
     });
   }
 
-  const authHeader = req.headers.get('Authorization');
-  if (!authHeader?.startsWith('Bearer ')) {
+  const token = parseBearerToken(req.headers.get('Authorization'));
+  if (token == null) {
     return new Response(JSON.stringify({ error: 'missing_authorization' }), {
       status: 401,
       headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
     });
   }
-
-  const token = authHeader.replace(/^Bearer\s+/i, '').trim();
   const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
   const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
 

--- a/supabase/migrations/20260416120000_practitioner_mfa_assurance_rls.sql
+++ b/supabase/migrations/20260416120000_practitioner_mfa_assurance_rls.sql
@@ -1,0 +1,55 @@
+-- Practitioner patient-data reads: fail closed on MFA assurance (AAL2).
+--
+-- PRD: RLS must not rely on a custom access token hook that can omit claims; require
+-- auth.jwt()->>'aal' = 'aal2' on the practitioner grant path. If an active practitioner_access
+-- grant exists but assurance is missing or not aal2, deny with SQLSTATE 42501 so PostgREST
+-- returns a permission error (not an empty 200).
+--
+-- Note: Raising aborts the transaction, so no access_log row is written in the same request;
+-- use the Edge Function practitioner-mfa-auth-audit for append-only auth_failure rows in a
+-- separate transaction when explicit server-side audit is required.
+
+CREATE OR REPLACE FUNCTION public.user_has_practitioner_access (p_patient_user_id uuid)
+  RETURNS boolean
+  LANGUAGE plpgsql
+  VOLATILE
+  SECURITY INVOKER
+  SET search_path = pg_catalog, public
+  AS $$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_has_grant boolean;
+BEGIN
+  IF v_uid IS NULL THEN
+    RETURN FALSE;
+  END IF;
+
+  SELECT
+    EXISTS (
+      SELECT
+        1
+      FROM
+        public.practitioner_access pa
+        INNER JOIN public.profiles pr ON pr.id = v_uid
+      WHERE
+        pa.patient_user_id = p_patient_user_id
+        AND pa.practitioner_user_id = v_uid
+        AND pa.revoked_at IS NULL
+        AND pr.app_role = 'practitioner') INTO v_has_grant;
+
+  IF NOT v_has_grant THEN
+    RETURN FALSE;
+  END IF;
+
+  -- Active practitioner grant: require AAL2 (TOTP-verified session). Missing or non-aal2 claim
+  -- fails closed (PRD: no hook-only reliance).
+  IF (auth.jwt() ->> 'aal') IS DISTINCT FROM 'aal2' THEN
+    RAISE EXCEPTION 'Practitioner MFA assurance (AAL2) is required to access patient data'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN TRUE;
+END;
+$$;
+
+COMMENT ON FUNCTION public.user_has_practitioner_access (uuid) IS 'True when the current user has profiles.app_role practitioner, an active practitioner_access grant for this patient, and JWT aal claim is aal2 (MFA assurance). If a grant exists but aal is missing or not aal2, raises insufficient_privilege (42501), fail-closed.';

--- a/supabase/migrations/20260416120000_practitioner_mfa_assurance_rls.sql
+++ b/supabase/migrations/20260416120000_practitioner_mfa_assurance_rls.sql
@@ -7,7 +7,9 @@
 --
 -- Note: Raising aborts the transaction, so no access_log row is written in the same request;
 -- use the Edge Function practitioner-mfa-auth-audit for append-only auth_failure rows in a
--- separate transaction when explicit server-side audit is required.
+-- separate transaction when explicit server-side audit is required. That function SELECTs
+-- practitioner_access as service_role; explicit policy below matches access_log (issue #8) when
+-- service_role is subject to RLS.
 --
 -- STABLE: no writes; reads grants/profile and auth.jwt() only. RAISE does not persist data.
 -- VOLATILE is unnecessary and can pessimise planner behaviour for repeated same-arg calls.
@@ -56,3 +58,13 @@ END;
 $$;
 
 COMMENT ON FUNCTION public.user_has_practitioner_access (uuid) IS 'True when the current user has profiles.app_role practitioner, an active practitioner_access grant for this patient, and JWT aal claim is aal2 (MFA assurance). If a grant exists but aal is missing or not aal2, raises insufficient_privilege (42501), fail-closed.';
+
+-- ---------------------------------------------------------------------------
+-- practitioner_access: service_role SELECT (MFA audit Edge Function grant verification)
+-- ---------------------------------------------------------------------------
+CREATE POLICY practitioner_access_service_role_select ON public.practitioner_access
+  FOR SELECT
+  TO service_role
+  USING (TRUE);
+
+COMMENT ON POLICY practitioner_access_service_role_select ON public.practitioner_access IS 'Trusted SELECT for automation (e.g. MFA audit Edge Function) when service_role is subject to RLS.';

--- a/supabase/migrations/20260416120000_practitioner_mfa_assurance_rls.sql
+++ b/supabase/migrations/20260416120000_practitioner_mfa_assurance_rls.sql
@@ -8,11 +8,14 @@
 -- Note: Raising aborts the transaction, so no access_log row is written in the same request;
 -- use the Edge Function practitioner-mfa-auth-audit for append-only auth_failure rows in a
 -- separate transaction when explicit server-side audit is required.
+--
+-- STABLE: no writes; reads grants/profile and auth.jwt() only. RAISE does not persist data.
+-- VOLATILE is unnecessary and can pessimise planner behaviour for repeated same-arg calls.
 
 CREATE OR REPLACE FUNCTION public.user_has_practitioner_access (p_patient_user_id uuid)
   RETURNS boolean
   LANGUAGE plpgsql
-  VOLATILE
+  STABLE
   SECURITY INVOKER
   SET search_path = pg_catalog, public
   AS $$


### PR DESCRIPTION
Closes #68

## Summary

Ensures practitioner reads of patient PHI fail closed unless the session’s JWT includes MFA assurance (`aal: aal2`), per PRD. Adds an optional Edge Function path to record `auth_failure` rows in `access_log` when assurance is missing (separate transaction from RLS).

## Changes

- **RLS:** `user_has_practitioner_access()` is **`STABLE`** (reads only; `RAISE` does not write). It requires an active `practitioner_access` grant **and** `(auth.jwt() ->> 'aal') = 'aal2'`. If a grant exists but assurance is missing or not AAL2, the function raises **`42501`** so the API returns a permission error instead of an empty 200.
- **Edge Function:** `practitioner-mfa-auth-audit` parses **`Authorization` case-insensitively** (RFC 9110 `Bearer` scheme). It validates the Bearer token in-handler (`verify_jwt = false` so OPTIONS preflight works). Optional JSON `patient_user_id` is validated: malformed UUID → **400**; well-formed UUIDs are only logged if the user exists in Auth **and** there is an active `practitioner_access` row for that practitioner–patient pair (otherwise stored as `null` to satisfy FK and avoid bad attribution).
- **HTTP contract** (clients should handle each):
  - **204** — profile is practitioner and JWT `aal` is `aal2` (nothing to audit).
  - **403** — practitioner and `aal` is not `aal2`; `access_log` row inserted (`auth_failure`).
  - **200** — `{"ok":true,"audited":false,"reason":"not_practitioner"}` — authenticated user is not a practitioner; audit does not apply (intentionally distinct from 204).
  - Plus **400** / **401** / **405** / **500** as documented in the function header.
- **Config:** `[functions.practitioner-mfa-auth-audit]` in `supabase/config.toml`.

## Testing

- [ ] `pnpm dlx supabase db push` (or already applied) + `gen types` / Prettier per `AGENTS.md` if migration/types committed together.
- [ ] Manual: practitioner test user with `profiles.app_role = practitioner`, active `practitioner_access` grant; compare session **with** TOTP / AAL2 vs password-only / AAL1 against PHI or Storage paths; optional POST to deployed Edge Function (including non-practitioner session → 200 `audited: false`, and `Authorization: bearer …` casing).

## Notes

- RLS `RAISE` does not persist `access_log` in the same request (transaction rolls back); the Edge Function is the append-only audit path for explicit MFA verification failures.
- Deploy function when ready: `pnpm dlx supabase functions deploy practitioner-mfa-auth-audit`.