### PR TITLE
feat(practitioner): add JWT/profile claim contract, routing gate, and gated logout

### DIFF
--- a/apps/practitioner/specs/index.spec.tsx
+++ b/apps/practitioner/specs/index.spec.tsx
@@ -1,15 +1,59 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { LiveAnnouncerProvider } from '@abstrack/ui/a11y-web';
 import Page from '../src/app/page';
 import type { PractitionerSupabaseProfilesRow } from '../src/lib/supabase-wiring';
+import { useAuth } from '../src/lib/auth-provider';
+import type { Session } from '@abstrack/supabase';
 
 jest.mock('../src/lib/auth-provider', () => ({
-  useAuth: () => ({
-    session: null,
-    loading: false,
-    gate: { kind: 'signed_out' as const },
-  }),
+  useAuth: jest.fn(),
 }));
+
+const mockedUseAuth = jest.mocked(useAuth);
+
+/** Minimal session shape for gate branches that require `session?.access_token`. */
+function sessionWithToken(): Session {
+  return {
+    access_token: 'test-access-token',
+    refresh_token: '',
+    expires_in: 3600,
+    expires_at: undefined,
+    token_type: 'bearer',
+    user: {
+      id: '00000000-0000-0000-0000-000000000001',
+      aud: 'authenticated',
+      role: 'authenticated',
+      email: 'user@example.com',
+      app_metadata: {},
+      user_metadata: {},
+      created_at: '',
+    },
+  } as Session;
+}
+
+function renderPage() {
+  return render(
+    <LiveAnnouncerProvider>
+      <Page />
+    </LiveAnnouncerProvider>,
+  );
+}
+
+function expectLogoutPostForm() {
+  const form = document.querySelector(
+    'form[action="/api/auth/logout"][method="POST"]',
+  );
+  expect(form).not.toBeNull();
+  expect(screen.getByRole('button', { name: /^Log out$/i })).toBeTruthy();
+}
+
+const patientProfileRow: PractitionerSupabaseProfilesRow = {
+  id: '00000000-0000-0000-0000-000000000001',
+  display_name: null,
+  app_role: 'patient',
+  created_at: '2020-01-01T00:00:00.000Z',
+  updated_at: '2020-01-01T00:00:00.000Z',
+};
 
 /** Home page calls `getSupabaseBrowserClient()` on mount; env-public throws without URL + key. */
 const JEST_SUPABASE_URL = 'https://test.supabase.co';
@@ -40,13 +84,98 @@ describe('Page', () => {
     }
   });
 
-  it('should render successfully', () => {
-    const { baseElement } = render(
-      <LiveAnnouncerProvider>
-        <Page />
-      </LiveAnnouncerProvider>,
-    );
+  beforeEach(() => {
+    mockedUseAuth.mockReturnValue({
+      session: null,
+      loading: false,
+      profile: undefined,
+      profileError: null,
+      accessTokenClaims: null,
+      gate: { kind: 'signed_out' },
+    });
+  });
+
+  it('should render successfully when signed out', () => {
+    const { baseElement } = renderPage();
     expect(baseElement).toBeTruthy();
+  });
+
+  it('shows signed-out landing with Log in link and no logout form', () => {
+    renderPage();
+    expect(
+      screen.getByRole('heading', { name: /ABStrack Practitioner/i }),
+    ).toBeTruthy();
+    expect(screen.getByRole('link', { name: /^Log in$/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /^Log out$/i })).toBeNull();
+  });
+
+  it('shows profile_error copy and POST /api/auth/logout form', () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    mockedUseAuth.mockReturnValue({
+      session: sessionWithToken(),
+      loading: false,
+      profile: null,
+      profileError: new Error('simulated PostgREST failure'),
+      accessTokenClaims: null,
+      gate: {
+        kind: 'profile_error',
+        error: new Error('simulated PostgREST failure'),
+      },
+    });
+
+    renderPage();
+
+    expect(
+      screen.getByRole('heading', { name: /Could not load your profile/i }),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/Something went wrong while loading your account/i),
+    ).toBeTruthy();
+    expect(screen.queryByText(/simulated PostgREST failure/i)).toBeNull();
+    expectLogoutPostForm();
+
+    consoleSpy.mockRestore();
+  });
+
+  it('shows profile_missing copy and POST /api/auth/logout form', () => {
+    mockedUseAuth.mockReturnValue({
+      session: sessionWithToken(),
+      loading: false,
+      profile: null,
+      profileError: null,
+      accessTokenClaims: null,
+      gate: { kind: 'profile_missing' },
+    });
+
+    renderPage();
+
+    expect(
+      screen.getByRole('heading', { name: /No profile for this account/i }),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/does not have an ABStrack profile yet/i),
+    ).toBeTruthy();
+    expectLogoutPostForm();
+  });
+
+  it('shows wrong_app_role copy and POST /api/auth/logout form', () => {
+    mockedUseAuth.mockReturnValue({
+      session: sessionWithToken(),
+      loading: false,
+      profile: patientProfileRow,
+      profileError: null,
+      accessTokenClaims: null,
+      gate: { kind: 'wrong_app_role', appRole: 'patient' },
+    });
+
+    renderPage();
+
+    expect(
+      screen.getByRole('heading', { name: /Wrong account type for this app/i }),
+    ).toBeTruthy();
+    expect(screen.getByText(/healthcare practitioners/i)).toBeTruthy();
+    expect(screen.getByText('patient')).toBeTruthy();
+    expectLogoutPostForm();
   });
 
   it('resolves @abstrack/supabase types', () => {

--- a/apps/practitioner/specs/index.spec.tsx
+++ b/apps/practitioner/specs/index.spec.tsx
@@ -4,7 +4,11 @@ import Page from '../src/app/page';
 import type { PractitionerSupabaseProfilesRow } from '../src/lib/supabase-wiring';
 
 jest.mock('../src/lib/auth-provider', () => ({
-  useAuth: () => ({ session: null, loading: false }),
+  useAuth: () => ({
+    session: null,
+    loading: false,
+    gate: { kind: 'signed_out' as const },
+  }),
 }));
 
 /** Home page calls `getSupabaseBrowserClient()` on mount; env-public throws without URL + key. */

--- a/apps/practitioner/src/app/page.tsx
+++ b/apps/practitioner/src/app/page.tsx
@@ -81,7 +81,7 @@ async function otpauthUriToQrPngDataUrl(otpauthUri: string): Promise<string> {
 export default function Index() {
   const supabase = useMemo(() => getSupabaseBrowserClient(), []);
   const { announce } = useAnnounce();
-  const { session, loading: authLoading } = useAuth();
+  const { session, loading: sessionLoading, gate } = useAuth();
 
   const [isLoading, setIsLoading] = useState(true);
   const [isEnrolling, setIsEnrolling] = useState(false);
@@ -122,7 +122,7 @@ export default function Index() {
   };
 
   useEffect(() => {
-    if (authLoading) {
+    if (sessionLoading) {
       return;
     }
 
@@ -154,7 +154,7 @@ export default function Index() {
     };
 
     void load();
-  }, [session, authLoading]);
+  }, [session, sessionLoading]);
 
   const startEnrollment = async () => {
     const isAuthenticated = Boolean(session?.access_token);
@@ -308,9 +308,9 @@ export default function Index() {
   };
 
   const isAuthenticated = Boolean(session?.access_token);
-  const showLoadingState = authLoading || isLoading;
+  const showLoadingState = sessionLoading || isLoading;
 
-  if (authLoading) {
+  if (sessionLoading) {
     return (
       <div
         id="practitioner-home"
@@ -353,6 +353,92 @@ export default function Index() {
     );
   }
 
+  if (gate.kind === 'profile_error') {
+    return (
+      <div
+        id="practitioner-home"
+        className="mx-auto max-w-lg px-4 py-12 sm:px-6"
+        role="alert"
+      >
+        <h1 className="text-xl font-semibold text-app-ink">
+          Could not load your profile
+        </h1>
+        <p className="mt-3 text-sm text-app-muted">
+          {gate.error.message}. You can try signing out and back in, or try
+          again later.
+        </p>
+        <form action="/api/auth/logout" method="POST" className="mt-6">
+          <button
+            type="submit"
+            className="min-h-11 rounded-md border border-app-border bg-app-surface px-4 py-2 text-sm font-medium text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          >
+            Log out
+          </button>
+        </form>
+      </div>
+    );
+  }
+
+  if (gate.kind === 'profile_missing') {
+    return (
+      <div
+        id="practitioner-home"
+        className="mx-auto max-w-lg px-4 py-12 sm:px-6"
+        role="alert"
+      >
+        <h1 className="text-xl font-semibold text-app-ink">
+          No profile for this account
+        </h1>
+        <p className="mt-3 text-sm text-app-muted">
+          This sign-in does not have an ABStrack profile yet. Practitioner
+          accounts must be created through the correct invitation flow.
+        </p>
+        <form action="/api/auth/logout" method="POST" className="mt-6">
+          <button
+            type="submit"
+            className="min-h-11 rounded-md border border-app-border bg-app-surface px-4 py-2 text-sm font-medium text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          >
+            Log out
+          </button>
+        </form>
+      </div>
+    );
+  }
+
+  if (gate.kind === 'wrong_app_role') {
+    return (
+      <div
+        id="practitioner-home"
+        className="mx-auto max-w-lg px-4 py-12 sm:px-6"
+        role="alert"
+      >
+        <h1 className="text-xl font-semibold text-app-ink">
+          Wrong account type for this app
+        </h1>
+        <p className="mt-3 text-sm text-app-muted">
+          This app is for healthcare practitioners. Your account is registered
+          as <span className="font-medium text-app-ink">{gate.appRole}</span>.
+          Use the patient or caretaker app instead.
+        </p>
+        <p className="mt-3 text-sm text-app-muted">
+          Sign out to use a different account, or open the patient or caretaker
+          app.
+        </p>
+        <form action="/api/auth/logout" method="POST" className="mt-6">
+          <button
+            type="submit"
+            className="min-h-11 rounded-md border border-app-border bg-app-surface px-4 py-2 text-sm font-medium text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          >
+            Log out
+          </button>
+        </form>
+      </div>
+    );
+  }
+
+  const mfaAssuranceReady =
+    gate.kind === 'practitioner' && gate.hasMfaAssuranceAal2;
+
   return (
     <div id="practitioner-home" className="mx-auto max-w-2xl px-4 py-8 sm:px-6">
       <header className="mb-6">
@@ -362,6 +448,16 @@ export default function Index() {
         <p className="mt-2 text-sm text-app-muted">
           Enroll at least one TOTP factor to make this practitioner account
           MFA-ready.
+          {mfaAssuranceReady ? (
+            <span className="mt-2 block text-emerald-800 dark:text-emerald-200">
+              Current session has MFA assurance (AAL2) for patient-data access.
+            </span>
+          ) : (
+            <span className="mt-2 block">
+              After you verify TOTP, complete a challenge when prompted so your
+              session reaches AAL2 — required for patient data access.
+            </span>
+          )}
         </p>
         {userEmail ? (
           <p

--- a/apps/practitioner/src/app/page.tsx
+++ b/apps/practitioner/src/app/page.tsx
@@ -122,6 +122,13 @@ export default function Index() {
   };
 
   useEffect(() => {
+    if (gate.kind !== 'profile_error') {
+      return;
+    }
+    console.error('Practitioner profile load failed', gate.error);
+  }, [gate]);
+
+  useEffect(() => {
     if (sessionLoading) {
       return;
     }
@@ -375,8 +382,8 @@ export default function Index() {
           Could not load your profile
         </h1>
         <p className="mt-3 text-sm text-app-muted">
-          {gate.error.message}. You can try signing out and back in, or try
-          again later.
+          Something went wrong while loading your account. Try signing out and
+          signing in again. If this keeps happening, try again later.
         </p>
         <form action="/api/auth/logout" method="POST" className="mt-6">
           <button

--- a/apps/practitioner/src/app/page.tsx
+++ b/apps/practitioner/src/app/page.tsx
@@ -140,6 +140,17 @@ export default function Index() {
         return;
       }
 
+      // Only list MFA factors for practitioner profiles; avoid API + SR noise on error gates.
+      if (gate.kind !== 'practitioner') {
+        setEnrollment(null);
+        setVerifyCode('');
+        setVerifyFailureMessage(null);
+        setVerifiedTotpCount(0);
+        setStatusMessage(null);
+        setIsLoading(false);
+        return;
+      }
+
       try {
         await refreshMfaState();
       } catch (error) {
@@ -154,7 +165,7 @@ export default function Index() {
     };
 
     void load();
-  }, [session, sessionLoading]);
+  }, [session, sessionLoading, gate.kind]);
 
   const startEnrollment = async () => {
     const isAuthenticated = Boolean(session?.access_token);

--- a/apps/practitioner/src/lib/auth-provider.tsx
+++ b/apps/practitioner/src/lib/auth-provider.tsx
@@ -1,5 +1,14 @@
 'use client';
 
+import {
+  fetchProfileByUserId,
+  parseAbstrackAccessTokenClaims,
+  resolvePractitionerAppGate,
+  type AbstrackAccessTokenClaims,
+  type Database,
+  type PractitionerAppGate,
+  type Session,
+} from '@abstrack/supabase';
 import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
 import {
   createContext,
@@ -10,12 +19,21 @@ import {
   type ReactNode,
 } from 'react';
 
+type ProfileRow = Database['public']['Tables']['profiles']['Row'];
+
 interface AuthContextType {
-  session: {
-    user: { id: string; email?: string };
-    access_token?: string;
-  } | null;
+  session: Session | null;
+  /**
+   * True while initial auth is resolving or, when signed in, while the profile row is loading.
+   */
   loading: boolean;
+  /** Own profile row: undefined = not loaded yet; null = no row or load failed without error object. */
+  profile: ProfileRow | null | undefined;
+  profileError: Error | null;
+  /** Claims from the current access token (signature not verified locally). */
+  accessTokenClaims: AbstrackAccessTokenClaims | null;
+  /** Normalized gate for practitioner routing (role from DB, MFA from JWT `aal`). */
+  gate: PractitionerAppGate;
 }
 
 const AuthContext = createContext<AuthContextType | null>(null);
@@ -42,15 +60,41 @@ function isRefreshTokenFailure(error: unknown): boolean {
 }
 
 /**
- * Provides practitioner auth session state from Supabase browser auth.
+ * Provides practitioner auth session state, `profiles.app_role`, and JWT claim metadata from
+ * Supabase browser auth. See `docs/AUTH_CLAIM_CONTRACT.md`.
  *
  * @param props - Wrapper props.
- * @returns Context provider with session and loading state.
+ * @returns Context provider with session, profile, and loading state.
  */
 export function AuthProvider({ children }: { children: ReactNode }) {
   const supabase = useMemo(() => getSupabaseBrowserClient(), []);
-  const [session, setSession] = useState<AuthContextType['session']>(null);
-  const [loading, setLoading] = useState(true);
+  const [session, setSession] = useState<Session | null>(null);
+  const [authLoading, setAuthLoading] = useState(true);
+  const [profile, setProfile] = useState<ProfileRow | null | undefined>(
+    undefined,
+  );
+  const [profileError, setProfileError] = useState<Error | null>(null);
+
+  const accessTokenClaims = useMemo(
+    () => parseAbstrackAccessTokenClaims(session?.access_token),
+    [session?.access_token],
+  );
+
+  const gate = useMemo(
+    () =>
+      resolvePractitionerAppGate({
+        hasSession: Boolean(session?.user),
+        profile,
+        profileError,
+        accessTokenClaims,
+      }),
+    [session?.user, profile, profileError, accessTokenClaims],
+  );
+
+  const identityLoading =
+    Boolean(session?.user) && profile === undefined && profileError === null;
+
+  const loading = authLoading || identityLoading;
 
   useEffect(() => {
     let mounted = true;
@@ -108,7 +152,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           clearTimeout(timeoutId);
         }
         if (mounted) {
-          setLoading(false);
+          setAuthLoading(false);
         }
       }
     };
@@ -127,11 +171,62 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     };
   }, [supabase]);
 
-  return (
-    <AuthContext.Provider value={{ session, loading }}>
-      {children}
-    </AuthContext.Provider>
+  useEffect(() => {
+    const userId = session?.user?.id;
+    if (!userId) {
+      setProfile(undefined);
+      setProfileError(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadProfile = async () => {
+      setProfile(undefined);
+      setProfileError(null);
+      const { data, error } = await fetchProfileByUserId(supabase, userId);
+      if (cancelled) {
+        return;
+      }
+      if (error) {
+        const err =
+          error instanceof Error
+            ? error
+            : new Error(
+                typeof error === 'object' &&
+                error !== null &&
+                'message' in error &&
+                typeof (error as { message: unknown }).message === 'string'
+                  ? (error as { message: string }).message
+                  : 'Profile request failed',
+              );
+        setProfileError(err);
+        setProfile(null);
+        return;
+      }
+      setProfile(data ?? null);
+    };
+
+    void loadProfile();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [session?.user?.id, supabase]);
+
+  const value = useMemo(
+    () => ({
+      session,
+      loading,
+      profile,
+      profileError,
+      accessTokenClaims,
+      gate,
+    }),
+    [session, loading, profile, profileError, accessTokenClaims, gate],
   );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
 /**

--- a/docs/AUTH_CLAIM_CONTRACT.md
+++ b/docs/AUTH_CLAIM_CONTRACT.md
@@ -1,0 +1,47 @@
+# Auth claim contract (ABStrack)
+
+This document defines **which identity fields** ABStrack uses for **routing**, **UI gating**, and how they relate to **database enforcement** (RLS and Edge Functions). It exists so client, server, and policy layers stay aligned and **do not rely on ambiguous JWT hook behavior** for security guarantees.
+
+## Two different “roles”
+
+| Field                 | Where it lives                                                          | Purpose                                                                                                                                    |
+| --------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Application role**  | `public.profiles.app_role` (`patient` \| `caretaker` \| `practitioner`) | Product routing: which app and which flows apply. **Source of truth is Postgres**, selected under RLS as the authenticated user’s own row. |
+| **Supabase API role** | JWT claim `role` (`authenticated` \| `anon` \| `service_role`)          | Supabase Auth / PostgREST role. **Not** the same as `profiles.app_role`. Do **not** use JWT `role` for application routing.                |
+
+Self-service signup can only create `patient` or `caretaker` profiles; `practitioner` requires a trusted path (see migrations on `profiles_enforce_app_role`).
+
+## JWT claims used by ABStrack
+
+Access tokens are standard Supabase Auth JWTs. The following claims are **intentionally** used in code and/or SQL:
+
+| Claim  | Use                                                                                                                                                                                                                                      |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sub`  | Auth user id (matches `profiles.id`).                                                                                                                                                                                                    |
+| `role` | Supabase API role only (see above).                                                                                                                                                                                                      |
+| `aal`  | **Authenticator assurance level.** For practitioner access to patient data, RLS requires `aal` **exactly** `'aal2'` inside `user_has_practitioner_access` (see `supabase/migrations/20260416120000_practitioner_mfa_assurance_rls.sql`). |
+| `amr`  | Optional diagnostic context (Supabase); not used for authorization logic in-repo today.                                                                                                                                                  |
+
+### MFA assurance (practitioner)
+
+- **Client / UI:** `parseAbstrackAccessTokenClaims` + `hasMfaAssuranceAal2` in `@abstrack/supabase` treat **only** `aal === 'aal2'` as MFA-ready. Missing `aal` or any other value is **false** (no fail-open default to password-only).
+- **Database:** Practitioner grant path enforces the same predicate in SQL; if a grant exists but `aal` is not `aal2`, the function **raises** `42501` (fail-closed), not a silent empty result.
+- **Edge Function:** `practitioner-mfa-auth-audit` validates session via Auth API and inspects JWT `aal` for auditing; RLS remains the primary control.
+
+## What we do not rely on for authorization
+
+- **Custom access-token hooks** that inject `app_role` or MFA claims: even if present, **enforcement** does not depend on hooks alone, because hooks can fail in ways that omit claims (PRD: no hook-only reliance for practitioner MFA).
+- **JWT `role` = `authenticated`** as proof of application role: it only means “logged in to Supabase.”
+
+## Shared helpers
+
+| Export                           | Package              | Role                                                                                                     |
+| -------------------------------- | -------------------- | -------------------------------------------------------------------------------------------------------- |
+| `parseAbstrackAccessTokenClaims` | `@abstrack/supabase` | Decode JWT payload for `aal` / `role` (after Supabase has already issued the session).                   |
+| `resolvePractitionerAppGate`     | `@abstrack/supabase` | Combine session + `profiles` row + claims into a single discriminated gate for the practitioner web app. |
+| `fetchProfileByUserId`           | `@abstrack/supabase` | Load `profiles.app_role` for routing.                                                                    |
+
+## Related documents
+
+- [PRD: Two-factor authentication (TOTP)](PRD.md#two-factor-authentication-totp) — practitioner MFA expectations.
+- [SECURITY_BASELINE.md](SECURITY_BASELINE.md) — control inventory and traceability.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -80,7 +80,7 @@
 
 - [x] TOTP setup flow for practitioners via Supabase Auth MFA API (mandatory for practitioners)
 - [x] Practitioner MFA **fail-closed** per [PRD](PRD.md): RLS and/or **Edge Function** (or equivalent) verifies MFA via Auth APIs before patient-data reads; hooks alone must not be the sole control if they can fail open
-- [ ] JWT claims / role metadata for routing; practitioner patient-data access must satisfy MFA rules in policy or server path
+- [x] JWT claims / role metadata for routing; practitioner patient-data access must satisfy MFA rules in policy or server path
 - [ ] Frontend MFA gating in practitioner app (no patient routes until MFA verified)
 
 **Second half (April 16-19, school finished):**

--- a/docs/SECURITY_BASELINE.md
+++ b/docs/SECURITY_BASELINE.md
@@ -12,18 +12,18 @@ This document summarizes the repository security posture, points to implementati
 
 ## Security Posture at a Glance
 
-| Control                                                               | Current Status                 | Where Defined / Implemented                                                                                                                                                                            |
-| --------------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| TLS for client to Supabase traffic                                    | Implemented                    | [PRD: Architecture](PRD.md#architecture-overview) + [Security](PRD.md#security-privacy-and-compliance), Supabase platform/API model                                                                    |
-| RLS for PHI tables                                                    | Implemented                    | `supabase/migrations/20260327130000_rls_policies.sql`                                                                                                                                                  |
-| Grant-table authorization (`practitioner_access`, `caretaker_access`) | Implemented                    | `supabase/migrations/20260327120000_abstrack_core_schema.sql`, `supabase/migrations/20260327130000_rls_policies.sql`                                                                                   |
-| Append-only `access_log` with trusted insert path                     | Implemented                    | `supabase/migrations/20260327120000_abstrack_core_schema.sql`, `supabase/migrations/20260327130000_rls_policies.sql`                                                                                   |
-| Auth (email/password, persistent session, password reset/change)      | Implemented                    | `packages/supabase/src/lib/auth.ts`, app auth screens/providers                                                                                                                                        |
-| Practitioner MFA enforcement (fail-closed)                            | Planned (Week 5)               | [PRD: Authentication](PRD.md#1-authentication) + [Security](PRD.md#security-privacy-and-compliance); [roadmap Week 5](ROADMAP.md#week-5-april-13-19----auth-completion-and-episode-logging-foundation) |
-| Media bucket privacy + `storage.objects` RLS                          | Implemented                    | `supabase/migrations/20260328100000_episode_media_storage_bucket.sql`                                                                                                                                  |
-| Media access via signed URLs                                          | Planned for app flow (Week 7)  | [PRD §10](PRD.md#10-video--photo-capture) + [roadmap Week 7](ROADMAP.md#week-7-april-27---may-3----media-capture-and-offline-sync)                                                                     |
-| Data model: plaintext PHI under RLS (no app-layer E2E encryption)     | Implemented as design baseline | [PRD: Security](PRD.md#security-privacy-and-compliance) + [data model](PRD.md#data-model-plaintext-phi-in-supabase-under-rls); schema comments in core migration                                       |
-| PowerSync + SQLCipher offline protections                             | Planned (Week 7)               | [PRD: Architecture](PRD.md#architecture-overview)/[Security](PRD.md#security-privacy-and-compliance) and [roadmap Week 7](ROADMAP.md#week-7-april-27---may-3----media-capture-and-offline-sync)        |
+| Control                                                               | Current Status                                      | Where Defined / Implemented                                                                                                                                                                                                                           |
+| --------------------------------------------------------------------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| TLS for client to Supabase traffic                                    | Implemented                                         | [PRD: Architecture](PRD.md#architecture-overview) + [Security](PRD.md#security-privacy-and-compliance), Supabase platform/API model                                                                                                                   |
+| RLS for PHI tables                                                    | Implemented                                         | `supabase/migrations/20260327130000_rls_policies.sql`                                                                                                                                                                                                 |
+| Grant-table authorization (`practitioner_access`, `caretaker_access`) | Implemented                                         | `supabase/migrations/20260327120000_abstrack_core_schema.sql`, `supabase/migrations/20260327130000_rls_policies.sql`                                                                                                                                  |
+| Append-only `access_log` with trusted insert path                     | Implemented                                         | `supabase/migrations/20260327120000_abstrack_core_schema.sql`, `supabase/migrations/20260327130000_rls_policies.sql`                                                                                                                                  |
+| Auth (email/password, persistent session, password reset/change)      | Implemented                                         | `packages/supabase/src/lib/auth.ts`, app auth screens/providers                                                                                                                                                                                       |
+| Practitioner MFA enforcement (fail-closed)                            | Implemented (RLS + helpers; UI uses claim contract) | [PRD: Authentication](PRD.md#1-authentication); [AUTH_CLAIM_CONTRACT.md](AUTH_CLAIM_CONTRACT.md); `supabase/migrations/20260416120000_practitioner_mfa_assurance_rls.sql`; `packages/supabase/src/lib/session-claims.ts`; practitioner `AuthProvider` |
+| Media bucket privacy + `storage.objects` RLS                          | Implemented                                         | `supabase/migrations/20260328100000_episode_media_storage_bucket.sql`                                                                                                                                                                                 |
+| Media access via signed URLs                                          | Planned for app flow (Week 7)                       | [PRD §10](PRD.md#10-video--photo-capture) + [roadmap Week 7](ROADMAP.md#week-7-april-27---may-3----media-capture-and-offline-sync)                                                                                                                    |
+| Data model: plaintext PHI under RLS (no app-layer E2E encryption)     | Implemented as design baseline                      | [PRD: Security](PRD.md#security-privacy-and-compliance) + [data model](PRD.md#data-model-plaintext-phi-in-supabase-under-rls); schema comments in core migration                                                                                      |
+| PowerSync + SQLCipher offline protections                             | Planned (Week 7)                                    | [PRD: Architecture](PRD.md#architecture-overview)/[Security](PRD.md#security-privacy-and-compliance) and [roadmap Week 7](ROADMAP.md#week-7-april-27---may-3----media-capture-and-offline-sync)                                                       |
 
 ## Control Details
 
@@ -68,7 +68,7 @@ This document summarizes the repository security posture, points to implementati
   - Helper functions `user_has_practitioner_access` and `user_is_caretaker_for_patient` are used across PHI and storage policies.
 - PRD references:
   - [PRD: Users & Roles](PRD.md#users--roles), [Authorized access](PRD.md#authorized-access-practitioners-and-caretakers-no-dek-sharing), and RLS requirements table.
-- Status: Implemented. Practitioner MFA check in the practitioner path is planned for Week 5.
+- Status: Implemented. Practitioner MFA assurance is enforced in SQL on the grant path; client routing uses `profiles.app_role` plus JWT `aal` per [AUTH_CLAIM_CONTRACT.md](AUTH_CLAIM_CONTRACT.md) (no ambiguous fallbacks).
 
 ### 4) `access_log`: append-only audit logging with trusted insert path
 
@@ -104,11 +104,11 @@ This document summarizes the repository security posture, points to implementati
     - `apps/mobile/src/app/screens/HomeScreen.tsx`
     - `apps/web/src/app/dashboard/page.tsx`
 - Planned:
-  - Practitioner MFA fail-closed enforcement path (Week 5).
+  - Additional practitioner app routes gated on MFA readiness (see [ROADMAP](ROADMAP.md)).
 - PRD references:
   - [PRD §1: Authentication](PRD.md#1-authentication).
   - [PRD: Practitioner TOTP enforcement (fail-closed)](PRD.md#two-factor-authentication-totp).
-- Status: Week 3 auth baseline implemented; practitioner MFA controls planned for Week 5.
+- Status: Week 3 auth baseline implemented; practitioner MFA enforcement and claim contract documented in [AUTH_CLAIM_CONTRACT.md](AUTH_CLAIM_CONTRACT.md).
 
 ### 6) Media storage security
 
@@ -150,7 +150,7 @@ Implemented now:
 
 Planned (not yet complete):
 
-- Practitioner MFA fail-closed enforcement hardening (Week 5).
+- Practitioner app navigation to patient-data routes behind explicit MFA-ready UI checks (beyond security setup page).
 - PowerSync + SQLCipher offline model implementation (Week 7).
 - Signed URL media playback/download flow completion in product UX and offline queue flow (Week 7).
 
@@ -173,4 +173,5 @@ Core implementation artifacts:
 Primary design references:
 
 - [docs/PRD.md](PRD.md) (Security, Authentication, and Media sections)
+- [docs/AUTH_CLAIM_CONTRACT.md](AUTH_CLAIM_CONTRACT.md) (JWT + `profiles.app_role` contract)
 - [docs/ROADMAP.md](ROADMAP.md) (Week 3, Week 5, Week 7)

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -28,6 +28,16 @@ export {
   fetchProfileByUserId,
   healthCheckProfilesLimit1,
 } from './lib/queries.js';
+export type {
+  AbstrackAccessTokenClaims,
+  PractitionerAppGate,
+} from './lib/session-claims.js';
+export {
+  hasMfaAssuranceAal2,
+  parseAbstrackAccessTokenClaims,
+  parseProfileAppRole,
+  resolvePractitionerAppGate,
+} from './lib/session-claims.js';
 export type { PresetDataErrorCode } from './lib/preset-data-error.js';
 export {
   PresetDataError,

--- a/packages/supabase/src/lib/session-claims.spec.ts
+++ b/packages/supabase/src/lib/session-claims.spec.ts
@@ -36,6 +36,26 @@ describe('parseAbstrackAccessTokenClaims', () => {
     expect(claims?.role).toBe('authenticated');
     expect(claims?.sub).toBe('11111111-1111-1111-1111-111111111111');
   });
+
+  it('returns null when neither atob nor Buffer is available', () => {
+    const token = makeUnsignedJwt({ aal: 'aal2' });
+    const prevAtob = globalThis.atob;
+    const prevBuffer = globalThis.Buffer;
+    try {
+      // @ts-expect-error delete atob to simulate RN/Hermes without a web base64 decoder
+      delete globalThis.atob;
+      // @ts-expect-error delete Buffer to simulate RN/Hermes without Node base64
+      delete globalThis.Buffer;
+      expect(parseAbstrackAccessTokenClaims(token)).toBeNull();
+    } finally {
+      if (prevAtob !== undefined) {
+        globalThis.atob = prevAtob;
+      }
+      if (prevBuffer !== undefined) {
+        globalThis.Buffer = prevBuffer;
+      }
+    }
+  });
 });
 
 describe('hasMfaAssuranceAal2', () => {
@@ -76,6 +96,39 @@ describe('resolvePractitionerAppGate', () => {
         accessTokenClaims: null,
       }),
     ).toEqual({ kind: 'profile_loading' });
+  });
+
+  it('returns profile_error when profile lookup failed (even while profile is still undefined)', () => {
+    const err = new Error('network');
+    const gate = resolvePractitionerAppGate({
+      hasSession: true,
+      profile: undefined,
+      profileError: err,
+      accessTokenClaims: null,
+    });
+    expect(gate).toEqual({ kind: 'profile_error', error: err });
+  });
+
+  it('returns profile_missing when session exists but profile row is absent', () => {
+    expect(
+      resolvePractitionerAppGate({
+        hasSession: true,
+        profile: null,
+        profileError: null,
+        accessTokenClaims: { aal: 'aal2' },
+      }),
+    ).toEqual({ kind: 'profile_missing' });
+  });
+
+  it('returns profile_missing when app_role is not a canonical value', () => {
+    expect(
+      resolvePractitionerAppGate({
+        hasSession: true,
+        profile: { app_role: 'not_a_valid_role' },
+        profileError: null,
+        accessTokenClaims: null,
+      }),
+    ).toEqual({ kind: 'profile_missing' });
   });
 
   it('returns wrong_app_role for non-practitioner profiles', () => {

--- a/packages/supabase/src/lib/session-claims.spec.ts
+++ b/packages/supabase/src/lib/session-claims.spec.ts
@@ -49,20 +49,33 @@ describe('parseAbstrackAccessTokenClaims', () => {
 
   it('returns null when neither atob nor Buffer is available', () => {
     const token = makeUnsignedJwt({ aal: 'aal2' });
-    const prevAtob = globalThis.atob;
-    const prevBuffer = globalThis.Buffer;
+    const atobDesc = Object.getOwnPropertyDescriptor(globalThis, 'atob');
+    const bufferDesc = Object.getOwnPropertyDescriptor(globalThis, 'Buffer');
     try {
-      // @ts-expect-error delete atob to simulate RN/Hermes without a web base64 decoder
-      delete globalThis.atob;
-      // @ts-expect-error delete Buffer to simulate RN/Hermes without Node base64
-      delete globalThis.Buffer;
+      // Stub away decoders (delete can be a no-op when non-configurable; defineProperty is reliable).
+      Object.defineProperty(globalThis, 'atob', {
+        value: undefined,
+        configurable: true,
+        enumerable: atobDesc?.enumerable ?? false,
+        writable: true,
+      });
+      Object.defineProperty(globalThis, 'Buffer', {
+        value: undefined,
+        configurable: true,
+        enumerable: bufferDesc?.enumerable ?? false,
+        writable: true,
+      });
       expect(parseAbstrackAccessTokenClaims(token)).toBeNull();
     } finally {
-      if (prevAtob !== undefined) {
-        globalThis.atob = prevAtob;
+      if (atobDesc) {
+        Object.defineProperty(globalThis, 'atob', atobDesc);
+      } else {
+        Reflect.deleteProperty(globalThis, 'atob');
       }
-      if (prevBuffer !== undefined) {
-        globalThis.Buffer = prevBuffer;
+      if (bufferDesc) {
+        Object.defineProperty(globalThis, 'Buffer', bufferDesc);
+      } else {
+        Reflect.deleteProperty(globalThis, 'Buffer');
       }
     }
   });

--- a/packages/supabase/src/lib/session-claims.spec.ts
+++ b/packages/supabase/src/lib/session-claims.spec.ts
@@ -37,6 +37,16 @@ describe('parseAbstrackAccessTokenClaims', () => {
     expect(claims?.sub).toBe('11111111-1111-1111-1111-111111111111');
   });
 
+  it('decodes UTF-8 claim values in the JWT payload (not Latin-1)', () => {
+    const token = makeUnsignedJwt({
+      aal: 'aal2',
+      email: 'tëst@example.com',
+    });
+    const claims = parseAbstrackAccessTokenClaims(token);
+    expect(claims?.aal).toBe('aal2');
+    expect(claims?.email).toBe('tëst@example.com');
+  });
+
   it('returns null when neither atob nor Buffer is available', () => {
     const token = makeUnsignedJwt({ aal: 'aal2' });
     const prevAtob = globalThis.atob;

--- a/packages/supabase/src/lib/session-claims.spec.ts
+++ b/packages/supabase/src/lib/session-claims.spec.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hasMfaAssuranceAal2,
+  parseAbstrackAccessTokenClaims,
+  parseProfileAppRole,
+  resolvePractitionerAppGate,
+} from './session-claims.js';
+
+function makeUnsignedJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(
+    JSON.stringify({ alg: 'none', typ: 'JWT' }),
+    'utf8',
+  ).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload), 'utf8').toString(
+    'base64url',
+  );
+  return `${header}.${body}.sig`;
+}
+
+describe('parseAbstrackAccessTokenClaims', () => {
+  it('returns null for empty or malformed tokens', () => {
+    expect(parseAbstrackAccessTokenClaims(undefined)).toBeNull();
+    expect(parseAbstrackAccessTokenClaims('')).toBeNull();
+    expect(parseAbstrackAccessTokenClaims('not-a-jwt')).toBeNull();
+    expect(parseAbstrackAccessTokenClaims('a.b')).toBeNull();
+  });
+
+  it('decodes aal and role from a valid JWT-shaped string', () => {
+    const token = makeUnsignedJwt({
+      aal: 'aal2',
+      role: 'authenticated',
+      sub: '11111111-1111-1111-1111-111111111111',
+    });
+    const claims = parseAbstrackAccessTokenClaims(token);
+    expect(claims?.aal).toBe('aal2');
+    expect(claims?.role).toBe('authenticated');
+    expect(claims?.sub).toBe('11111111-1111-1111-1111-111111111111');
+  });
+});
+
+describe('hasMfaAssuranceAal2', () => {
+  it('is true only for exact aal2', () => {
+    expect(hasMfaAssuranceAal2(null)).toBe(false);
+    expect(hasMfaAssuranceAal2({})).toBe(false);
+    expect(hasMfaAssuranceAal2({ aal: 'aal1' })).toBe(false);
+    expect(hasMfaAssuranceAal2({ aal: 'aal2' })).toBe(true);
+  });
+});
+
+describe('parseProfileAppRole', () => {
+  it('accepts canonical roles only', () => {
+    expect(parseProfileAppRole('practitioner')).toBe('practitioner');
+    expect(parseProfileAppRole('invalid')).toBeNull();
+    expect(parseProfileAppRole(null)).toBeNull();
+  });
+});
+
+describe('resolvePractitionerAppGate', () => {
+  it('returns signed_out without session', () => {
+    expect(
+      resolvePractitionerAppGate({
+        hasSession: false,
+        profile: { app_role: 'practitioner' },
+        profileError: null,
+        accessTokenClaims: { aal: 'aal2' },
+      }),
+    ).toEqual({ kind: 'signed_out' });
+  });
+
+  it('returns profile_loading when profile not yet available', () => {
+    expect(
+      resolvePractitionerAppGate({
+        hasSession: true,
+        profile: undefined,
+        profileError: null,
+        accessTokenClaims: null,
+      }),
+    ).toEqual({ kind: 'profile_loading' });
+  });
+
+  it('returns wrong_app_role for non-practitioner profiles', () => {
+    expect(
+      resolvePractitionerAppGate({
+        hasSession: true,
+        profile: { app_role: 'patient' },
+        profileError: null,
+        accessTokenClaims: { aal: 'aal2' },
+      }),
+    ).toEqual({ kind: 'wrong_app_role', appRole: 'patient' });
+  });
+
+  it('returns practitioner with hasMfaAssuranceAal2 from claims (no fallback)', () => {
+    expect(
+      resolvePractitionerAppGate({
+        hasSession: true,
+        profile: { app_role: 'practitioner' },
+        profileError: null,
+        accessTokenClaims: null,
+      }),
+    ).toEqual({
+      kind: 'practitioner',
+      appRole: 'practitioner',
+      hasMfaAssuranceAal2: false,
+    });
+
+    expect(
+      resolvePractitionerAppGate({
+        hasSession: true,
+        profile: { app_role: 'practitioner' },
+        profileError: null,
+        accessTokenClaims: { aal: 'aal2' },
+      }),
+    ).toEqual({
+      kind: 'practitioner',
+      appRole: 'practitioner',
+      hasMfaAssuranceAal2: true,
+    });
+  });
+});

--- a/packages/supabase/src/lib/session-claims.ts
+++ b/packages/supabase/src/lib/session-claims.ts
@@ -38,6 +38,39 @@ export type AbstrackAccessTokenClaims = {
 };
 
 /**
+ * Decodes standard base64 (padded) payload segment bytes to a UTF-8 string.
+ *
+ * JWT payloads are JSON encoded as UTF-8 per RFC 7519; `atob()` alone yields a Latin-1 string
+ * and can mis-handle non-ASCII code points in claim values.
+ *
+ * @param paddedBase64 - Base64-encoded payload (with padding).
+ * @returns UTF-8 JSON text, or null if no decoder is available.
+ */
+function base64PayloadToUtf8String(paddedBase64: string): string | null {
+  try {
+    if (typeof Buffer !== 'undefined' && typeof Buffer.from === 'function') {
+      return Buffer.from(paddedBase64, 'base64').toString('utf8');
+    }
+    if (typeof atob === 'function') {
+      const binary = atob(paddedBase64);
+      const len = binary.length;
+      const bytes = new Uint8Array(len);
+      for (let i = 0; i < len; i++) {
+        bytes[i] = binary.charCodeAt(i) & 0xff;
+      }
+      if (typeof TextDecoder !== 'undefined') {
+        return new TextDecoder('utf-8', { fatal: false }).decode(bytes);
+      }
+      // Very old runtimes: no TextDecoder — ASCII-only JWT JSON still parses; non-ASCII may fail.
+      return binary;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Decodes a JWT access token payload without verifying the signature.
  *
  * Callers MUST only use this on tokens already issued to the Supabase client session; signature
@@ -61,16 +94,8 @@ export function parseAbstrackAccessTokenClaims(
     const pad = (4 - (base64.length % 4)) % 4;
     const padded = base64 + '='.repeat(pad);
 
-    let json: string;
-    if (typeof atob === 'function') {
-      json = atob(padded);
-    } else if (
-      typeof Buffer !== 'undefined' &&
-      typeof Buffer.from === 'function'
-    ) {
-      json = Buffer.from(padded, 'base64').toString('utf8');
-    } else {
-      // Hermes / some runtimes: no atob and no Buffer — fail closed (no claims).
+    const json = base64PayloadToUtf8String(padded);
+    if (json == null) {
       return null;
     }
 

--- a/packages/supabase/src/lib/session-claims.ts
+++ b/packages/supabase/src/lib/session-claims.ts
@@ -1,0 +1,157 @@
+/**
+ * Normalized view of Supabase access-token JWT fields used for ABStrack routing and policy checks.
+ *
+ * **Role split:** `profiles.app_role` (patient | caretaker | practitioner) is the application
+ * role and MUST be read from Postgres for routing decisions. The JWT `role` claim names the
+ * Supabase Auth API role (`authenticated`, `anon`, `service_role`) and MUST NOT be used as
+ * `app_role`. See `docs/AUTH_CLAIM_CONTRACT.md`.
+ */
+
+import { isAppRole, type AppRole } from '@abstrack/types';
+
+/**
+ * Subset of Supabase Auth JWT payload fields relied on by ABStrack client and server code.
+ *
+ * Values are produced by Supabase Auth; we decode the access token payload locally for UI gating.
+ * **Authorization for PHI remains enforced by RLS** (and Edge Functions where applicable), not by
+ * these client-side checks.
+ */
+export type AbstrackAccessTokenClaims = {
+  /** Subject (auth user id). */
+  sub?: string;
+  /** Unix expiry seconds. */
+  exp?: number;
+  /**
+   * Supabase Auth API role (`authenticated`, `anon`, `service_role`).
+   * **Not** `profiles.app_role`; do not use for app routing.
+   */
+  role?: string;
+  /**
+   * Authenticator assurance level from Supabase (`aal1` password-only, `aal2` after MFA step).
+   * Practitioner patient-data paths require `aal2` in RLS (`user_has_practitioner_access`).
+   */
+  aal?: string;
+  /** Authentication methods references (Supabase). */
+  amr?: { method: string; timestamp: number }[];
+  session_id?: string;
+  email?: string;
+};
+
+/**
+ * Decodes a JWT access token payload without verifying the signature.
+ *
+ * Callers MUST only use this on tokens already issued to the Supabase client session; signature
+ * verification is performed by Supabase on refresh and server-side `getUser()` flows.
+ *
+ * @param accessToken - Bearer access token string, or undefined if absent.
+ * @returns Parsed payload fields, or null if malformed.
+ */
+export function parseAbstrackAccessTokenClaims(
+  accessToken: string | undefined,
+): AbstrackAccessTokenClaims | null {
+  if (accessToken == null || accessToken === '') {
+    return null;
+  }
+  const parts = accessToken.split('.');
+  if (parts.length !== 3 || !parts[1]) {
+    return null;
+  }
+  try {
+    const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const pad = (4 - (base64.length % 4)) % 4;
+    const padded = base64 + '='.repeat(pad);
+    const json =
+      typeof atob === 'function'
+        ? atob(padded)
+        : Buffer.from(padded, 'base64').toString('utf8');
+    const raw = JSON.parse(json) as Record<string, unknown>;
+    return raw as AbstrackAccessTokenClaims;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when MFA assurance for the current session is AAL2 (TOTP-verified step completed).
+ *
+ * **Fail-closed:** missing `aal`, unknown values, or null claims yield false — no implicit fallback
+ * to password-only (`aal1`) for practitioner patient-data gates.
+ *
+ * @param claims - Parsed access token claims, or null if unavailable.
+ * @returns Whether `aal === 'aal2'`.
+ */
+export function hasMfaAssuranceAal2(
+  claims: AbstrackAccessTokenClaims | null,
+): boolean {
+  return claims?.aal === 'aal2';
+}
+
+/**
+ * Returns `profiles.app_role` when valid; otherwise null (missing or non-canonical string).
+ *
+ * @param appRole - Raw `profiles.app_role` column value.
+ * @returns Canonical {@link AppRole} or null.
+ */
+export function parseProfileAppRole(
+  appRole: string | null | undefined,
+): AppRole | null {
+  if (appRole == null || appRole === '') {
+    return null;
+  }
+  return isAppRole(appRole) ? appRole : null;
+}
+
+export type PractitionerAppGate =
+  | { kind: 'signed_out' }
+  | { kind: 'profile_loading' }
+  | { kind: 'profile_error'; error: Error }
+  | { kind: 'profile_missing' }
+  | { kind: 'wrong_app_role'; appRole: AppRole }
+  | {
+      kind: 'practitioner';
+      appRole: 'practitioner';
+      hasMfaAssuranceAal2: boolean;
+    };
+
+/**
+ * Single place for practitioner-app routing and UI gating from session + profile + JWT claims.
+ *
+ * - **Application role** comes only from `profiles.app_role` (not from JWT `role` or metadata).
+ * - **MFA readiness** uses JWT `aal === 'aal2'` only; no ambiguous defaults.
+ *
+ * @param input - Session presence, profile row or error state, and parsed claims.
+ * @returns Discriminated gate for navigation and messaging.
+ */
+export function resolvePractitionerAppGate(input: {
+  hasSession: boolean;
+  profile: { app_role: string } | null | undefined;
+  profileError: Error | null;
+  accessTokenClaims: AbstrackAccessTokenClaims | null;
+}): PractitionerAppGate {
+  if (!input.hasSession) {
+    return { kind: 'signed_out' };
+  }
+  if (input.profileError) {
+    return { kind: 'profile_error', error: input.profileError };
+  }
+  if (input.profile === undefined) {
+    return { kind: 'profile_loading' };
+  }
+  if (input.profile === null) {
+    return { kind: 'profile_missing' };
+  }
+
+  const appRole = parseProfileAppRole(input.profile.app_role);
+  if (appRole == null) {
+    return { kind: 'profile_missing' };
+  }
+  if (appRole !== 'practitioner') {
+    return { kind: 'wrong_app_role', appRole };
+  }
+
+  return {
+    kind: 'practitioner',
+    appRole: 'practitioner',
+    hasMfaAssuranceAal2: hasMfaAssuranceAal2(input.accessTokenClaims),
+  };
+}

--- a/packages/supabase/src/lib/session-claims.ts
+++ b/packages/supabase/src/lib/session-claims.ts
@@ -60,10 +60,20 @@ export function parseAbstrackAccessTokenClaims(
     const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
     const pad = (4 - (base64.length % 4)) % 4;
     const padded = base64 + '='.repeat(pad);
-    const json =
-      typeof atob === 'function'
-        ? atob(padded)
-        : Buffer.from(padded, 'base64').toString('utf8');
+
+    let json: string;
+    if (typeof atob === 'function') {
+      json = atob(padded);
+    } else if (
+      typeof Buffer !== 'undefined' &&
+      typeof Buffer.from === 'function'
+    ) {
+      json = Buffer.from(padded, 'base64').toString('utf8');
+    } else {
+      // Hermes / some runtimes: no atob and no Buffer — fail closed (no claims).
+      return null;
+    }
+
     const raw = JSON.parse(json) as Record<string, unknown>;
     return raw as AbstrackAccessTokenClaims;
   } catch {


### PR DESCRIPTION
Closes #69

## Summary

Introduces a stable **auth claim contract** for practitioner routing and MFA awareness, implements it in the practitioner app via profile + JWT metadata, and documents how this aligns with RLS (no hook-only reliance).

## Changes

- **`@abstrack/supabase`:** Adds `parseAbstrackAccessTokenClaims`, `hasMfaAssuranceAal2`, `resolvePractitionerAppGate`, and related types; unit tests in `session-claims.spec.ts`.
- **Practitioner app:** `AuthProvider` loads `profiles` after sign-in, decodes access-token claims, and exposes a discriminated `gate` for routing. Home page handles profile errors, missing profile, and wrong `app_role`, and surfaces AAL2 vs non–AAL2 messaging for practitioners.
- **UX:** Log out (`POST /api/auth/logout`) on gated error states so users stuck on “wrong account type” (or profile errors) can clear the session without manually deleting cookies.
- **Docs:** New `docs/AUTH_CLAIM_CONTRACT.md`; `docs/SECURITY_BASELINE.md` updated to reference the contract and current MFA posture.

## Testing

- `nx test @abstrack/supabase`, `nx test practitioner`, `nx build practitioner` (local).
- Manual: sign in as non-practitioner → wrong-role message + Log out; practitioner → security setup and AAL copy as appropriate.

## Notes

- No migration or `database.types.ts` changes.