### PR TITLE
feat(practitioner): gate patient routes and sign-in on verified MFA (TOTP + AAL2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,7 +59,8 @@ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_your_key
 NEXT_PUBLIC_APP_NAME=ABStrack
 
 # apps/practitioner: MFA device trust (localStorage session bundle). Copy into apps/practitioner/.env.local.
-# Omit or leave empty for default (enabled). Set to false or 0 only to disable.
+# Omit or leave empty for default (enabled). Use true or 1 to enable explicitly; false or 0 to disable.
+# Any other non-empty value is treated as disabled (fail-closed).
 # NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST=false
 
 # --- Expo (apps/mobile) — inlined at bundle time; same values as Next

--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,10 @@ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_your_key
 # Does not replace Supabase Dashboard → Authentication → URL Configuration (Site URL).
 NEXT_PUBLIC_APP_NAME=ABStrack
 
+# apps/practitioner: MFA device trust (localStorage session bundle). Copy into apps/practitioner/.env.local.
+# Omit or leave empty for default (enabled). Set to false or 0 only to disable.
+# NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST=false
+
 # --- Expo (apps/mobile) — inlined at bundle time; same values as Next
 EXPO_PUBLIC_SUPABASE_URL=https://YOUR_PROJECT_REF.supabase.co
 EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_your_key

--- a/apps/practitioner-e2e/src/a11y.spec.ts
+++ b/apps/practitioner-e2e/src/a11y.spec.ts
@@ -43,4 +43,39 @@ test.describe('Accessibility (axe-core)', () => {
         : '',
     ).toEqual([]);
   });
+
+  test('patients gate (signed out) has no axe violations @a11y', async ({
+    page,
+  }, testInfo) => {
+    // eslint-disable-next-line playwright/no-skipped-test -- intentional per-project skip
+    test.skip(
+      testInfo.project.name !== 'chromium',
+      'Axe runs on Chromium only for this suite; adjust if you need per-engine scans.',
+    );
+
+    await page.goto('/patients');
+
+    const gate = page.locator('#practitioner-patient-gate-root');
+    await gate.waitFor({ state: 'visible', timeout: 20_000 });
+
+    const results = await new AxeBuilder({ page })
+      .include('#practitioner-patient-gate-root')
+      .analyze();
+
+    expect(
+      results.violations,
+      results.violations.length
+        ? `axe violations:\n${JSON.stringify(
+            results.violations.map((v) => ({
+              id: v.id,
+              impact: v.impact,
+              description: v.description,
+              nodes: v.nodes.slice(0, 5).map((n) => n.html),
+            })),
+            null,
+            2,
+          )}`
+        : '',
+    ).toEqual([]);
+  });
 });

--- a/apps/practitioner-e2e/src/a11y.spec.ts
+++ b/apps/practitioner-e2e/src/a11y.spec.ts
@@ -57,7 +57,9 @@ test.describe('Accessibility (axe-core)', () => {
 
     // `#practitioner-patient-gate-root` is also used for the loading spinner; wait for the
     // signed-out gate so the scan does not run mid-transition or against spinner markup.
-    const signedOutHeading = page.getByRole('heading', { name: 'Sign in required' });
+    const signedOutHeading = page.getByRole('heading', {
+      name: 'Sign in required',
+    });
     await signedOutHeading.waitFor({ state: 'visible', timeout: 20_000 });
 
     const results = await new AxeBuilder({ page })

--- a/apps/practitioner-e2e/src/a11y.spec.ts
+++ b/apps/practitioner-e2e/src/a11y.spec.ts
@@ -55,8 +55,10 @@ test.describe('Accessibility (axe-core)', () => {
 
     await page.goto('/patients');
 
-    const gate = page.locator('#practitioner-patient-gate-root');
-    await gate.waitFor({ state: 'visible', timeout: 20_000 });
+    // `#practitioner-patient-gate-root` is also used for the loading spinner; wait for the
+    // signed-out gate so the scan does not run mid-transition or against spinner markup.
+    const signedOutHeading = page.getByRole('heading', { name: 'Sign in required' });
+    await signedOutHeading.waitFor({ state: 'visible', timeout: 20_000 });
 
     const results = await new AxeBuilder({ page })
       .include('#practitioner-patient-gate-root')

--- a/apps/practitioner-e2e/src/home.spec.ts
+++ b/apps/practitioner-e2e/src/home.spec.ts
@@ -5,3 +5,14 @@ test('unauthenticated landing shows practitioner heading', async ({ page }) => {
 
   await expect(page.locator('h1')).toContainText('ABStrack Practitioner');
 });
+
+test('unauthenticated patients route shows sign-in gate', async ({ page }) => {
+  await page.goto('/patients');
+
+  await expect(
+    page.getByRole('heading', { name: /Sign in required/i }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('link', { name: /Go to sign in/i }),
+  ).toBeVisible();
+});

--- a/apps/practitioner/specs/index.spec.tsx
+++ b/apps/practitioner/specs/index.spec.tsx
@@ -39,11 +39,8 @@ function renderPage() {
   );
 }
 
-function expectLogoutPostForm() {
-  const form = document.querySelector(
-    'form[action="/api/auth/logout"][method="POST"]',
-  );
-  expect(form).not.toBeNull();
+function expectPractitionerSignOutButton() {
+  expect(screen.getByTestId('practitioner-sign-out')).toBeTruthy();
   expect(screen.getByRole('button', { name: /^Log out$/i })).toBeTruthy();
 }
 
@@ -109,7 +106,7 @@ describe('Page', () => {
     expect(screen.queryByRole('button', { name: /^Log out$/i })).toBeNull();
   });
 
-  it('shows profile_error copy and POST /api/auth/logout form', () => {
+  it('shows profile_error copy and practitioner sign-out control', () => {
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
     mockedUseAuth.mockReturnValue({
       session: sessionWithToken(),
@@ -132,12 +129,12 @@ describe('Page', () => {
       screen.getByText(/Something went wrong while loading your account/i),
     ).toBeTruthy();
     expect(screen.queryByText(/simulated PostgREST failure/i)).toBeNull();
-    expectLogoutPostForm();
+    expectPractitionerSignOutButton();
 
     consoleSpy.mockRestore();
   });
 
-  it('shows profile_missing copy and POST /api/auth/logout form', () => {
+  it('shows profile_missing copy and practitioner sign-out control', () => {
     mockedUseAuth.mockReturnValue({
       session: sessionWithToken(),
       loading: false,
@@ -155,10 +152,10 @@ describe('Page', () => {
     expect(
       screen.getByText(/does not have an ABStrack profile yet/i),
     ).toBeTruthy();
-    expectLogoutPostForm();
+    expectPractitionerSignOutButton();
   });
 
-  it('shows wrong_app_role copy and POST /api/auth/logout form', () => {
+  it('shows wrong_app_role copy and practitioner sign-out control', () => {
     mockedUseAuth.mockReturnValue({
       session: sessionWithToken(),
       loading: false,
@@ -175,7 +172,7 @@ describe('Page', () => {
     ).toBeTruthy();
     expect(screen.getByText(/healthcare practitioners/i)).toBeTruthy();
     expect(screen.getByText('patient')).toBeTruthy();
-    expectLogoutPostForm();
+    expectPractitionerSignOutButton();
   });
 
   it('resolves @abstrack/supabase types', () => {

--- a/apps/practitioner/specs/index.spec.tsx
+++ b/apps/practitioner/specs/index.spec.tsx
@@ -41,7 +41,11 @@ function renderPage() {
 
 function expectPractitionerSignOutButton() {
   expect(screen.getByTestId('practitioner-sign-out')).toBeTruthy();
+  expect(screen.getByTestId('practitioner-sign-out-everywhere')).toBeTruthy();
   expect(screen.getByRole('button', { name: /^Log out$/i })).toBeTruthy();
+  expect(
+    screen.getByRole('button', { name: /^Sign out everywhere$/i }),
+  ).toBeTruthy();
 }
 
 const patientProfileRow: PractitionerSupabaseProfilesRow = {

--- a/apps/practitioner/specs/login-page.spec.tsx
+++ b/apps/practitioner/specs/login-page.spec.tsx
@@ -132,7 +132,7 @@ function createLoginSupabaseMock(options?: {
     access_token: 'access-token',
   };
   const mfaSessionOpts = options?.mfaVerifyGetSession;
-  const getSession = jest.fn().mockResolvedValue({
+  const verifyPhaseGetSessionResult = {
     data: {
       session:
         mfaSessionOpts?.session === undefined
@@ -140,7 +140,21 @@ function createLoginSupabaseMock(options?: {
           : mfaSessionOpts.session,
     },
     error: mfaSessionOpts?.error ?? null,
-  });
+  };
+  /** Login calls `getSession` after `tryRestoreTrustedMfaSession` before MFA; keep that success when verify-phase mocks simulate failure. */
+  const postTrustRestoreGetSessionOk = {
+    data: { session: defaultMfaSession },
+    error: null as const,
+  };
+  const verifyPhaseDiffersFromHealthy =
+    mfaSessionOpts != null &&
+    (mfaSessionOpts.error != null || mfaSessionOpts.session === null);
+  const getSession = verifyPhaseDiffersFromHealthy
+    ? jest
+        .fn()
+        .mockResolvedValueOnce(postTrustRestoreGetSessionOk)
+        .mockResolvedValue(verifyPhaseGetSessionResult)
+    : jest.fn().mockResolvedValue(verifyPhaseGetSessionResult);
   const signOut = jest.fn().mockResolvedValue({ error: null });
 
   const challenge = jest.fn().mockResolvedValue({
@@ -227,15 +241,35 @@ describe('LoginPage MFA state machine', () => {
     mockPush.mockClear();
     mockRefresh.mockClear();
     mockedTryRestore.mockReset();
-    mockedTryRestore.mockResolvedValue(false);
+    mockedTryRestore.mockResolvedValue({ status: 'not_restored' });
     mockedSaveBundle.mockClear();
     mockedClearBundle.mockClear();
     mockedTrustedUntil.mockClear();
     mockedTrustedUntil.mockReturnValue(Date.now() + 86_400_000);
   });
 
+  it('shows message and stays on credentials when trust restore ends session (signed_out)', async () => {
+    mockedTryRestore.mockResolvedValue({ status: 'signed_out' });
+    const { client } = createLoginSupabaseMock({
+      assuranceFirst: { currentLevel: 'aal1', nextLevel: 'aal2' },
+    });
+    mockedGetClient.mockReturnValue(client as never);
+
+    renderLogin();
+    await submitCredentials();
+
+    await waitFor(() => {
+      expect(getVisibleFormError().textContent).toContain(
+        'Your sign-in session ended during the saved device check',
+      );
+    });
+    expect(screen.queryByLabelText(/Authenticator code/i)).toBeNull();
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(client.auth.getSession).not.toHaveBeenCalled();
+  });
+
   it('navigates to /patients when trusted MFA session restores', async () => {
-    mockedTryRestore.mockResolvedValue(true);
+    mockedTryRestore.mockResolvedValue({ status: 'restored' });
     const { client } = createLoginSupabaseMock({
       assuranceFirst: { currentLevel: 'aal1', nextLevel: 'aal2' },
     });
@@ -411,6 +445,78 @@ describe('LoginPage MFA state machine', () => {
       );
     });
     expect(mockPush).not.toHaveBeenCalledWith('/patients');
+  });
+
+  it('returns to credentials when getSession fails after trust restore returns false', async () => {
+    const { client } = createLoginSupabaseMock({
+      assuranceFirst: { currentLevel: 'aal1', nextLevel: 'aal2' },
+    });
+    (client.auth.getSession as jest.Mock).mockResolvedValueOnce({
+      error: { message: 'storage read failed' },
+      data: { session: null },
+    });
+    mockedGetClient.mockReturnValue(client as never);
+
+    renderLogin();
+    await submitCredentials();
+
+    await waitFor(() => {
+      expect(getVisibleFormError().textContent).toContain(
+        'Could not confirm your session after the saved device check',
+      );
+    });
+    expect(screen.queryByLabelText(/Authenticator code/i)).toBeNull();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('returns to credentials when getSession returns no session after trust restore returns false', async () => {
+    const { client } = createLoginSupabaseMock({
+      assuranceFirst: { currentLevel: 'aal1', nextLevel: 'aal2' },
+    });
+    (client.auth.getSession as jest.Mock).mockResolvedValueOnce({
+      error: null,
+      data: { session: null },
+    });
+    mockedGetClient.mockReturnValue(client as never);
+
+    renderLogin();
+    await submitCredentials();
+
+    await waitFor(() => {
+      expect(getVisibleFormError().textContent).toContain(
+        'Your sign-in session ended during the saved device check',
+      );
+    });
+    expect(screen.queryByLabelText(/Authenticator code/i)).toBeNull();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('returns to credentials when session user id differs after trust restore returns false', async () => {
+    const { client } = createLoginSupabaseMock({
+      assuranceFirst: { currentLevel: 'aal1', nextLevel: 'aal2' },
+    });
+    (client.auth.getSession as jest.Mock).mockResolvedValueOnce({
+      error: null,
+      data: {
+        session: {
+          user: { id: '99999999-9999-9999-9999-999999999999' },
+          refresh_token: 'refresh-token',
+          access_token: 'access-token',
+        },
+      },
+    });
+    mockedGetClient.mockReturnValue(client as never);
+
+    renderLogin();
+    await submitCredentials();
+
+    await waitFor(() => {
+      expect(getVisibleFormError().textContent).toContain(
+        'no longer matches this sign-in after the saved device check',
+      );
+    });
+    expect(screen.queryByLabelText(/Authenticator code/i)).toBeNull();
+    expect(mockPush).not.toHaveBeenCalled();
   });
 
   it('shows auth error when password sign-in fails', async () => {

--- a/apps/practitioner/specs/login-page.spec.tsx
+++ b/apps/practitioner/specs/login-page.spec.tsx
@@ -7,8 +7,6 @@ import {
   saveMfaTrustBundle,
   clearMfaTrustBundle,
   getTrustedUntilMsAfterVerification,
-  refreshTrustedMfaBundleBeforePasswordSignIn,
-  readMfaTrustBundle,
 } from '../src/lib/practitioner-device-trust';
 
 jest.mock('@abstrack/supabase/browser', () => ({
@@ -25,10 +23,6 @@ jest.mock('../src/lib/practitioner-device-trust', () => {
     saveMfaTrustBundle: jest.fn(),
     clearMfaTrustBundle: jest.fn(),
     getTrustedUntilMsAfterVerification: jest.fn(() => Date.now() + 86_400_000),
-    refreshTrustedMfaBundleBeforePasswordSignIn: jest
-      .fn()
-      .mockResolvedValue(false),
-    readMfaTrustBundle: jest.fn().mockReturnValue(null),
   };
 });
 
@@ -47,10 +41,6 @@ const mockedTryRestore = jest.mocked(tryRestoreTrustedMfaSession);
 const mockedSaveBundle = jest.mocked(saveMfaTrustBundle);
 const mockedClearBundle = jest.mocked(clearMfaTrustBundle);
 const mockedTrustedUntil = jest.mocked(getTrustedUntilMsAfterVerification);
-const mockedRefreshBeforePassword = jest.mocked(
-  refreshTrustedMfaBundleBeforePasswordSignIn,
-);
-const mockedReadBundle = jest.mocked(readMfaTrustBundle);
 
 const USER_ID = '00000000-0000-0000-0000-000000000042';
 const FACTOR_ID = 'factor-totp-1';
@@ -116,7 +106,7 @@ function createLoginSupabaseMock(options?: {
       access_token: string;
     } | null;
   };
-  /** Access token for default `getSession()` results (e.g. JWT with `aal` for primed fast-path). */
+  /** Access token for default `getSession()` results (e.g. JWT with `aal` for post-verify flows). */
   sessionAccessToken?: string;
 }): { client: { auth: Record<string, unknown> }; mfa: MfaMock } {
   const signInError = options?.signInError ?? null;
@@ -292,10 +282,6 @@ describe('LoginPage MFA state machine', () => {
     mockedClearBundle.mockClear();
     mockedTrustedUntil.mockClear();
     mockedTrustedUntil.mockReturnValue(Date.now() + 86_400_000);
-    mockedRefreshBeforePassword.mockReset();
-    mockedRefreshBeforePassword.mockResolvedValue(false);
-    mockedReadBundle.mockReset();
-    mockedReadBundle.mockReturnValue(null);
   });
 
   it('shows message and stays on credentials when trust restore ends session (signed_out)', async () => {
@@ -332,46 +318,6 @@ describe('LoginPage MFA state machine', () => {
       expect(mockedTryRestore).toHaveBeenCalledWith(expect.anything(), USER_ID);
       expect(mockPush).toHaveBeenCalledWith('/patients');
     });
-    expect(screen.queryByLabelText(/Authenticator code/i)).toBeNull();
-  });
-
-  it('navigates to /patients when bundle was primed and assurance is AAL2 after password', async () => {
-    mockedRefreshBeforePassword.mockResolvedValue(true);
-    const trustedUntil = Date.now() + 86_400_000;
-    mockedReadBundle.mockReturnValue({
-      userId: USER_ID,
-      email: 'doc@example.com',
-      refresh_token: 'r',
-      access_token: 'a',
-      trustedUntilMs: trustedUntil,
-    });
-    const aal2AccessToken = makeUnsignedJwtForTest({
-      aal: 'aal2',
-      sub: USER_ID,
-    });
-    const { client } = createLoginSupabaseMock({
-      assuranceFirst: { currentLevel: 'aal2', nextLevel: 'aal2' },
-      sessionAccessToken: aal2AccessToken,
-    });
-    mockedGetClient.mockReturnValue(client as never);
-
-    renderLogin();
-    await submitCredentials();
-
-    await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/patients');
-    });
-    expect(client.auth.mfa.getAuthenticatorAssuranceLevel).toHaveBeenCalled();
-    expect(mockedTryRestore).not.toHaveBeenCalled();
-    expect(client.auth.mfa.listFactors).not.toHaveBeenCalled();
-    expect(mockedSaveBundle).toHaveBeenCalledWith(
-      expect.objectContaining({
-        user: { id: USER_ID },
-        refresh_token: 'refresh-token',
-        access_token: aal2AccessToken,
-      }),
-      trustedUntil,
-    );
     expect(screen.queryByLabelText(/Authenticator code/i)).toBeNull();
   });
 

--- a/apps/practitioner/specs/login-page.spec.tsx
+++ b/apps/practitioner/specs/login-page.spec.tsx
@@ -55,6 +55,18 @@ const mockedReadBundle = jest.mocked(readMfaTrustBundle);
 const USER_ID = '00000000-0000-0000-0000-000000000042';
 const FACTOR_ID = 'factor-totp-1';
 
+/** Unsigned JWT for tests that need `parseAbstrackAccessTokenClaims` / `aal` (Node `Buffer`). */
+function makeUnsignedJwtForTest(payload: Record<string, unknown>): string {
+  const header = Buffer.from(
+    JSON.stringify({ alg: 'none', typ: 'JWT' }),
+    'utf8',
+  ).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload), 'utf8').toString(
+    'base64url',
+  );
+  return `${header}.${body}.sig`;
+}
+
 type MfaMock = {
   signInWithPassword: jest.Mock;
   getUser: jest.Mock;
@@ -93,6 +105,8 @@ function createLoginSupabaseMock(options?: {
       access_token: string;
     } | null;
   };
+  /** Access token for default `getSession()` results (e.g. JWT with `aal` for primed fast-path). */
+  sessionAccessToken?: string;
 }): { client: { auth: Record<string, unknown> }; mfa: MfaMock } {
   const signInError = options?.signInError ?? null;
   const totpList = options?.listFactors?.totp ?? [
@@ -139,7 +153,7 @@ function createLoginSupabaseMock(options?: {
   const defaultMfaSession = {
     user: { id: USER_ID },
     refresh_token: 'refresh-token',
-    access_token: 'access-token',
+    access_token: options?.sessionAccessToken ?? 'access-token',
   };
   const mfaSessionOpts = options?.mfaVerifyGetSession;
   const verifyPhaseGetSessionResult = {
@@ -236,6 +250,9 @@ async function submitCredentials() {
   fireEvent.click(screen.getByRole('button', { name: /^Sign in$/i }));
 }
 
+const prevLoginPageMfaDeviceTrustEnv =
+  process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'];
+
 describe('LoginPage MFA state machine', () => {
   let consoleErrorSpy: jest.SpyInstance;
 
@@ -246,6 +263,12 @@ describe('LoginPage MFA state machine', () => {
 
   afterAll(() => {
     consoleErrorSpy.mockRestore();
+    if (prevLoginPageMfaDeviceTrustEnv === undefined) {
+      delete process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'];
+    } else {
+      process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'] =
+        prevLoginPageMfaDeviceTrustEnv;
+    }
   });
 
   beforeEach(() => {
@@ -300,7 +323,7 @@ describe('LoginPage MFA state machine', () => {
     expect(screen.queryByLabelText(/Authenticator code/i)).toBeNull();
   });
 
-  it('navigates to /patients when bundle was primed before password and bundle matches user', async () => {
+  it('navigates to /patients when bundle was primed and assurance is AAL2 after password', async () => {
     mockedRefreshBeforePassword.mockResolvedValue(true);
     const trustedUntil = Date.now() + 86_400_000;
     mockedReadBundle.mockReturnValue({
@@ -310,8 +333,13 @@ describe('LoginPage MFA state machine', () => {
       access_token: 'a',
       trustedUntilMs: trustedUntil,
     });
+    const aal2AccessToken = makeUnsignedJwtForTest({
+      aal: 'aal2',
+      sub: USER_ID,
+    });
     const { client } = createLoginSupabaseMock({
-      assuranceFirst: { currentLevel: 'aal1', nextLevel: 'aal2' },
+      assuranceFirst: { currentLevel: 'aal2', nextLevel: 'aal2' },
+      sessionAccessToken: aal2AccessToken,
     });
     mockedGetClient.mockReturnValue(client as never);
 
@@ -321,13 +349,16 @@ describe('LoginPage MFA state machine', () => {
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith('/patients');
     });
+    expect(
+      client.auth.mfa.getAuthenticatorAssuranceLevel,
+    ).toHaveBeenCalled();
     expect(mockedTryRestore).not.toHaveBeenCalled();
     expect(client.auth.mfa.listFactors).not.toHaveBeenCalled();
     expect(mockedSaveBundle).toHaveBeenCalledWith(
       expect.objectContaining({
         user: { id: USER_ID },
         refresh_token: 'refresh-token',
-        access_token: 'access-token',
+        access_token: aal2AccessToken,
       }),
       trustedUntil,
     );

--- a/apps/practitioner/specs/login-page.spec.tsx
+++ b/apps/practitioner/specs/login-page.spec.tsx
@@ -230,6 +230,7 @@ describe('LoginPage MFA state machine', () => {
   let consoleErrorSpy: jest.SpyInstance;
 
   beforeAll(() => {
+    process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'] = 'true';
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
   });
 

--- a/apps/practitioner/specs/login-page.spec.tsx
+++ b/apps/practitioner/specs/login-page.spec.tsx
@@ -74,6 +74,15 @@ function createLoginSupabaseMock(options?: {
   assuranceFirst?: { currentLevel: string; nextLevel: string | null };
   assuranceAfterVerify?: { currentLevel: string; nextLevel: string | null };
   verifyError?: unknown;
+  /** Result of `getSession()` during MFA verify (only call site on this page). */
+  mfaVerifyGetSession?: {
+    error?: { message: string } | null;
+    session?: {
+      user: { id: string };
+      refresh_token: string;
+      access_token: string;
+    } | null;
+  };
 }): { client: { auth: Record<string, unknown> }; mfa: MfaMock } {
   const signInError = options?.signInError ?? null;
   const totpList = options?.listFactors?.totp ?? [
@@ -117,14 +126,20 @@ function createLoginSupabaseMock(options?: {
       data: assuranceAfterVerify,
     });
 
+  const defaultMfaSession = {
+    user: { id: USER_ID },
+    refresh_token: 'refresh-token',
+    access_token: 'access-token',
+  };
+  const mfaSessionOpts = options?.mfaVerifyGetSession;
   const getSession = jest.fn().mockResolvedValue({
     data: {
-      session: {
-        user: { id: USER_ID },
-        refresh_token: 'refresh-token',
-        access_token: 'access-token',
-      },
+      session:
+        mfaSessionOpts?.session === undefined
+          ? defaultMfaSession
+          : mfaSessionOpts.session,
     },
+    error: mfaSessionOpts?.error ?? null,
   });
   const signOut = jest.fn().mockResolvedValue({ error: null });
 
@@ -334,6 +349,68 @@ describe('LoginPage MFA state machine', () => {
 
     expect(mockedClearBundle).toHaveBeenCalled();
     expect(mockedSaveBundle).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate when getSession fails after MFA verify', async () => {
+    const { client } = createLoginSupabaseMock({
+      mfaVerifyGetSession: {
+        error: { message: 'session read failed' },
+        session: null,
+      },
+    });
+    mockedGetClient.mockReturnValue(client as never);
+
+    renderLogin();
+    await submitCredentials();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Authenticator code/i)).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText(/Authenticator code/i), {
+      target: { value: '123456' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: /Verify and continue/i }),
+    );
+
+    await waitFor(() => {
+      expect(getVisibleFormError().textContent).toContain(
+        'Could not read your session after verification',
+      );
+    });
+    expect(mockPush).not.toHaveBeenCalledWith('/patients');
+  });
+
+  it('does not navigate when getSession returns no session after MFA verify', async () => {
+    const { client } = createLoginSupabaseMock({
+      mfaVerifyGetSession: {
+        error: null,
+        session: null,
+      },
+    });
+    mockedGetClient.mockReturnValue(client as never);
+
+    renderLogin();
+    await submitCredentials();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Authenticator code/i)).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText(/Authenticator code/i), {
+      target: { value: '654321' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: /Verify and continue/i }),
+    );
+
+    await waitFor(() => {
+      expect(getVisibleFormError().textContent).toContain(
+        'could not be confirmed after verification',
+      );
+    });
+    expect(mockPush).not.toHaveBeenCalledWith('/patients');
   });
 
   it('shows auth error when password sign-in fails', async () => {

--- a/apps/practitioner/specs/login-page.spec.tsx
+++ b/apps/practitioner/specs/login-page.spec.tsx
@@ -7,6 +7,8 @@ import {
   saveMfaTrustBundle,
   clearMfaTrustBundle,
   getTrustedUntilMsAfterVerification,
+  refreshTrustedMfaBundleBeforePasswordSignIn,
+  readMfaTrustBundle,
 } from '../src/lib/practitioner-device-trust';
 
 jest.mock('@abstrack/supabase/browser', () => ({
@@ -23,6 +25,10 @@ jest.mock('../src/lib/practitioner-device-trust', () => {
     saveMfaTrustBundle: jest.fn(),
     clearMfaTrustBundle: jest.fn(),
     getTrustedUntilMsAfterVerification: jest.fn(() => Date.now() + 86_400_000),
+    refreshTrustedMfaBundleBeforePasswordSignIn: jest
+      .fn()
+      .mockResolvedValue(false),
+    readMfaTrustBundle: jest.fn().mockReturnValue(null),
   };
 });
 
@@ -41,6 +47,10 @@ const mockedTryRestore = jest.mocked(tryRestoreTrustedMfaSession);
 const mockedSaveBundle = jest.mocked(saveMfaTrustBundle);
 const mockedClearBundle = jest.mocked(clearMfaTrustBundle);
 const mockedTrustedUntil = jest.mocked(getTrustedUntilMsAfterVerification);
+const mockedRefreshBeforePassword = jest.mocked(
+  refreshTrustedMfaBundleBeforePasswordSignIn,
+);
+const mockedReadBundle = jest.mocked(readMfaTrustBundle);
 
 const USER_ID = '00000000-0000-0000-0000-000000000042';
 const FACTOR_ID = 'factor-totp-1';
@@ -247,6 +257,10 @@ describe('LoginPage MFA state machine', () => {
     mockedClearBundle.mockClear();
     mockedTrustedUntil.mockClear();
     mockedTrustedUntil.mockReturnValue(Date.now() + 86_400_000);
+    mockedRefreshBeforePassword.mockReset();
+    mockedRefreshBeforePassword.mockResolvedValue(false);
+    mockedReadBundle.mockReset();
+    mockedReadBundle.mockReturnValue(null);
   });
 
   it('shows message and stays on credentials when trust restore ends session (signed_out)', async () => {
@@ -286,6 +300,40 @@ describe('LoginPage MFA state machine', () => {
     expect(screen.queryByLabelText(/Authenticator code/i)).toBeNull();
   });
 
+  it('navigates to /patients when bundle was primed before password and bundle matches user', async () => {
+    mockedRefreshBeforePassword.mockResolvedValue(true);
+    const trustedUntil = Date.now() + 86_400_000;
+    mockedReadBundle.mockReturnValue({
+      userId: USER_ID,
+      email: 'doc@example.com',
+      refresh_token: 'r',
+      access_token: 'a',
+      trustedUntilMs: trustedUntil,
+    });
+    const { client } = createLoginSupabaseMock({
+      assuranceFirst: { currentLevel: 'aal1', nextLevel: 'aal2' },
+    });
+    mockedGetClient.mockReturnValue(client as never);
+
+    renderLogin();
+    await submitCredentials();
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/patients');
+    });
+    expect(mockedTryRestore).not.toHaveBeenCalled();
+    expect(client.auth.mfa.listFactors).not.toHaveBeenCalled();
+    expect(mockedSaveBundle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user: { id: USER_ID },
+        refresh_token: 'refresh-token',
+        access_token: 'access-token',
+      }),
+      trustedUntil,
+    );
+    expect(screen.queryByLabelText(/Authenticator code/i)).toBeNull();
+  });
+
   it('navigates to /patients when session is already AAL2', async () => {
     const { client } = createLoginSupabaseMock({
       assuranceFirst: { currentLevel: 'aal2', nextLevel: 'aal2' },
@@ -312,7 +360,7 @@ describe('LoginPage MFA state machine', () => {
     expect(screen.queryByLabelText(/Authenticator code/i)).toBeNull();
   });
 
-  it('redirects to security setup when there is no verified TOTP factor', async () => {
+  it('redirects to practitioner home when there is no verified TOTP factor', async () => {
     const { client } = createLoginSupabaseMock({
       listFactors: { error: null, totp: [] },
     });

--- a/apps/practitioner/specs/login-page.spec.tsx
+++ b/apps/practitioner/specs/login-page.spec.tsx
@@ -54,6 +54,7 @@ const mockedReadBundle = jest.mocked(readMfaTrustBundle);
 
 const USER_ID = '00000000-0000-0000-0000-000000000042';
 const FACTOR_ID = 'factor-totp-1';
+const FACTOR_ID_2 = 'factor-totp-2';
 
 /** Unsigned JWT for tests that need `parseAbstrackAccessTokenClaims` / `aal` (Node `Buffer`). */
 function makeUnsignedJwtForTest(payload: Record<string, unknown>): string {
@@ -91,7 +92,11 @@ function createLoginSupabaseMock(options?: {
   };
   listFactors?: {
     error: Error | null;
-    totp: Array<{ id: string; status: string }>;
+    totp: Array<{
+      id: string;
+      status: string;
+      friendly_name?: string | null;
+    }>;
   };
   assuranceFirst?: { currentLevel: string; nextLevel: string | null };
   assuranceAfterVerify?: { currentLevel: string; nextLevel: string | null };
@@ -349,9 +354,7 @@ describe('LoginPage MFA state machine', () => {
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith('/patients');
     });
-    expect(
-      client.auth.mfa.getAuthenticatorAssuranceLevel,
-    ).toHaveBeenCalled();
+    expect(client.auth.mfa.getAuthenticatorAssuranceLevel).toHaveBeenCalled();
     expect(mockedTryRestore).not.toHaveBeenCalled();
     expect(client.auth.mfa.listFactors).not.toHaveBeenCalled();
     expect(mockedSaveBundle).toHaveBeenCalledWith(
@@ -437,6 +440,52 @@ describe('LoginPage MFA state machine', () => {
     });
     expect(mockedSaveBundle).toHaveBeenCalled();
     expect(mockedClearBundle).not.toHaveBeenCalled();
+  });
+
+  it('credentials → MFA verify challenges the selected factor when multiple verified TOTP factors exist', async () => {
+    const { client, mfa } = createLoginSupabaseMock({
+      listFactors: {
+        error: null,
+        totp: [
+          { id: FACTOR_ID, status: 'verified', friendly_name: 'Work phone' },
+          { id: FACTOR_ID_2, status: 'verified', friendly_name: 'Personal' },
+        ],
+      },
+    });
+    mockedGetClient.mockReturnValue(client as never);
+
+    renderLogin();
+    await submitCredentials();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('combobox', { name: /^Authenticator$/i }),
+      ).toBeTruthy();
+    });
+
+    fireEvent.change(
+      screen.getByRole('combobox', { name: /^Authenticator$/i }),
+      {
+        target: { value: FACTOR_ID_2 },
+      },
+    );
+    fireEvent.change(screen.getByLabelText(/Authenticator code/i), {
+      target: { value: '123456' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: /Verify and continue/i }),
+    );
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/patients');
+    });
+
+    expect(mfa.challenge).toHaveBeenCalledWith({ factorId: FACTOR_ID_2 });
+    expect(mfa.verify).toHaveBeenCalledWith({
+      factorId: FACTOR_ID_2,
+      challengeId: 'challenge-id',
+      code: '123456',
+    });
   });
 
   it('clears trust bundle on successful verify when remember device is unchecked', async () => {

--- a/apps/practitioner/specs/login-page.spec.tsx
+++ b/apps/practitioner/specs/login-page.spec.tsx
@@ -1,0 +1,440 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { LiveAnnouncerProvider } from '@abstrack/ui/a11y-web';
+import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
+import LoginPage from '../src/app/login/page';
+import {
+  tryRestoreTrustedMfaSession,
+  saveMfaTrustBundle,
+  clearMfaTrustBundle,
+  getTrustedUntilMsAfterVerification,
+} from '../src/lib/practitioner-device-trust';
+
+jest.mock('@abstrack/supabase/browser', () => ({
+  getSupabaseBrowserClient: jest.fn(),
+}));
+
+jest.mock('../src/lib/practitioner-device-trust', () => {
+  const actual = jest.requireActual<
+    typeof import('../src/lib/practitioner-device-trust')
+  >('../src/lib/practitioner-device-trust');
+  return {
+    ...actual,
+    tryRestoreTrustedMfaSession: jest.fn(),
+    saveMfaTrustBundle: jest.fn(),
+    clearMfaTrustBundle: jest.fn(),
+    getTrustedUntilMsAfterVerification: jest.fn(() => Date.now() + 86_400_000),
+  };
+});
+
+const mockPush = jest.fn();
+const mockRefresh = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    refresh: mockRefresh,
+  }),
+}));
+
+const mockedGetClient = jest.mocked(getSupabaseBrowserClient);
+const mockedTryRestore = jest.mocked(tryRestoreTrustedMfaSession);
+const mockedSaveBundle = jest.mocked(saveMfaTrustBundle);
+const mockedClearBundle = jest.mocked(clearMfaTrustBundle);
+const mockedTrustedUntil = jest.mocked(getTrustedUntilMsAfterVerification);
+
+const USER_ID = '00000000-0000-0000-0000-000000000042';
+const FACTOR_ID = 'factor-totp-1';
+
+type MfaMock = {
+  signInWithPassword: jest.Mock;
+  getUser: jest.Mock;
+  listFactors: jest.Mock;
+  getAuthenticatorAssuranceLevel: jest.Mock;
+  getSession: jest.Mock;
+  signOut: jest.Mock;
+  challenge: jest.Mock;
+  verify: jest.Mock;
+};
+
+/**
+ * Builds a Supabase client mock for the practitioner login state machine. Defaults: password
+ * sign-in succeeds, one verified TOTP factor, trust restore fails, assurance is aal1 then aal2
+ * after MFA verify.
+ */
+function createLoginSupabaseMock(options?: {
+  signInError?: { message: string } | null;
+  listFactors?: {
+    error: Error | null;
+    totp: Array<{ id: string; status: string }>;
+  };
+  assuranceFirst?: { currentLevel: string; nextLevel: string | null };
+  assuranceAfterVerify?: { currentLevel: string; nextLevel: string | null };
+  verifyError?: unknown;
+}): { client: { auth: Record<string, unknown> }; mfa: MfaMock } {
+  const signInError = options?.signInError ?? null;
+  const totpList = options?.listFactors?.totp ?? [
+    { id: FACTOR_ID, status: 'verified' },
+  ];
+  const listErr = options?.listFactors?.error ?? null;
+
+  const signInWithPassword = jest
+    .fn()
+    .mockResolvedValue({ error: signInError });
+  const getUser = jest.fn().mockResolvedValue({
+    data: { user: { id: USER_ID } },
+  });
+  const listFactors = jest.fn().mockResolvedValue({
+    error: listErr,
+    data: { totp: totpList },
+  });
+
+  const assuranceFirst = options?.assuranceFirst ?? {
+    currentLevel: 'aal1',
+    nextLevel: 'aal2',
+  };
+  const assuranceAfterVerify = options?.assuranceAfterVerify ?? {
+    currentLevel: 'aal2',
+    nextLevel: 'aal2',
+  };
+
+  const getAuthenticatorAssuranceLevel = jest
+    .fn()
+    .mockResolvedValueOnce({
+      error: null,
+      data: assuranceFirst,
+    })
+    .mockResolvedValue({
+      error: null,
+      data: assuranceAfterVerify,
+    });
+
+  const getSession = jest.fn().mockResolvedValue({
+    data: {
+      session: {
+        user: { id: USER_ID },
+        refresh_token: 'refresh-token',
+        access_token: 'access-token',
+      },
+    },
+  });
+  const signOut = jest.fn().mockResolvedValue({ error: null });
+
+  const challenge = jest.fn().mockResolvedValue({
+    error: null,
+    data: { id: 'challenge-id' },
+  });
+  const verify = options?.verifyError
+    ? jest.fn().mockResolvedValue({ error: options.verifyError, data: null })
+    : jest.fn().mockResolvedValue({ error: null, data: {} });
+
+  const mfa: MfaMock = {
+    signInWithPassword,
+    getUser,
+    listFactors,
+    getAuthenticatorAssuranceLevel,
+    getSession,
+    signOut,
+    challenge,
+    verify,
+  };
+
+  const client = {
+    auth: {
+      signInWithPassword,
+      getUser,
+      getSession,
+      signOut,
+      mfa: {
+        listFactors,
+        getAuthenticatorAssuranceLevel,
+        challenge,
+        verify,
+      },
+    },
+  };
+
+  return { client, mfa };
+}
+
+function renderLogin() {
+  return render(
+    <LiveAnnouncerProvider>
+      <LoginPage />
+    </LiveAnnouncerProvider>,
+  );
+}
+
+/**
+ * Visible inline error is a `<p role="alert">`; `useAnnounce` also mounts a live-region `role="alert"`.
+ */
+function getVisibleFormError(): HTMLElement {
+  const alerts = screen.getAllByRole('alert');
+  const paragraph = alerts.find((node) => node.tagName === 'P') as
+    | HTMLElement
+    | undefined;
+  if (!paragraph) {
+    throw new Error('Visible form error paragraph not found');
+  }
+  return paragraph;
+}
+
+async function submitCredentials() {
+  fireEvent.change(screen.getByLabelText(/^Email$/i), {
+    target: { value: 'doc@example.com' },
+  });
+  fireEvent.change(screen.getByLabelText(/^Password$/i), {
+    target: { value: 'password123' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /^Sign in$/i }));
+}
+
+describe('LoginPage MFA state machine', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockRefresh.mockClear();
+    mockedTryRestore.mockReset();
+    mockedTryRestore.mockResolvedValue(false);
+    mockedSaveBundle.mockClear();
+    mockedClearBundle.mockClear();
+    mockedTrustedUntil.mockClear();
+    mockedTrustedUntil.mockReturnValue(Date.now() + 86_400_000);
+  });
+
+  it('navigates to /patients when trusted MFA session restores', async () => {
+    mockedTryRestore.mockResolvedValue(true);
+    const { client } = createLoginSupabaseMock({
+      assuranceFirst: { currentLevel: 'aal1', nextLevel: 'aal2' },
+    });
+    mockedGetClient.mockReturnValue(client as never);
+
+    renderLogin();
+    await submitCredentials();
+
+    await waitFor(() => {
+      expect(mockedTryRestore).toHaveBeenCalledWith(expect.anything(), USER_ID);
+      expect(mockPush).toHaveBeenCalledWith('/patients');
+    });
+    expect(screen.queryByLabelText(/Authenticator code/i)).toBeNull();
+  });
+
+  it('navigates to /patients when session is already AAL2', async () => {
+    const { client } = createLoginSupabaseMock({
+      assuranceFirst: { currentLevel: 'aal2', nextLevel: 'aal2' },
+    });
+    // Only one assurance read — override chain to single resolution
+    (
+      client.auth.mfa as { getAuthenticatorAssuranceLevel: jest.Mock }
+    ).getAuthenticatorAssuranceLevel.mockReset();
+    (
+      client.auth.mfa as { getAuthenticatorAssuranceLevel: jest.Mock }
+    ).getAuthenticatorAssuranceLevel.mockResolvedValue({
+      error: null,
+      data: { currentLevel: 'aal2', nextLevel: 'aal2' },
+    });
+
+    mockedGetClient.mockReturnValue(client as never);
+
+    renderLogin();
+    await submitCredentials();
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/patients');
+    });
+    expect(screen.queryByLabelText(/Authenticator code/i)).toBeNull();
+  });
+
+  it('redirects to security setup when there is no verified TOTP factor', async () => {
+    const { client } = createLoginSupabaseMock({
+      listFactors: { error: null, totp: [] },
+    });
+    mockedGetClient.mockReturnValue(client as never);
+
+    renderLogin();
+    await submitCredentials();
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('credentials → MFA verify → /patients and saves trust bundle when remember device is checked', async () => {
+    const { client, mfa } = createLoginSupabaseMock();
+    mockedGetClient.mockReturnValue(client as never);
+
+    renderLogin();
+    await submitCredentials();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Authenticator code/i)).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByLabelText(/Trust this device for 30 days/i));
+    fireEvent.change(screen.getByLabelText(/Authenticator code/i), {
+      target: { value: '123456' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: /Verify and continue/i }),
+    );
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/patients');
+    });
+
+    expect(mfa.challenge).toHaveBeenCalledWith({ factorId: FACTOR_ID });
+    expect(mfa.verify).toHaveBeenCalledWith({
+      factorId: FACTOR_ID,
+      challengeId: 'challenge-id',
+      code: '123456',
+    });
+    expect(mockedSaveBundle).toHaveBeenCalled();
+    expect(mockedClearBundle).not.toHaveBeenCalled();
+  });
+
+  it('clears trust bundle on successful verify when remember device is unchecked', async () => {
+    const { client } = createLoginSupabaseMock();
+    mockedGetClient.mockReturnValue(client as never);
+
+    renderLogin();
+    await submitCredentials();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Authenticator code/i)).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText(/Authenticator code/i), {
+      target: { value: '654321' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: /Verify and continue/i }),
+    );
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/patients');
+    });
+
+    expect(mockedClearBundle).toHaveBeenCalled();
+    expect(mockedSaveBundle).not.toHaveBeenCalled();
+  });
+
+  it('shows auth error when password sign-in fails', async () => {
+    const { client } = createLoginSupabaseMock({
+      signInError: { message: 'Invalid login credentials' },
+    });
+    mockedGetClient.mockReturnValue(client as never);
+
+    renderLogin();
+    await submitCredentials();
+
+    await waitFor(() => {
+      expect(getVisibleFormError().textContent).toContain(
+        'Invalid login credentials',
+      );
+    });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('signs out and clears trust bundle when MFA setup fails after password succeeds', async () => {
+    const { client, mfa } = createLoginSupabaseMock({
+      listFactors: { error: new Error('network'), totp: [] },
+    });
+    mockedGetClient.mockReturnValue(client as never);
+
+    renderLogin();
+    await submitCredentials();
+
+    await waitFor(() => {
+      expect(getVisibleFormError().textContent).toMatch(
+        /signed out for safety/i,
+      );
+    });
+
+    expect(mfa.signOut).toHaveBeenCalled();
+    expect(mockedClearBundle).toHaveBeenCalled();
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+
+  it('does not call MFA challenge when code is not six digits', async () => {
+    const { client, mfa } = createLoginSupabaseMock();
+    mockedGetClient.mockReturnValue(client as never);
+
+    renderLogin();
+    await submitCredentials();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Authenticator code/i)).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText(/Authenticator code/i), {
+      target: { value: '12345' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: /Verify and continue/i }),
+    );
+
+    await waitFor(() => {
+      expect(getVisibleFormError().textContent).toMatch(/six-digit/i);
+    });
+    expect(mfa.challenge).not.toHaveBeenCalled();
+  });
+
+  it('shows error when assurance is not AAL2 after verify', async () => {
+    const { client } = createLoginSupabaseMock({
+      assuranceAfterVerify: { currentLevel: 'aal1', nextLevel: 'aal2' },
+    });
+    mockedGetClient.mockReturnValue(client as never);
+
+    renderLogin();
+    await submitCredentials();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Authenticator code/i)).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText(/Authenticator code/i), {
+      target: { value: '111111' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: /Verify and continue/i }),
+    );
+
+    await waitFor(() => {
+      expect(getVisibleFormError().textContent).toMatch(
+        /did not finish updating your session/i,
+      );
+    });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('returns to credentials after Back to sign out', async () => {
+    const { client, mfa } = createLoginSupabaseMock();
+    mockedGetClient.mockReturnValue(client as never);
+
+    renderLogin();
+    await submitCredentials();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Authenticator code/i)).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Back to sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^Sign in$/i })).toBeTruthy();
+    });
+
+    expect(mfa.signOut).toHaveBeenCalled();
+    expect(mockedClearBundle).toHaveBeenCalled();
+    expect(mockRefresh).toHaveBeenCalled();
+    expect(screen.queryByLabelText(/Authenticator code/i)).toBeNull();
+  });
+});

--- a/apps/practitioner/specs/login-page.spec.tsx
+++ b/apps/practitioner/specs/login-page.spec.tsx
@@ -515,6 +515,11 @@ describe('LoginPage MFA state machine', () => {
         'no longer matches this sign-in after the saved device check',
       );
     });
+    expect(getVisibleFormError().textContent).toContain(
+      'signed out for safety',
+    );
+    expect(client.auth.signOut).toHaveBeenCalled();
+    expect(mockedClearBundle).toHaveBeenCalled();
     expect(screen.queryByLabelText(/Authenticator code/i)).toBeNull();
     expect(mockPush).not.toHaveBeenCalled();
   });

--- a/apps/practitioner/specs/login-page.spec.tsx
+++ b/apps/practitioner/specs/login-page.spec.tsx
@@ -63,6 +63,10 @@ type MfaMock = {
  */
 function createLoginSupabaseMock(options?: {
   signInError?: { message: string } | null;
+  getUserResponse?: {
+    error: Error | null;
+    user: { id: string } | null;
+  };
   listFactors?: {
     error: Error | null;
     totp: Array<{ id: string; status: string }>;
@@ -80,8 +84,13 @@ function createLoginSupabaseMock(options?: {
   const signInWithPassword = jest
     .fn()
     .mockResolvedValue({ error: signInError });
+  const getUserResolved = options?.getUserResponse ?? {
+    error: null as Error | null,
+    user: { id: USER_ID },
+  };
   const getUser = jest.fn().mockResolvedValue({
-    data: { user: { id: USER_ID } },
+    data: { user: getUserResolved.user },
+    error: getUserResolved.error,
   });
   const listFactors = jest.fn().mockResolvedValue({
     error: listErr,
@@ -342,6 +351,27 @@ describe('LoginPage MFA state machine', () => {
       );
     });
     expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('signs out and clears trust bundle when getUser does not resolve after password sign-in', async () => {
+    const { client, mfa } = createLoginSupabaseMock({
+      getUserResponse: { error: null, user: null },
+    });
+    mockedGetClient.mockReturnValue(client as never);
+
+    renderLogin();
+    await submitCredentials();
+
+    await waitFor(() => {
+      expect(getVisibleFormError().textContent).toContain(
+        'Could not resolve your account after sign-in.',
+      );
+    });
+
+    expect(mfa.signOut).toHaveBeenCalled();
+    expect(mockedClearBundle).toHaveBeenCalled();
+    expect(mockRefresh).toHaveBeenCalled();
+    expect(mfa.listFactors).not.toHaveBeenCalled();
   });
 
   it('signs out and clears trust bundle when MFA setup fails after password succeeds', async () => {

--- a/apps/practitioner/specs/login-page.spec.tsx
+++ b/apps/practitioner/specs/login-page.spec.tsx
@@ -265,6 +265,7 @@ describe('LoginPage MFA state machine', () => {
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith('/');
     });
+    expect(mockedClearBundle).toHaveBeenCalled();
   });
 
   it('credentials → MFA verify → /patients and saves trust bundle when remember device is checked', async () => {

--- a/apps/practitioner/specs/login-page.spec.tsx
+++ b/apps/practitioner/specs/login-page.spec.tsx
@@ -68,6 +68,12 @@ function makeUnsignedJwtForTest(payload: Record<string, unknown>): string {
   return `${header}.${body}.sig`;
 }
 
+/** Default mock access token with `aal: aal2` so login waits and `/patients` match the patient gate. */
+const DEFAULT_SESSION_ACCESS_TOKEN_AAL2 = makeUnsignedJwtForTest({
+  aal: 'aal2',
+  sub: USER_ID,
+});
+
 type MfaMock = {
   signInWithPassword: jest.Mock;
   getUser: jest.Mock;
@@ -158,7 +164,8 @@ function createLoginSupabaseMock(options?: {
   const defaultMfaSession = {
     user: { id: USER_ID },
     refresh_token: 'refresh-token',
-    access_token: options?.sessionAccessToken ?? 'access-token',
+    access_token:
+      options?.sessionAccessToken ?? DEFAULT_SESSION_ACCESS_TOKEN_AAL2,
   };
   const mfaSessionOpts = options?.mfaVerifyGetSession;
   const verifyPhaseGetSessionResult = {

--- a/apps/practitioner/src/app/api/auth/logout/route.spec.ts
+++ b/apps/practitioner/src/app/api/auth/logout/route.spec.ts
@@ -1,0 +1,74 @@
+import { createSupabaseServerClient } from '@abstrack/supabase/server';
+import { POST } from './route';
+import type { NextRequest } from 'next/server';
+
+jest.mock('@abstrack/supabase/server', () => ({
+  createSupabaseServerClient: jest.fn(),
+}));
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: jest.fn((body: unknown, init?: { status?: number }) => ({
+      type: 'json',
+      body,
+      status: init?.status ?? 200,
+    })),
+    redirect: jest.fn((url: URL, status?: number) => ({
+      type: 'redirect',
+      location: url.toString(),
+      status,
+      cookies: { set: jest.fn() },
+    })),
+  },
+}));
+
+const mockedCreate = jest.mocked(createSupabaseServerClient);
+
+describe('POST /api/auth/logout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedCreate.mockReturnValue({
+      auth: {
+        signOut: jest.fn().mockResolvedValue(undefined),
+      },
+    } as never);
+  });
+
+  it('returns 403 and does not sign out when Origin is wrong', async () => {
+    const request = {
+      url: 'https://practitioner.example.com/api/auth/logout',
+      headers: new Headers({
+        Origin: 'https://evil.example',
+      }),
+      cookies: { getAll: jest.fn(() => []) },
+    } as unknown as NextRequest;
+
+    const response = await POST(request);
+
+    expect(response).toEqual(
+      expect.objectContaining({ type: 'json', status: 403 }),
+    );
+    expect(mockedCreate).not.toHaveBeenCalled();
+  });
+
+  it('redirects and signs out when Origin matches', async () => {
+    const request = {
+      url: 'https://practitioner.example.com/api/auth/logout',
+      headers: new Headers({
+        Origin: 'https://practitioner.example.com',
+      }),
+      cookies: { getAll: jest.fn(() => []) },
+    } as unknown as NextRequest;
+
+    const response = await POST(request);
+
+    expect(mockedCreate).toHaveBeenCalled();
+    expect(response).toEqual(
+      expect.objectContaining({
+        type: 'redirect',
+        status: 303,
+        location: expect.stringContaining('/login'),
+      }),
+    );
+  });
+});

--- a/apps/practitioner/src/app/api/auth/logout/route.ts
+++ b/apps/practitioner/src/app/api/auth/logout/route.ts
@@ -2,7 +2,10 @@ import { createSupabaseServerClient } from '@abstrack/supabase/server';
 import { NextRequest, NextResponse } from 'next/server';
 
 /**
- * Signs out the current practitioner session and clears auth cookies.
+ * Signs out the current practitioner session and clears auth cookies (full Supabase sign-out).
+ * Revokes refresh tokens server-side; the MFA “trusted device” bundle in `localStorage` may be
+ * stale until the next sign-in attempt clears it. Prefer the in-app Log out control for trust-aware
+ * sign-out when available.
  *
  * @param request - Incoming request with current cookies.
  * @returns Redirect response to practitioner login.

--- a/apps/practitioner/src/app/api/auth/logout/route.ts
+++ b/apps/practitioner/src/app/api/auth/logout/route.ts
@@ -1,5 +1,6 @@
 import { createSupabaseServerClient } from '@abstrack/supabase/server';
 import { NextRequest, NextResponse } from 'next/server';
+import { getSameOriginLogoutPostFailure } from '@/lib/same-origin-logout-post';
 
 /**
  * Signs out the current practitioner session and clears auth cookies (full Supabase sign-out).
@@ -7,10 +8,21 @@ import { NextRequest, NextResponse } from 'next/server';
  * stale until the next sign-in attempt clears it. Prefer the in-app Log out control for trust-aware
  * sign-out when available.
  *
+ * Rejects cross-site `POST` requests (same-origin / `Sec-Fetch-Site` / `Referer` checks) before
+ * mutating session state, to mitigate CSRF-driven logouts.
+ *
  * @param request - Incoming request with current cookies.
- * @returns Redirect response to practitioner login.
+ * @returns Redirect response to practitioner login, or 403 when origin validation fails.
  */
 export async function POST(request: NextRequest) {
+  const csrfFailure = getSameOriginLogoutPostFailure(request);
+  if (csrfFailure) {
+    return NextResponse.json(
+      { error: csrfFailure.error },
+      { status: csrfFailure.status },
+    );
+  }
+
   const response = NextResponse.redirect(new URL('/login', request.url), 303);
 
   const supabase = createSupabaseServerClient({

--- a/apps/practitioner/src/app/api/auth/logout/route.ts
+++ b/apps/practitioner/src/app/api/auth/logout/route.ts
@@ -12,7 +12,8 @@ import { getSameOriginLogoutPostFailure } from '@/lib/same-origin-logout-post';
  * mutating session state, to mitigate CSRF-driven logouts.
  *
  * @param request - Incoming request with current cookies.
- * @returns Redirect response to practitioner login, or 403 when origin validation fails.
+ * @returns Redirect response to practitioner login, or **400** (e.g. malformed `Referer`) / **403**
+ *   when same-origin validation fails — see {@link getSameOriginLogoutPostFailure}.
  */
 export async function POST(request: NextRequest) {
   const csrfFailure = getSameOriginLogoutPostFailure(request);

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -5,7 +5,7 @@ import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useMemo, useState, type FormEvent } from 'react';
+import { useCallback, useMemo, useState, type FormEvent } from 'react';
 import {
   clearMfaTrustBundle,
   getTrustedUntilMsAfterVerification,
@@ -34,6 +34,11 @@ type LoginStep = 'credentials' | 'mfa_verify';
  * match the account from password sign-in, the client signs out and clears the trust bundle before
  * prompting for credentials again.
  *
+ * `resetToCredentials` centralizes fallback to the credentials step: it clears MFA-only UI
+ * state (code, trust checkbox, status line) so a later MFA step is not prefilled from a prior
+ * attempt, optionally sets assertive error copy, and can clear the password after session-ending
+ * failures so secrets are not left in memory.
+ *
  * @returns Login UI.
  */
 export default function LoginPage() {
@@ -52,6 +57,32 @@ export default function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<string | null>(null);
 
+  /**
+   * Returns the UI to the credentials step and clears MFA-only state so later flows are not
+   * prefilled from a prior attempt. Optionally sets an assertive error line and matching live
+   * announcement, and clears the password after abandoned or session-ending sign-in.
+   *
+   * @param options.message - When set, passed to `setError` and `announce` (assertive).
+   * @param options.clearPassword - Clears the password field when true.
+   */
+  const resetToCredentials = useCallback(
+    (options?: { clearPassword?: boolean; message?: string }) => {
+      setStep('credentials');
+      setVerifyCode('');
+      setRememberDevice(false);
+      setMfaFactorId(null);
+      setStatus(null);
+      if (options?.clearPassword) {
+        setPassword('');
+      }
+      if (options?.message != null) {
+        setError(options.message);
+        announce(options.message, { politeness: 'assertive' });
+      }
+    },
+    [announce],
+  );
+
   const handleLogin = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setError(null);
@@ -69,8 +100,7 @@ export default function LoginPage() {
       );
 
       if (authError) {
-        setError(authError.message);
-        announce(authError.message, { politeness: 'assertive' });
+        resetToCredentials({ message: authError.message });
         return;
       }
 
@@ -84,9 +114,9 @@ export default function LoginPage() {
           console.error(cleanupError);
         }
         router.refresh();
-        const message = 'Could not resolve your account after sign-in.';
-        setError(message);
-        announce(message, { politeness: 'assertive' });
+        resetToCredentials({
+          message: 'Could not resolve your account after sign-in.',
+        });
         return;
       }
 
@@ -121,33 +151,30 @@ export default function LoginPage() {
       }
       if (restoreOutcome.status === 'signed_out') {
         router.refresh();
-        const message =
-          'Your sign-in session ended during the saved device check. Enter your email and password again.';
-        setError(message);
-        announce(message, { politeness: 'assertive' });
-        setStep('credentials');
-        setMfaFactorId(null);
+        resetToCredentials({
+          clearPassword: true,
+          message:
+            'Your sign-in session ended during the saved device check. Enter your email and password again.',
+        });
         return;
       }
 
       const afterRestoreSession = await supabase.auth.getSession();
       if (afterRestoreSession.error) {
         console.error(afterRestoreSession.error);
-        const message =
-          'Could not confirm your session after the saved device check. Enter your email and password again.';
-        setError(message);
-        announce(message, { politeness: 'assertive' });
-        setStep('credentials');
-        setMfaFactorId(null);
+        resetToCredentials({
+          clearPassword: true,
+          message:
+            'Could not confirm your session after the saved device check. Enter your email and password again.',
+        });
         return;
       }
       if (afterRestoreSession.data.session?.user?.id == null) {
-        const message =
-          'Your sign-in session ended during the saved device check. Enter your email and password again.';
-        setError(message);
-        announce(message, { politeness: 'assertive' });
-        setStep('credentials');
-        setMfaFactorId(null);
+        resetToCredentials({
+          clearPassword: true,
+          message:
+            'Your sign-in session ended during the saved device check. Enter your email and password again.',
+        });
         return;
       }
       if (afterRestoreSession.data.session.user.id !== user.id) {
@@ -158,12 +185,11 @@ export default function LoginPage() {
           console.error(cleanupError);
         }
         router.refresh();
-        const message =
-          'Your session no longer matches this sign-in after the saved device check. You have been signed out for safety. Enter your email and password again.';
-        setError(message);
-        announce(message, { politeness: 'assertive' });
-        setStep('credentials');
-        setMfaFactorId(null);
+        resetToCredentials({
+          clearPassword: true,
+          message:
+            'Your session no longer matches this sign-in after the saved device check. You have been signed out for safety. Enter your email and password again.',
+        });
         return;
       }
 
@@ -195,15 +221,15 @@ export default function LoginPage() {
           console.error(cleanupError);
         }
         router.refresh();
-        const message =
-          'Your password was accepted, but we could not finish verifying multi-factor sign-in. You have been signed out for safety. Please try again.';
-        setError(message);
-        announce(message, { politeness: 'assertive' });
+        resetToCredentials({
+          clearPassword: true,
+          message:
+            'Your password was accepted, but we could not finish verifying multi-factor sign-in. You have been signed out for safety. Please try again.',
+        });
       } else {
-        const message =
-          'Unable to complete sign-in right now. Please try again.';
-        setError(message);
-        announce(message, { politeness: 'assertive' });
+        resetToCredentials({
+          message: 'Unable to complete sign-in right now. Please try again.',
+        });
       }
     } finally {
       setLoading(false);
@@ -317,12 +343,7 @@ export default function LoginPage() {
         throw signOutError;
       }
       clearMfaTrustBundle();
-      setStep('credentials');
-      setVerifyCode('');
-      setMfaFactorId(null);
-      setRememberDevice(false);
-      setPassword('');
-      setStatus(null);
+      resetToCredentials({ clearPassword: true });
       router.refresh();
       announce(
         'Signed out. You can enter your email and password to sign in again.',

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useMemo, useState, type FormEvent } from 'react';
 import {
+  clearMfaTrustBundle,
   getTrustedUntilMsAfterVerification,
   saveMfaTrustBundle,
   tryRestoreTrustedMfaSession,
@@ -36,6 +37,7 @@ export default function LoginPage() {
   const [step, setStep] = useState<LoginStep>('credentials');
   const [loading, setLoading] = useState(false);
   const [verifyLoading, setVerifyLoading] = useState(false);
+  const [backToSignInLoading, setBackToSignInLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<string | null>(null);
 
@@ -179,6 +181,40 @@ export default function LoginPage() {
     }
   };
 
+  const handleBackToSignIn = async () => {
+    if (verifyLoading || backToSignInLoading) {
+      return;
+    }
+    setError(null);
+    setBackToSignInLoading(true);
+    try {
+      const { error: signOutError } = await supabase.auth.signOut();
+      if (signOutError) {
+        throw signOutError;
+      }
+      clearMfaTrustBundle();
+      setStep('credentials');
+      setVerifyCode('');
+      setMfaFactorId(null);
+      setRememberDevice(false);
+      setPassword('');
+      setStatus(null);
+      router.refresh();
+      announce(
+        'Signed out. You can enter your email and password to sign in again.',
+        { politeness: 'polite' },
+      );
+    } catch (backError) {
+      console.error(backError);
+      const message =
+        'Could not sign out. Try again, or refresh the page before using a different account.';
+      setError(message);
+      announce(message, { politeness: 'assertive' });
+    } finally {
+      setBackToSignInLoading(false);
+    }
+  };
+
   const showCredentialsStep = step === 'credentials';
 
   return (
@@ -313,18 +349,23 @@ export default function LoginPage() {
 
             <button
               type="button"
+              disabled={verifyLoading || backToSignInLoading}
+              {...(backToSignInLoading ? { 'aria-busy': true as const } : {})}
+              aria-describedby="login-back-to-sign-in-hint"
               onClick={() => {
-                setStep('credentials');
-                setVerifyCode('');
-                setMfaFactorId(null);
-                setRememberDevice(false);
-                setStatus(null);
-                setError(null);
+                void handleBackToSignIn();
               }}
-              className="w-full rounded-md border border-app-border bg-app-surface px-4 py-2 text-app-ink transition hover:bg-[var(--app-nav-hover-bg)]"
+              className="w-full rounded-md border border-app-border bg-app-surface px-4 py-2 text-app-ink transition hover:bg-[var(--app-nav-hover-bg)] disabled:cursor-not-allowed disabled:opacity-50"
             >
-              Back to sign in
+              {backToSignInLoading ? 'Signing out…' : 'Back to sign in'}
             </button>
+            <p
+              id="login-back-to-sign-in-hint"
+              className="text-center text-xs text-app-muted"
+            >
+              Ends this session so you can use a different account or start
+              over.
+            </p>
           </form>
         )}
 

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -23,7 +23,8 @@ type LoginStep = 'credentials' | 'mfa_verify';
 /**
  * Practitioner email/password login with MFA step-up and optional device trust (browser storage).
  * Successful verification with “Trust this device” unchecked clears any stored bundle so trust
- * matches the checkbox for this sign-in.
+ * matches the checkbox for this sign-in. If there is no verified TOTP factor, any existing bundle
+ * is cleared before redirecting to security setup so stale tokens are not kept in storage.
  *
  * @returns Login UI.
  */
@@ -86,6 +87,7 @@ export default function LoginPage() {
         (factor) => factor.status === 'verified',
       );
       if (verifiedTotpFactors.length < 1) {
+        clearMfaTrustBundle();
         const message =
           'No verified TOTP factor yet. Opening security setup so you can enroll TOTP.';
         announce(message, { politeness: 'assertive' });

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -33,6 +33,31 @@ import {
 
 type LoginStep = 'credentials' | 'mfa_verify';
 
+/** Verified TOTP row from `auth.mfa.listFactors()` — `friendly_name` is optional in API payloads. */
+type ListedTotpFactor = {
+  id: string;
+  friendly_name?: string | null;
+};
+
+/**
+ * Builds stable labels for the MFA factor picker when multiple verified TOTP factors exist.
+ *
+ * @param factors - Verified TOTP factors for the current user.
+ * @returns `{ id, label }` entries for each factor.
+ */
+function buildMfaFactorChoices(factors: ListedTotpFactor[]): Array<{
+  id: string;
+  label: string;
+}> {
+  return factors.map((f, index) => ({
+    id: f.id,
+    label:
+      typeof f.friendly_name === 'string' && f.friendly_name.trim() !== ''
+        ? f.friendly_name.trim()
+        : `Authenticator ${index + 1}`,
+  }));
+}
+
 /**
  * Practitioner email/password login with MFA step-up and optional device trust (browser storage).
  * Successful verification with “Trust this device” unchecked clears any stored bundle so trust
@@ -61,6 +86,9 @@ type LoginStep = 'credentials' | 'mfa_verify';
  * attempt, optionally sets assertive error copy, and can clear the password after session-ending
  * failures so secrets are not left in memory.
  *
+ * When several verified TOTP factors exist, the MFA step shows an **Authenticator** combobox
+ * (friendly name or “Authenticator N”) so challenge/verify use the factor the user selects.
+ *
  * @returns Login UI.
  */
 export default function LoginPage() {
@@ -76,6 +104,10 @@ export default function LoginPage() {
   const [verifyCode, setVerifyCode] = useState('');
   const [rememberDevice, setRememberDevice] = useState(false);
   const [mfaFactorId, setMfaFactorId] = useState<string | null>(null);
+  /** Populated when entering MFA verify so multiple enrolled TOTP factors can be chosen by label. */
+  const [mfaFactorChoices, setMfaFactorChoices] = useState<
+    Array<{ id: string; label: string }>
+  >([]);
   const [step, setStep] = useState<LoginStep>('credentials');
   const [loading, setLoading] = useState(false);
   const [verifyLoading, setVerifyLoading] = useState(false);
@@ -88,6 +120,7 @@ export default function LoginPage() {
   /** Synchronous guard: `verifyLoading` can lag behind rapid duplicate MFA submits. */
   const verifyMfaInFlightRef = useRef(false);
   const emailInputRef = useRef<HTMLInputElement>(null);
+  const mfaFactorSelectRef = useRef<HTMLSelectElement>(null);
   const mfaCodeInputRef = useRef<HTMLInputElement>(null);
   const prevStepRef = useRef<LoginStep>(step);
 
@@ -116,7 +149,11 @@ export default function LoginPage() {
 
     if (step === 'mfa_verify' && previousStep !== 'mfa_verify') {
       const frameId = requestAnimationFrame(() => {
-        mfaCodeInputRef.current?.focus();
+        if (mfaFactorChoices.length > 1) {
+          mfaFactorSelectRef.current?.focus();
+        } else {
+          mfaCodeInputRef.current?.focus();
+        }
       });
       return () => cancelAnimationFrame(frameId);
     }
@@ -129,7 +166,7 @@ export default function LoginPage() {
     }
 
     return undefined;
-  }, [step]);
+  }, [step, mfaFactorChoices.length]);
 
   const resetToCredentials = useCallback(
     (options?: { clearPassword?: boolean; message?: string }) => {
@@ -137,6 +174,7 @@ export default function LoginPage() {
       setVerifyCode('');
       setRememberDevice(false);
       setMfaFactorId(null);
+      setMfaFactorChoices([]);
       setStatus(null);
       if (options?.clearPassword) {
         setPassword('');
@@ -323,10 +361,15 @@ export default function LoginPage() {
         return;
       }
 
+      setMfaFactorChoices(
+        buildMfaFactorChoices(verifiedTotpFactors as ListedTotpFactor[]),
+      );
       setMfaFactorId(verifiedTotpFactors[0]?.id ?? null);
       setStep('mfa_verify');
       const message =
-        'Enter the six-digit code from your authenticator app to continue.';
+        verifiedTotpFactors.length > 1
+          ? 'Choose which authenticator to use, then enter the six-digit code.'
+          : 'Enter the six-digit code from your authenticator app to continue.';
       setStatus(message);
       announce(message, { politeness: 'assertive' });
     } catch (nextError) {
@@ -573,6 +616,37 @@ export default function LoginPage() {
           </form>
         ) : (
           <form onSubmit={handleVerifyMfa} className="mt-5 space-y-4">
+            {mfaFactorChoices.length > 1 ? (
+              <div>
+                <label
+                  htmlFor="mfa-factor"
+                  className="block text-sm font-medium text-app-muted"
+                >
+                  Authenticator
+                </label>
+                <select
+                  ref={mfaFactorSelectRef}
+                  id="mfa-factor"
+                  name="mfa-factor"
+                  aria-describedby="mfa-factor-hint"
+                  value={mfaFactorId ?? ''}
+                  onChange={(event) => {
+                    setMfaFactorId(event.target.value || null);
+                    setError(null);
+                  }}
+                  className="mt-1 block w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+                >
+                  {mfaFactorChoices.map((choice) => (
+                    <option key={choice.id} value={choice.id}>
+                      {choice.label}
+                    </option>
+                  ))}
+                </select>
+                <p id="mfa-factor-hint" className="mt-1 text-xs text-app-muted">
+                  Use the code from the app you named here.
+                </p>
+              </div>
+            ) : null}
             <div>
               <label
                 htmlFor="mfa-code"

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -193,7 +193,23 @@ export default function LoginPage() {
         throw verify.error;
       }
 
-      await supabase.auth.getSession();
+      const { data: sessionAfterVerify, error: sessionAfterVerifyError } =
+        await supabase.auth.getSession();
+      if (sessionAfterVerifyError) {
+        console.error(sessionAfterVerifyError);
+        const message =
+          'Could not read your session after verification. Try a new code from your authenticator app, or use Back to sign in to start over.';
+        setError(message);
+        announce(message, { politeness: 'assertive' });
+        return;
+      }
+      if (sessionAfterVerify.session == null) {
+        const message =
+          'Your session could not be confirmed after verification. Try a new code from your authenticator app, or use Back to sign in to start over.';
+        setError(message);
+        announce(message, { politeness: 'assertive' });
+        return;
+      }
 
       const assuranceAfterVerify =
         await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
@@ -214,11 +230,10 @@ export default function LoginPage() {
       }
 
       if (rememberDevice) {
-        const { data: sessionData } = await supabase.auth.getSession();
-        const session = sessionData.session;
-        if (session) {
-          saveMfaTrustBundle(session, getTrustedUntilMsAfterVerification());
-        }
+        saveMfaTrustBundle(
+          sessionAfterVerify.session,
+          getTrustedUntilMsAfterVerification(),
+        );
       } else {
         clearMfaTrustBundle();
       }

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -25,6 +25,8 @@ type LoginStep = 'credentials' | 'mfa_verify';
  * Successful verification with “Trust this device” unchecked clears any stored bundle so trust
  * matches the checkbox for this sign-in. If there is no verified TOTP factor, any existing bundle
  * is cleared before redirecting to security setup so stale tokens are not kept in storage.
+ * If `getUser` does not return a user id after a successful password sign-in, the client signs out
+ * and clears the trust bundle so no half-established session remains.
  *
  * @returns Login UI.
  */
@@ -66,10 +68,16 @@ export default function LoginPage() {
         return;
       }
 
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (!user?.id) {
+      const userResult = await supabase.auth.getUser();
+      const user = userResult.data.user;
+      if (userResult.error || user?.id == null || user.id === '') {
+        try {
+          await supabase.auth.signOut();
+          clearMfaTrustBundle();
+        } catch (cleanupError) {
+          console.error(cleanupError);
+        }
+        router.refresh();
         const message = 'Could not resolve your account after sign-in.';
         setError(message);
         announce(message, { politeness: 'assertive' });

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -22,6 +22,8 @@ type LoginStep = 'credentials' | 'mfa_verify';
 
 /**
  * Practitioner email/password login with MFA step-up and optional device trust (browser storage).
+ * Successful verification with “Trust this device” unchecked clears any stored bundle so trust
+ * matches the checkbox for this sign-in.
  *
  * @returns Login UI.
  */
@@ -181,12 +183,34 @@ export default function LoginPage() {
         throw verify.error;
       }
 
+      await supabase.auth.getSession();
+
+      const assuranceAfterVerify =
+        await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+      if (assuranceAfterVerify.error) {
+        console.error(assuranceAfterVerify.error);
+        const message =
+          'Could not confirm multi-factor status after verification. Try a new code from your authenticator app, or use Back to sign in to start over.';
+        setError(message);
+        announce(message, { politeness: 'assertive' });
+        return;
+      }
+      if (assuranceAfterVerify.data.currentLevel !== 'aal2') {
+        const message =
+          'Multi-factor sign-in did not finish updating your session. Try another code, or use Back to sign in to start over.';
+        setError(message);
+        announce(message, { politeness: 'assertive' });
+        return;
+      }
+
       if (rememberDevice) {
         const { data: sessionData } = await supabase.auth.getSession();
         const session = sessionData.session;
         if (session) {
           saveMfaTrustBundle(session, getTrustedUntilMsAfterVerification());
         }
+      } else {
+        clearMfaTrustBundle();
       }
 
       router.push('/patients');

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -2,28 +2,50 @@
 
 import { signInWithEmailPassword } from '@abstrack/supabase';
 import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useState, type FormEvent } from 'react';
+import { useMemo, useState, type FormEvent } from 'react';
+import {
+  getTrustedUntilMsAfterVerification,
+  saveMfaTrustBundle,
+  tryRestoreTrustedMfaSession,
+} from '../../lib/practitioner-device-trust';
+import {
+  looksLikeTotpSetupPayload,
+  mapMfaVerifyErrorToUserMessage,
+  normalizeTotpCode,
+} from '../../lib/mfa-user-messages';
+
+type LoginStep = 'credentials' | 'mfa_verify';
 
 /**
- * Practitioner email/password login page.
+ * Practitioner email/password login with MFA step-up and optional device trust (browser storage).
  *
- * @returns Login form that establishes Supabase browser auth session.
+ * @returns Login UI.
  */
 export default function LoginPage() {
   const router = useRouter();
+  const supabase = useMemo(() => getSupabaseBrowserClient(), []);
+  const { announce } = useAnnounce();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [verifyCode, setVerifyCode] = useState('');
+  const [rememberDevice, setRememberDevice] = useState(false);
+  const [mfaFactorId, setMfaFactorId] = useState<string | null>(null);
+  const [step, setStep] = useState<LoginStep>('credentials');
   const [loading, setLoading] = useState(false);
+  const [verifyLoading, setVerifyLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
 
   const handleLogin = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setError(null);
+    setStatus(null);
     setLoading(true);
 
     try {
-      const supabase = getSupabaseBrowserClient();
       const { error: authError } = await signInWithEmailPassword(
         supabase,
         email,
@@ -32,18 +54,131 @@ export default function LoginPage() {
 
       if (authError) {
         setError(authError.message);
+        announce(authError.message, { politeness: 'assertive' });
         return;
       }
 
-      router.push('/');
-      router.refresh();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user?.id) {
+        setError('Could not resolve your account after sign-in.');
+        return;
+      }
+
+      const factorsResult = await supabase.auth.mfa.listFactors();
+      if (factorsResult.error) {
+        throw factorsResult.error;
+      }
+
+      const verifiedTotpFactors = factorsResult.data.totp.filter(
+        (factor) => factor.status === 'verified',
+      );
+      if (verifiedTotpFactors.length < 1) {
+        const message =
+          'No verified TOTP factor is enabled yet. Finish security setup before accessing practitioner patient workflows.';
+        setStatus(message);
+        announce(message, { politeness: 'assertive' });
+        router.push('/');
+        router.refresh();
+        return;
+      }
+
+      const restored = await tryRestoreTrustedMfaSession(supabase, user.id);
+      if (restored) {
+        router.push('/patients');
+        router.refresh();
+        return;
+      }
+
+      const assurance =
+        await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+      if (assurance.error) {
+        throw assurance.error;
+      }
+
+      if (assurance.data.currentLevel === 'aal2') {
+        router.push('/patients');
+        router.refresh();
+        return;
+      }
+
+      setMfaFactorId(verifiedTotpFactors[0]?.id ?? null);
+      setStep('mfa_verify');
+      const message =
+        'Enter the six-digit code from your authenticator app to continue.';
+      setStatus(message);
+      announce(message, { politeness: 'assertive' });
     } catch (nextError) {
       console.error(nextError);
       setError('Unable to sign in right now. Please try again.');
+      announce('Unable to sign in right now. Please try again.', {
+        politeness: 'assertive',
+      });
     } finally {
       setLoading(false);
     }
   };
+
+  const handleVerifyMfa = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setStatus(null);
+
+    if (mfaFactorId == null) {
+      const message =
+        'Could not determine which authenticator to verify. Please sign in again.';
+      setError(message);
+      announce(message, { politeness: 'assertive' });
+      return;
+    }
+
+    if (!/^\d{6}$/.test(verifyCode)) {
+      const message =
+        'Enter the current six-digit code from your authenticator app.';
+      setError(message);
+      announce(message, { politeness: 'assertive' });
+      return;
+    }
+
+    setVerifyLoading(true);
+    try {
+      const challenge = await supabase.auth.mfa.challenge({
+        factorId: mfaFactorId,
+      });
+      if (challenge.error) {
+        throw challenge.error;
+      }
+
+      const verify = await supabase.auth.mfa.verify({
+        factorId: mfaFactorId,
+        challengeId: challenge.data.id,
+        code: verifyCode,
+      });
+      if (verify.error) {
+        throw verify.error;
+      }
+
+      if (rememberDevice) {
+        const { data: sessionData } = await supabase.auth.getSession();
+        const session = sessionData.session;
+        if (session) {
+          saveMfaTrustBundle(session, getTrustedUntilMsAfterVerification());
+        }
+      }
+
+      router.push('/patients');
+      router.refresh();
+    } catch (verifyError) {
+      const message = mapMfaVerifyErrorToUserMessage(verifyError);
+      setError(message);
+      announce(message, { politeness: 'assertive' });
+    } finally {
+      setVerifyLoading(false);
+    }
+  };
+
+  const showCredentialsStep = step === 'credentials';
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-app-bg bg-app-gradient px-4">
@@ -55,6 +190,16 @@ export default function LoginPage() {
           Sign in to set up and verify your TOTP factor.
         </p>
 
+        {status ? (
+          <p
+            role="status"
+            aria-live="polite"
+            className="mt-4 rounded border border-app-border bg-app-bg p-3 text-sm text-app-muted"
+          >
+            {status}
+          </p>
+        ) : null}
+
         {error ? (
           <p
             role="alert"
@@ -64,53 +209,132 @@ export default function LoginPage() {
           </p>
         ) : null}
 
-        <form onSubmit={handleLogin} className="mt-5 space-y-4">
-          <div>
-            <label
-              htmlFor="email"
-              className="block text-sm font-medium text-app-muted"
-            >
-              Email
-            </label>
-            <input
-              id="email"
-              type="email"
-              required
-              autoComplete="email"
-              value={email}
-              onChange={(event) => setEmail(event.target.value)}
-              className="mt-1 block w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
-              placeholder="you@example.com"
-            />
-          </div>
+        {showCredentialsStep ? (
+          <form onSubmit={handleLogin} className="mt-5 space-y-4">
+            <div>
+              <label
+                htmlFor="email"
+                className="block text-sm font-medium text-app-muted"
+              >
+                Email
+              </label>
+              <input
+                id="email"
+                type="email"
+                required
+                autoComplete="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                className="mt-1 block w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+                placeholder="you@example.com"
+              />
+            </div>
 
-          <div>
-            <label
-              htmlFor="password"
-              className="block text-sm font-medium text-app-muted"
-            >
-              Password
-            </label>
-            <input
-              id="password"
-              type="password"
-              required
-              autoComplete="current-password"
-              value={password}
-              onChange={(event) => setPassword(event.target.value)}
-              className="mt-1 block w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
-              placeholder="••••••••"
-            />
-          </div>
+            <div>
+              <label
+                htmlFor="password"
+                className="block text-sm font-medium text-app-muted"
+              >
+                Password
+              </label>
+              <input
+                id="password"
+                type="password"
+                required
+                autoComplete="current-password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                className="mt-1 block w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+                placeholder="••••••••"
+              />
+            </div>
 
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full rounded-md bg-app-primary px-4 py-2 text-white transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full rounded-md bg-app-primary px-4 py-2 text-white transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {loading ? 'Signing in...' : 'Sign in'}
+            </button>
+          </form>
+        ) : (
+          <form onSubmit={handleVerifyMfa} className="mt-5 space-y-4">
+            <div>
+              <label
+                htmlFor="mfa-code"
+                className="block text-sm font-medium text-app-muted"
+              >
+                Authenticator code
+              </label>
+              <input
+                id="mfa-code"
+                name="mfa-code"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                pattern="[0-9]*"
+                maxLength={6}
+                value={verifyCode}
+                onChange={(event) => {
+                  const raw = event.target.value;
+                  if (looksLikeTotpSetupPayload(raw)) {
+                    const message =
+                      'Enter only the six-digit code from your authenticator app.';
+                    setVerifyCode('');
+                    setError(message);
+                    announce(message, { politeness: 'assertive' });
+                    return;
+                  }
+                  setError(null);
+                  setVerifyCode(normalizeTotpCode(raw));
+                }}
+                className="mt-1 block w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+                placeholder="123456"
+              />
+            </div>
+
+            <label className="flex items-start gap-2 text-sm text-app-muted">
+              <input
+                type="checkbox"
+                className="mt-1 h-4 w-4 rounded border-app-border text-app-primary focus:ring-app-ring"
+                checked={rememberDevice}
+                onChange={(event) => setRememberDevice(event.target.checked)}
+              />
+              <span>Trust this device for 30 days.</span>
+            </label>
+
+            <button
+              type="submit"
+              disabled={verifyLoading}
+              className="w-full rounded-md bg-app-primary px-4 py-2 text-white transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {verifyLoading ? 'Verifying code...' : 'Verify and continue'}
+            </button>
+
+            <button
+              type="button"
+              onClick={() => {
+                setStep('credentials');
+                setVerifyCode('');
+                setMfaFactorId(null);
+                setRememberDevice(false);
+                setStatus(null);
+                setError(null);
+              }}
+              className="w-full rounded-md border border-app-border bg-app-surface px-4 py-2 text-app-ink transition hover:bg-[var(--app-nav-hover-bg)]"
+            >
+              Back to sign in
+            </button>
+          </form>
+        )}
+
+        <div className="mt-5 text-center">
+          <Link
+            href="/"
+            className="text-sm font-medium text-app-primary underline-offset-2 hover:underline"
           >
-            {loading ? 'Signing in...' : 'Sign in'}
-          </button>
-        </form>
+            Open security setup
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -78,9 +78,10 @@ export default function LoginPage() {
       );
       if (verifiedTotpFactors.length < 1) {
         const message =
-          'No verified TOTP factor is enabled yet. Finish security setup before accessing practitioner patient workflows.';
-        setStatus(message);
+          'No verified TOTP factor yet. Opening security setup so you can enroll TOTP.';
         announce(message, { politeness: 'assertive' });
+        router.push('/');
+        router.refresh();
         return;
       }
 

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -81,8 +81,6 @@ export default function LoginPage() {
           'No verified TOTP factor is enabled yet. Finish security setup before accessing practitioner patient workflows.';
         setStatus(message);
         announce(message, { politeness: 'assertive' });
-        router.push('/');
-        router.refresh();
         return;
       }
 

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -62,7 +62,9 @@ export default function LoginPage() {
         data: { user },
       } = await supabase.auth.getUser();
       if (!user?.id) {
-        setError('Could not resolve your account after sign-in.');
+        const message = 'Could not resolve your account after sign-in.';
+        setError(message);
+        announce(message, { politeness: 'assertive' });
         return;
       }
 

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -26,7 +26,11 @@ type LoginStep = 'credentials' | 'mfa_verify';
  * matches the checkbox for this sign-in. If there is no verified TOTP factor, any existing bundle
  * is cleared before redirecting to security setup so stale tokens are not kept in storage.
  * If `getUser` does not return a user id after a successful password sign-in, the client signs out
- * and clears the trust bundle so no half-established session remains.
+ * and clears the trust bundle so no half-established session remains. After
+ * {@link tryRestoreTrustedMfaSession} (discriminated: `restored`, `not_restored`, or `signed_out`;
+ * some outcomes sign the user out), the client re-checks `getSession` when the outcome is
+ * `not_restored` before reading assurance or showing the MFA step so a missing session cannot be
+ * mistaken for a password session still awaiting TOTP.
  *
  * @returns Login UI.
  */
@@ -104,10 +108,53 @@ export default function LoginPage() {
         return;
       }
 
-      const restored = await tryRestoreTrustedMfaSession(supabase, user.id);
-      if (restored) {
+      const restoreOutcome = await tryRestoreTrustedMfaSession(
+        supabase,
+        user.id,
+      );
+      if (restoreOutcome.status === 'restored') {
         router.push('/patients');
         router.refresh();
+        return;
+      }
+      if (restoreOutcome.status === 'signed_out') {
+        router.refresh();
+        const message =
+          'Your sign-in session ended during the saved device check. Enter your email and password again.';
+        setError(message);
+        announce(message, { politeness: 'assertive' });
+        setStep('credentials');
+        setMfaFactorId(null);
+        return;
+      }
+
+      const afterRestoreSession = await supabase.auth.getSession();
+      if (afterRestoreSession.error) {
+        console.error(afterRestoreSession.error);
+        const message =
+          'Could not confirm your session after the saved device check. Enter your email and password again.';
+        setError(message);
+        announce(message, { politeness: 'assertive' });
+        setStep('credentials');
+        setMfaFactorId(null);
+        return;
+      }
+      if (afterRestoreSession.data.session?.user?.id == null) {
+        const message =
+          'Your sign-in session ended during the saved device check. Enter your email and password again.';
+        setError(message);
+        announce(message, { politeness: 'assertive' });
+        setStep('credentials');
+        setMfaFactorId(null);
+        return;
+      }
+      if (afterRestoreSession.data.session.user.id !== user.id) {
+        const message =
+          'Your session no longer matches this sign-in after the saved device check. Enter your email and password again.';
+        setError(message);
+        announce(message, { politeness: 'assertive' });
+        setStep('credentials');
+        setMfaFactorId(null);
         return;
       }
 

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import { signInWithEmailPassword } from '@abstrack/supabase';
+import {
+  hasMfaAssuranceAal2,
+  parseAbstrackAccessTokenClaims,
+  signInWithEmailPassword,
+} from '@abstrack/supabase';
 import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { useRouter } from 'next/navigation';
@@ -210,21 +214,29 @@ export default function LoginPage() {
 
       sessionEstablishedAfterPassword = true;
 
-      // Password sign-in replaces the pre-password AAL2 session from the trust bundle with an
-      // AAL1 grant, so we cannot require `aal2` here. If we refreshed from the bundle before
-      // password and password succeeded for the same user id, skip TOTP and persist the new tokens.
-      // Email was already matched inside `refreshTrustedMfaBundleBeforePasswordSignIn`; the bundle
-      // may omit `email` if the last save used a session without `user.email` (token payloads).
+      // Password-only sign-in is usually AAL1; patient routes require JWT `aal` aal2. Only skip MFA
+      // here when assurance and the access token both indicate AAL2; otherwise continue to tryRestore
+      // / MFA verify. Never write the trust bundle from a password-only (AAL1) session — that would
+      // replace valid AAL2 tokens and break future device-trust restores.
       if (trustedBundlePrimed) {
         const bundle = readMfaTrustBundle();
         if (bundle != null && bundle.userId === user.id) {
-          const sessionWrap = await supabase.auth.getSession();
-          if (sessionWrap.data.session) {
-            saveMfaTrustBundle(sessionWrap.data.session, bundle.trustedUntilMs);
+          const assuranceAfterPassword =
+            await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+          if (
+            !assuranceAfterPassword.error &&
+            assuranceAfterPassword.data.currentLevel === 'aal2'
+          ) {
+            const sessionWrap = await supabase.auth.getSession();
+            const sess = sessionWrap.data.session;
+            const claims = parseAbstrackAccessTokenClaims(sess?.access_token);
+            if (sess && hasMfaAssuranceAal2(claims)) {
+              saveMfaTrustBundle(sess, bundle.trustedUntilMs);
+              router.push('/patients');
+              router.refresh();
+              return;
+            }
           }
-          router.push('/patients');
-          router.refresh();
-          return;
         }
       }
 

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -3,7 +3,6 @@
 import { signInWithEmailPassword } from '@abstrack/supabase';
 import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import {
   useCallback,
@@ -17,6 +16,8 @@ import {
   clearMfaTrustBundle,
   getTrustedUntilMsAfterVerification,
   isPractitionerMfaDeviceTrustEnabled,
+  readMfaTrustBundle,
+  refreshTrustedMfaBundleBeforePasswordSignIn,
   saveMfaTrustBundle,
   tryRestoreTrustedMfaSession,
 } from '../../lib/practitioner-device-trust';
@@ -32,7 +33,9 @@ type LoginStep = 'credentials' | 'mfa_verify';
  * Practitioner email/password login with MFA step-up and optional device trust (browser storage).
  * Successful verification with “Trust this device” unchecked clears any stored bundle so trust
  * matches the checkbox for this sign-in. If there is no verified TOTP factor, any existing bundle
- * is cleared before redirecting to security setup so stale tokens are not kept in storage.
+ * is cleared before redirecting to practitioner home for TOTP enrollment so stale tokens are not kept in storage.
+ * After email/password authentication succeeds, password state is cleared immediately so the secret
+ * is not retained through MFA or device-trust checks.
  * If `getUser` does not return a user id after a successful password sign-in, the client signs out
  * and clears the trust bundle so no half-established session remains. After
  * {@link tryRestoreTrustedMfaSession} (discriminated: `restored`, `not_restored`, or `signed_out`;
@@ -46,8 +49,8 @@ type LoginStep = 'credentials' | 'mfa_verify';
  * `loading`, `step`, and `credentialLoginInFlightRef`) so parallel attempts cannot race. The MFA
  * verify form uses the same pattern (`verifyLoading`, `step`, `verifyMfaInFlightRef`).
  *
- * MFA “trust this device” is shown only when `isPractitionerMfaDeviceTrustEnabled()` is true
- * (`NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST` at build time; default off).
+ * MFA “trust this device” is hidden when `isPractitionerMfaDeviceTrustEnabled()` is false
+ * (`NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST` `false`/`0`; default on).
  *
  * `resetToCredentials` centralizes fallback to the credentials step: it clears MFA-only UI
  * state (code, trust checkbox, status line) so a later MFA step is not prefilled from a prior
@@ -158,8 +161,15 @@ export default function LoginPage() {
 
     /** True once password sign-in resolved a user; MFA/trust steps may still fail afterward. */
     let sessionEstablishedAfterPassword = false;
+    /** True when we refreshed AAL2 from the trust bundle before the password grant (see device-trust module). */
+    let trustedBundlePrimed = false;
 
     try {
+      trustedBundlePrimed = await refreshTrustedMfaBundleBeforePasswordSignIn(
+        supabase,
+        email,
+      );
+
       const { error: authError } = await signInWithEmailPassword(
         supabase,
         email,
@@ -167,9 +177,20 @@ export default function LoginPage() {
       );
 
       if (authError) {
+        if (trustedBundlePrimed) {
+          try {
+            await supabase.auth.signOut();
+          } catch {
+            /* ignore */
+          }
+        }
         resetToCredentials({ message: authError.message });
         return;
       }
+
+      // Drop the password from state as soon as Supabase accepted it so it is not retained through
+      // MFA / trust checks (controlled input clears with state).
+      setPassword('');
 
       const userResult = await supabase.auth.getUser();
       const user = userResult.data.user;
@@ -189,6 +210,24 @@ export default function LoginPage() {
 
       sessionEstablishedAfterPassword = true;
 
+      // Password sign-in replaces the pre-password AAL2 session from the trust bundle with an
+      // AAL1 grant, so we cannot require `aal2` here. If we refreshed from the bundle before
+      // password and password succeeded for the same user id, skip TOTP and persist the new tokens.
+      // Email was already matched inside `refreshTrustedMfaBundleBeforePasswordSignIn`; the bundle
+      // may omit `email` if the last save used a session without `user.email` (token payloads).
+      if (trustedBundlePrimed) {
+        const bundle = readMfaTrustBundle();
+        if (bundle != null && bundle.userId === user.id) {
+          const sessionWrap = await supabase.auth.getSession();
+          if (sessionWrap.data.session) {
+            saveMfaTrustBundle(sessionWrap.data.session, bundle.trustedUntilMs);
+          }
+          router.push('/patients');
+          router.refresh();
+          return;
+        }
+      }
+
       const factorsResult = await supabase.auth.mfa.listFactors();
       if (factorsResult.error) {
         throw factorsResult.error;
@@ -200,7 +239,7 @@ export default function LoginPage() {
       if (verifiedTotpFactors.length < 1) {
         clearMfaTrustBundle();
         const message =
-          'No verified TOTP factor yet. Opening security setup so you can enroll TOTP.';
+          'No verified TOTP factor yet. Redirecting so you can enroll an authenticator.';
         announce(message, { politeness: 'assertive' });
         router.push('/');
         router.refresh();
@@ -449,7 +488,7 @@ export default function LoginPage() {
           Practitioner login
         </h1>
         <p className="text-center text-sm text-app-muted">
-          Sign in to set up and verify your TOTP factor.
+          Sign in with your practitioner account.
         </p>
 
         {status ? (
@@ -597,15 +636,6 @@ export default function LoginPage() {
             </p>
           </form>
         )}
-
-        <div className="mt-5 text-center">
-          <Link
-            href="/"
-            className="text-sm font-medium text-app-primary underline-offset-2 hover:underline"
-          >
-            Open security setup
-          </Link>
-        </div>
       </div>
     </div>
   );

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -80,6 +80,9 @@ export default function LoginPage() {
   const credentialLoginInFlightRef = useRef(false);
   /** Synchronous guard: `verifyLoading` can lag behind rapid duplicate MFA submits. */
   const verifyMfaInFlightRef = useRef(false);
+  const emailInputRef = useRef<HTMLInputElement>(null);
+  const mfaCodeInputRef = useRef<HTMLInputElement>(null);
+  const prevStepRef = useRef<LoginStep>(step);
 
   /**
    * Returns the UI to the credentials step and clears MFA-only state so later flows are not
@@ -94,6 +97,32 @@ export default function LoginPage() {
       setRememberDevice(false);
     }
   }, [deviceTrustFeatureEnabled]);
+
+  /**
+   * Moves focus when the visible step changes so keyboard and screen-reader users are not left on
+   * an unmounted control (e.g. Sign in) after switching to MFA, and land on the email field when
+   * returning from MFA.
+   */
+  useEffect(() => {
+    const previousStep = prevStepRef.current;
+    prevStepRef.current = step;
+
+    if (step === 'mfa_verify' && previousStep !== 'mfa_verify') {
+      const frameId = requestAnimationFrame(() => {
+        mfaCodeInputRef.current?.focus();
+      });
+      return () => cancelAnimationFrame(frameId);
+    }
+
+    if (step === 'credentials' && previousStep === 'mfa_verify') {
+      const frameId = requestAnimationFrame(() => {
+        emailInputRef.current?.focus();
+      });
+      return () => cancelAnimationFrame(frameId);
+    }
+
+    return undefined;
+  }, [step]);
 
   const resetToCredentials = useCallback(
     (options?: { clearPassword?: boolean; message?: string }) => {
@@ -452,6 +481,7 @@ export default function LoginPage() {
                 Email
               </label>
               <input
+                ref={emailInputRef}
                 id="email"
                 type="email"
                 required
@@ -500,6 +530,7 @@ export default function LoginPage() {
                 Authenticator code
               </label>
               <input
+                ref={mfaCodeInputRef}
                 id="mfa-code"
                 name="mfa-code"
                 inputMode="numeric"

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -5,10 +5,18 @@ import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useCallback, useMemo, useState, type FormEvent } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+} from 'react';
 import {
   clearMfaTrustBundle,
   getTrustedUntilMsAfterVerification,
+  isPractitionerMfaDeviceTrustEnabled,
   saveMfaTrustBundle,
   tryRestoreTrustedMfaSession,
 } from '../../lib/practitioner-device-trust';
@@ -34,6 +42,13 @@ type LoginStep = 'credentials' | 'mfa_verify';
  * match the account from password sign-in, the client signs out and clears the trust bundle before
  * prompting for credentials again.
  *
+ * The credentials form ignores duplicate submits while a sign-in is already in progress (see
+ * `loading`, `step`, and `credentialLoginInFlightRef`) so parallel attempts cannot race. The MFA
+ * verify form uses the same pattern (`verifyLoading`, `step`, `verifyMfaInFlightRef`).
+ *
+ * MFA “trust this device” is shown only when `isPractitionerMfaDeviceTrustEnabled()` is true
+ * (`NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST` at build time; default off).
+ *
  * `resetToCredentials` centralizes fallback to the credentials step: it clears MFA-only UI
  * state (code, trust checkbox, status line) so a later MFA step is not prefilled from a prior
  * attempt, optionally sets assertive error copy, and can clear the password after session-ending
@@ -44,6 +59,10 @@ type LoginStep = 'credentials' | 'mfa_verify';
 export default function LoginPage() {
   const router = useRouter();
   const supabase = useMemo(() => getSupabaseBrowserClient(), []);
+  const deviceTrustFeatureEnabled = useMemo(
+    () => isPractitionerMfaDeviceTrustEnabled(),
+    [],
+  );
   const { announce } = useAnnounce();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -57,6 +76,11 @@ export default function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<string | null>(null);
 
+  /** Synchronous guard: `loading` can lag one frame behind rapid duplicate submits. */
+  const credentialLoginInFlightRef = useRef(false);
+  /** Synchronous guard: `verifyLoading` can lag behind rapid duplicate MFA submits. */
+  const verifyMfaInFlightRef = useRef(false);
+
   /**
    * Returns the UI to the credentials step and clears MFA-only state so later flows are not
    * prefilled from a prior attempt. Optionally sets an assertive error line and matching live
@@ -65,6 +89,12 @@ export default function LoginPage() {
    * @param options.message - When set, passed to `setError` and `announce` (assertive).
    * @param options.clearPassword - Clears the password field when true.
    */
+  useEffect(() => {
+    if (!deviceTrustFeatureEnabled) {
+      setRememberDevice(false);
+    }
+  }, [deviceTrustFeatureEnabled]);
+
   const resetToCredentials = useCallback(
     (options?: { clearPassword?: boolean; message?: string }) => {
       setStep('credentials');
@@ -85,6 +115,14 @@ export default function LoginPage() {
 
   const handleLogin = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    if (
+      step !== 'credentials' ||
+      loading ||
+      credentialLoginInFlightRef.current
+    ) {
+      return;
+    }
+    credentialLoginInFlightRef.current = true;
     setError(null);
     setStatus(null);
     setLoading(true);
@@ -232,102 +270,115 @@ export default function LoginPage() {
         });
       }
     } finally {
+      credentialLoginInFlightRef.current = false;
       setLoading(false);
     }
   };
 
   const handleVerifyMfa = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setError(null);
-    setStatus(null);
-
-    if (mfaFactorId == null) {
-      const message =
-        'Could not determine which authenticator to verify. Please sign in again.';
-      setError(message);
-      announce(message, { politeness: 'assertive' });
+    if (
+      step !== 'mfa_verify' ||
+      verifyLoading ||
+      verifyMfaInFlightRef.current
+    ) {
       return;
     }
-
-    if (!/^\d{6}$/.test(verifyCode)) {
-      const message =
-        'Enter the current six-digit code from your authenticator app.';
-      setError(message);
-      announce(message, { politeness: 'assertive' });
-      return;
-    }
-
-    setVerifyLoading(true);
+    verifyMfaInFlightRef.current = true;
     try {
-      const challenge = await supabase.auth.mfa.challenge({
-        factorId: mfaFactorId,
-      });
-      if (challenge.error) {
-        throw challenge.error;
-      }
+      setError(null);
+      setStatus(null);
 
-      const verify = await supabase.auth.mfa.verify({
-        factorId: mfaFactorId,
-        challengeId: challenge.data.id,
-        code: verifyCode,
-      });
-      if (verify.error) {
-        throw verify.error;
-      }
-
-      const { data: sessionAfterVerify, error: sessionAfterVerifyError } =
-        await supabase.auth.getSession();
-      if (sessionAfterVerifyError) {
-        console.error(sessionAfterVerifyError);
+      if (mfaFactorId == null) {
         const message =
-          'Could not read your session after verification. Try a new code from your authenticator app, or use Back to sign in to start over.';
-        setError(message);
-        announce(message, { politeness: 'assertive' });
-        return;
-      }
-      if (sessionAfterVerify.session == null) {
-        const message =
-          'Your session could not be confirmed after verification. Try a new code from your authenticator app, or use Back to sign in to start over.';
+          'Could not determine which authenticator to verify. Please sign in again.';
         setError(message);
         announce(message, { politeness: 'assertive' });
         return;
       }
 
-      const assuranceAfterVerify =
-        await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
-      if (assuranceAfterVerify.error) {
-        console.error(assuranceAfterVerify.error);
+      if (!/^\d{6}$/.test(verifyCode)) {
         const message =
-          'Could not confirm multi-factor status after verification. Try a new code from your authenticator app, or use Back to sign in to start over.';
-        setError(message);
-        announce(message, { politeness: 'assertive' });
-        return;
-      }
-      if (assuranceAfterVerify.data.currentLevel !== 'aal2') {
-        const message =
-          'Multi-factor sign-in did not finish updating your session. Try another code, or use Back to sign in to start over.';
+          'Enter the current six-digit code from your authenticator app.';
         setError(message);
         announce(message, { politeness: 'assertive' });
         return;
       }
 
-      if (rememberDevice) {
-        saveMfaTrustBundle(
-          sessionAfterVerify.session,
-          getTrustedUntilMsAfterVerification(),
-        );
-      } else {
-        clearMfaTrustBundle();
-      }
+      setVerifyLoading(true);
+      try {
+        const challenge = await supabase.auth.mfa.challenge({
+          factorId: mfaFactorId,
+        });
+        if (challenge.error) {
+          throw challenge.error;
+        }
 
-      router.push('/patients');
-      router.refresh();
-    } catch (verifyError) {
-      const message = mapMfaVerifyErrorToUserMessage(verifyError);
-      setError(message);
-      announce(message, { politeness: 'assertive' });
+        const verify = await supabase.auth.mfa.verify({
+          factorId: mfaFactorId,
+          challengeId: challenge.data.id,
+          code: verifyCode,
+        });
+        if (verify.error) {
+          throw verify.error;
+        }
+
+        const { data: sessionAfterVerify, error: sessionAfterVerifyError } =
+          await supabase.auth.getSession();
+        if (sessionAfterVerifyError) {
+          console.error(sessionAfterVerifyError);
+          const message =
+            'Could not read your session after verification. Try a new code from your authenticator app, or use Back to sign in to start over.';
+          setError(message);
+          announce(message, { politeness: 'assertive' });
+          return;
+        }
+        if (sessionAfterVerify.session == null) {
+          const message =
+            'Your session could not be confirmed after verification. Try a new code from your authenticator app, or use Back to sign in to start over.';
+          setError(message);
+          announce(message, { politeness: 'assertive' });
+          return;
+        }
+
+        const assuranceAfterVerify =
+          await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+        if (assuranceAfterVerify.error) {
+          console.error(assuranceAfterVerify.error);
+          const message =
+            'Could not confirm multi-factor status after verification. Try a new code from your authenticator app, or use Back to sign in to start over.';
+          setError(message);
+          announce(message, { politeness: 'assertive' });
+          return;
+        }
+        if (assuranceAfterVerify.data.currentLevel !== 'aal2') {
+          const message =
+            'Multi-factor sign-in did not finish updating your session. Try another code, or use Back to sign in to start over.';
+          setError(message);
+          announce(message, { politeness: 'assertive' });
+          return;
+        }
+
+        if (deviceTrustFeatureEnabled && rememberDevice) {
+          saveMfaTrustBundle(
+            sessionAfterVerify.session,
+            getTrustedUntilMsAfterVerification(),
+          );
+        } else {
+          clearMfaTrustBundle();
+        }
+
+        router.push('/patients');
+        router.refresh();
+      } catch (verifyError) {
+        const message = mapMfaVerifyErrorToUserMessage(verifyError);
+        setError(message);
+        announce(message, { politeness: 'assertive' });
+      } finally {
+        setVerifyLoading(false);
+      }
     } finally {
-      setVerifyLoading(false);
+      verifyMfaInFlightRef.current = false;
     }
   };
 
@@ -474,15 +525,17 @@ export default function LoginPage() {
               />
             </div>
 
-            <label className="flex items-start gap-2 text-sm text-app-muted">
-              <input
-                type="checkbox"
-                className="mt-1 h-4 w-4 rounded border-app-border text-app-primary focus:ring-app-ring"
-                checked={rememberDevice}
-                onChange={(event) => setRememberDevice(event.target.checked)}
-              />
-              <span>Trust this device for 30 days.</span>
-            </label>
+            {deviceTrustFeatureEnabled ? (
+              <label className="flex items-start gap-2 text-sm text-app-muted">
+                <input
+                  type="checkbox"
+                  className="mt-1 h-4 w-4 rounded border-app-border text-app-primary focus:ring-app-ring"
+                  checked={rememberDevice}
+                  onChange={(event) => setRememberDevice(event.target.checked)}
+                />
+                <span>Trust this device for 30 days.</span>
+              </label>
+            ) : null}
 
             <button
               type="submit"

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -47,6 +47,9 @@ export default function LoginPage() {
     setStatus(null);
     setLoading(true);
 
+    /** True once password sign-in resolved a user; MFA/trust steps may still fail afterward. */
+    let sessionEstablishedAfterPassword = false;
+
     try {
       const { error: authError } = await signInWithEmailPassword(
         supabase,
@@ -69,6 +72,8 @@ export default function LoginPage() {
         announce(message, { politeness: 'assertive' });
         return;
       }
+
+      sessionEstablishedAfterPassword = true;
 
       const factorsResult = await supabase.auth.mfa.listFactors();
       if (factorsResult.error) {
@@ -114,10 +119,24 @@ export default function LoginPage() {
       announce(message, { politeness: 'assertive' });
     } catch (nextError) {
       console.error(nextError);
-      setError('Unable to sign in right now. Please try again.');
-      announce('Unable to sign in right now. Please try again.', {
-        politeness: 'assertive',
-      });
+      if (sessionEstablishedAfterPassword) {
+        try {
+          await supabase.auth.signOut();
+          clearMfaTrustBundle();
+        } catch (cleanupError) {
+          console.error(cleanupError);
+        }
+        router.refresh();
+        const message =
+          'Your password was accepted, but we could not finish verifying multi-factor sign-in. You have been signed out for safety. Please try again.';
+        setError(message);
+        announce(message, { politeness: 'assertive' });
+      } else {
+        const message =
+          'Unable to complete sign-in right now. Please try again.';
+        setError(message);
+        announce(message, { politeness: 'assertive' });
+      }
     } finally {
       setLoading(false);
     }

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -21,8 +21,6 @@ import {
   clearMfaTrustBundle,
   getTrustedUntilMsAfterVerification,
   isPractitionerMfaDeviceTrustEnabled,
-  readMfaTrustBundle,
-  refreshTrustedMfaBundleBeforePasswordSignIn,
   saveMfaTrustBundle,
   tryRestoreTrustedMfaSession,
 } from '../../lib/practitioner-device-trust';
@@ -125,8 +123,9 @@ async function waitForSessionWithJwtAal2(
  * `loading`, `step`, and `credentialLoginInFlightRef`) so parallel attempts cannot race. The MFA
  * verify form uses the same pattern (`verifyLoading`, `step`, `verifyMfaInFlightRef`).
  *
- * MFA “trust this device” is hidden when `isPractitionerMfaDeviceTrustEnabled()` is false
- * (`NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST` `false`/`0`; default on).
+ * MFA “trust this device” is hidden when `isPractitionerMfaDeviceTrustEnabled()` is false; see
+ * that function for `NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST` parsing (unset defaults on;
+ * unrecognized non-empty values disable).
  *
  * `resetToCredentials` centralizes fallback to the credentials step: it clears MFA-only UI
  * state (code, trust checkbox, status line) so a later MFA step is not prefilled from a prior
@@ -138,6 +137,10 @@ async function waitForSessionWithJwtAal2(
  *
  * Before navigating to `/patients`, the client waits until the session access token’s JWT `aal`
  * claim matches patient-route gating (not only `getAuthenticatorAssuranceLevel`).
+ *
+ * **Device trust:** the client does not call `refreshSession` from the stored bundle until after
+ * `signInWithEmailPassword` succeeds, so no authenticated session is persisted from the trust bundle
+ * before the password is verified.
  *
  * @returns Login UI.
  */
@@ -257,15 +260,8 @@ export default function LoginPage() {
 
     /** True once password sign-in resolved a user; MFA/trust steps may still fail afterward. */
     let sessionEstablishedAfterPassword = false;
-    /** True when we refreshed AAL2 from the trust bundle before the password grant (see device-trust module). */
-    let trustedBundlePrimed = false;
 
     try {
-      trustedBundlePrimed = await refreshTrustedMfaBundleBeforePasswordSignIn(
-        supabase,
-        email,
-      );
-
       const { error: authError } = await signInWithEmailPassword(
         supabase,
         email,
@@ -273,13 +269,6 @@ export default function LoginPage() {
       );
 
       if (authError) {
-        if (trustedBundlePrimed) {
-          try {
-            await supabase.auth.signOut();
-          } catch {
-            /* ignore */
-          }
-        }
         resetToCredentials({ message: authError.message });
         return;
       }
@@ -306,29 +295,10 @@ export default function LoginPage() {
 
       sessionEstablishedAfterPassword = true;
 
-      // Password-only sign-in is usually AAL1; patient routes require JWT `aal` aal2. Only skip MFA
-      // here when assurance and the access token both indicate AAL2; otherwise continue to tryRestore
-      // / MFA verify. Never write the trust bundle from a password-only (AAL1) session — that would
-      // replace valid AAL2 tokens and break future device-trust restores.
-      if (trustedBundlePrimed) {
-        const bundle = readMfaTrustBundle();
-        if (bundle != null && bundle.userId === user.id) {
-          const assuranceAfterPassword =
-            await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
-          if (
-            !assuranceAfterPassword.error &&
-            assuranceAfterPassword.data.currentLevel === 'aal2'
-          ) {
-            const sess = await waitForSessionWithJwtAal2(supabase);
-            if (sess) {
-              saveMfaTrustBundle(sess, bundle.trustedUntilMs);
-              router.push('/patients');
-              router.refresh();
-              return;
-            }
-          }
-        }
-      }
+      // Password-only sign-in is usually AAL1; patient routes require JWT `aal` aal2. Device-trust
+      // restore runs only after the password grant via `tryRestoreTrustedMfaSession` — we do not
+      // call `refreshSession` from the bundle before password (that would persist an authenticated
+      // session before the password is verified).
 
       const factorsResult = await supabase.auth.mfa.listFactors();
       if (factorsResult.error) {

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -4,6 +4,7 @@ import {
   hasMfaAssuranceAal2,
   parseAbstrackAccessTokenClaims,
   signInWithEmailPassword,
+  type Session,
 } from '@abstrack/supabase';
 import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
@@ -58,6 +59,52 @@ function buildMfaFactorChoices(factors: ListedTotpFactor[]): Array<{
   }));
 }
 
+/** Max polls when waiting for the access token JWT to include `aal: aal2` after assurance reports AAL2. */
+const JWT_AAL2_SYNC_MAX_ATTEMPTS = 8;
+const JWT_AAL2_SYNC_DELAY_MS = 75;
+
+/**
+ * Patient routes gate on JWT `aal` via `hasMfaAssuranceAal2` (see `resolvePractitionerAppGate` in
+ * `@abstrack/supabase`). After MFA or trust restore, `getAuthenticatorAssuranceLevel` can
+ * report AAL2 before Supabase refreshes the session JWT — briefly polls `getSession()` so we do
+ * not navigate to `/patients` while the gate would still see `aal1`.
+ *
+ * When `sessionHint` is set (e.g. the `getSession()` result right after `mfa.verify`), parses that
+ * token first so a token already showing `aal: aal2` avoids an extra round-trip and matches what
+ * the practitioner gate reads from the client session.
+ *
+ * @param supabase - Browser Supabase client.
+ * @param sessionHint - Optional session to parse before polling (same shape as `getSession().data.session`).
+ * @returns The session whose `access_token` parses to AAL2, or `null` if still stale / missing.
+ */
+async function waitForSessionWithJwtAal2(
+  supabase: ReturnType<typeof getSupabaseBrowserClient>,
+  sessionHint?: Session | null,
+): Promise<Session | null> {
+  if (sessionHint?.access_token != null) {
+    const hintClaims = parseAbstrackAccessTokenClaims(sessionHint.access_token);
+    if (hasMfaAssuranceAal2(hintClaims)) {
+      return sessionHint;
+    }
+  }
+  for (let attempt = 0; attempt < JWT_AAL2_SYNC_MAX_ATTEMPTS; attempt++) {
+    if (attempt > 0) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, JWT_AAL2_SYNC_DELAY_MS),
+      );
+    }
+    const { data, error } = await supabase.auth.getSession();
+    if (error || data.session?.access_token == null) {
+      return null;
+    }
+    const claims = parseAbstrackAccessTokenClaims(data.session.access_token);
+    if (hasMfaAssuranceAal2(claims)) {
+      return data.session;
+    }
+  }
+  return null;
+}
+
 /**
  * Practitioner email/password login with MFA step-up and optional device trust (browser storage).
  * Successful verification with “Trust this device” unchecked clears any stored bundle so trust
@@ -88,6 +135,9 @@ function buildMfaFactorChoices(factors: ListedTotpFactor[]): Array<{
  *
  * When several verified TOTP factors exist, the MFA step shows an **Authenticator** combobox
  * (friendly name or “Authenticator N”) so challenge/verify use the factor the user selects.
+ *
+ * Before navigating to `/patients`, the client waits until the session access token’s JWT `aal`
+ * claim matches patient-route gating (not only `getAuthenticatorAssuranceLevel`).
  *
  * @returns Login UI.
  */
@@ -125,12 +175,8 @@ export default function LoginPage() {
   const prevStepRef = useRef<LoginStep>(step);
 
   /**
-   * Returns the UI to the credentials step and clears MFA-only state so later flows are not
-   * prefilled from a prior attempt. Optionally sets an assertive error line and matching live
-   * announcement, and clears the password after abandoned or session-ending sign-in.
-   *
-   * @param options.message - When set, passed to `setError` and `announce` (assertive).
-   * @param options.clearPassword - Clears the password field when true.
+   * When device trust is disabled (`NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST`), clears
+   * remember-device state so it cannot remain true while the trust UI is hidden.
    */
   useEffect(() => {
     if (!deviceTrustFeatureEnabled) {
@@ -168,6 +214,14 @@ export default function LoginPage() {
     return undefined;
   }, [step, mfaFactorChoices.length]);
 
+  /**
+   * Returns the UI to the credentials step and clears MFA-only state so later flows are not
+   * prefilled from a prior attempt. Optionally sets an assertive error line and matching live
+   * announcement, and clears the password after abandoned or session-ending sign-in.
+   *
+   * @param options.message - When set, passed to `setError` and `announce` (assertive).
+   * @param options.clearPassword - Clears the password field when true.
+   */
   const resetToCredentials = useCallback(
     (options?: { clearPassword?: boolean; message?: string }) => {
       setStep('credentials');
@@ -265,10 +319,8 @@ export default function LoginPage() {
             !assuranceAfterPassword.error &&
             assuranceAfterPassword.data.currentLevel === 'aal2'
           ) {
-            const sessionWrap = await supabase.auth.getSession();
-            const sess = sessionWrap.data.session;
-            const claims = parseAbstrackAccessTokenClaims(sess?.access_token);
-            if (sess && hasMfaAssuranceAal2(claims)) {
+            const sess = await waitForSessionWithJwtAal2(supabase);
+            if (sess) {
               saveMfaTrustBundle(sess, bundle.trustedUntilMs);
               router.push('/patients');
               router.refresh();
@@ -301,9 +353,13 @@ export default function LoginPage() {
         user.id,
       );
       if (restoreOutcome.status === 'restored') {
-        router.push('/patients');
-        router.refresh();
-        return;
+        const sessionWithJwtAal2 = await waitForSessionWithJwtAal2(supabase);
+        if (sessionWithJwtAal2 != null) {
+          router.push('/patients');
+          router.refresh();
+          return;
+        }
+        /* Else: JWT `aal` may still lag; fall through to session/assurance checks. */
       }
       if (restoreOutcome.status === 'signed_out') {
         router.refresh();
@@ -356,9 +412,13 @@ export default function LoginPage() {
       }
 
       if (assurance.data.currentLevel === 'aal2') {
-        router.push('/patients');
-        router.refresh();
-        return;
+        const sessionWithJwtAal2 = await waitForSessionWithJwtAal2(supabase);
+        if (sessionWithJwtAal2 != null) {
+          router.push('/patients');
+          router.refresh();
+          return;
+        }
+        /* Fall through to MFA step when JWT `aal` still reflects AAL1. */
       }
 
       setMfaFactorChoices(
@@ -482,9 +542,21 @@ export default function LoginPage() {
           return;
         }
 
+        const sessionWithJwtAal2 = await waitForSessionWithJwtAal2(
+          supabase,
+          sessionAfterVerify.session,
+        );
+        if (sessionWithJwtAal2 == null) {
+          const message =
+            'Your session did not show full two-factor verification yet. Try another code, or use Back to sign in to start over.';
+          setError(message);
+          announce(message, { politeness: 'assertive' });
+          return;
+        }
+
         if (deviceTrustFeatureEnabled && rememberDevice) {
           saveMfaTrustBundle(
-            sessionAfterVerify.session,
+            sessionWithJwtAal2,
             getTrustedUntilMsAfterVerification(),
           );
         } else {

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -30,7 +30,9 @@ type LoginStep = 'credentials' | 'mfa_verify';
  * {@link tryRestoreTrustedMfaSession} (discriminated: `restored`, `not_restored`, or `signed_out`;
  * some outcomes sign the user out), the client re-checks `getSession` when the outcome is
  * `not_restored` before reading assurance or showing the MFA step so a missing session cannot be
- * mistaken for a password session still awaiting TOTP.
+ * mistaken for a password session still awaiting TOTP. If the post-restore session user id does not
+ * match the account from password sign-in, the client signs out and clears the trust bundle before
+ * prompting for credentials again.
  *
  * @returns Login UI.
  */
@@ -149,8 +151,15 @@ export default function LoginPage() {
         return;
       }
       if (afterRestoreSession.data.session.user.id !== user.id) {
+        try {
+          await supabase.auth.signOut();
+          clearMfaTrustBundle();
+        } catch (cleanupError) {
+          console.error(cleanupError);
+        }
+        router.refresh();
         const message =
-          'Your session no longer matches this sign-in after the saved device check. Enter your email and password again.';
+          'Your session no longer matches this sign-in after the saved device check. You have been signed out for safety. Enter your email and password again.';
         setError(message);
         announce(message, { politeness: 'assertive' });
         setStep('credentials');

--- a/apps/practitioner/src/app/page.tsx
+++ b/apps/practitioner/src/app/page.tsx
@@ -14,9 +14,6 @@ import {
 } from '../lib/mfa-user-messages';
 import { PractitionerSignOutButton } from '../components/practitioner-sign-out-button';
 
-const PRACTITIONER_SIGN_OUT_BUTTON_CLASS =
-  'min-h-11 rounded-md border border-app-border bg-app-surface px-4 py-2 text-sm font-medium text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg';
-
 type TotpEnrollment = {
   id: string;
   qrCodeImageSrc: string;
@@ -390,9 +387,7 @@ export default function Index() {
           signing in again. If this keeps happening, try again later.
         </p>
         <div className="mt-6">
-          <PractitionerSignOutButton
-            className={PRACTITIONER_SIGN_OUT_BUTTON_CLASS}
-          />
+          <PractitionerSignOutButton />
         </div>
       </div>
     );
@@ -413,9 +408,7 @@ export default function Index() {
           accounts must be created through the correct invitation flow.
         </p>
         <div className="mt-6">
-          <PractitionerSignOutButton
-            className={PRACTITIONER_SIGN_OUT_BUTTON_CLASS}
-          />
+          <PractitionerSignOutButton />
         </div>
       </div>
     );
@@ -441,9 +434,7 @@ export default function Index() {
           app.
         </p>
         <div className="mt-6">
-          <PractitionerSignOutButton
-            className={PRACTITIONER_SIGN_OUT_BUTTON_CLASS}
-          />
+          <PractitionerSignOutButton />
         </div>
       </div>
     );
@@ -482,9 +473,7 @@ export default function Index() {
         ) : null}
         <div className="mt-4 flex flex-wrap items-center gap-3">
           {isAuthenticated ? (
-            <PractitionerSignOutButton
-              className={PRACTITIONER_SIGN_OUT_BUTTON_CLASS}
-            />
+            <PractitionerSignOutButton />
           ) : (
             <Link
               href="/login"

--- a/apps/practitioner/src/app/page.tsx
+++ b/apps/practitioner/src/app/page.tsx
@@ -12,6 +12,10 @@ import {
   mapMfaVerifyErrorToUserMessage,
   normalizeTotpCode,
 } from '../lib/mfa-user-messages';
+import { PractitionerSignOutButton } from '../components/practitioner-sign-out-button';
+
+const PRACTITIONER_SIGN_OUT_BUTTON_CLASS =
+  'min-h-11 rounded-md border border-app-border bg-app-surface px-4 py-2 text-sm font-medium text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg';
 
 type TotpEnrollment = {
   id: string;
@@ -385,14 +389,11 @@ export default function Index() {
           Something went wrong while loading your account. Try signing out and
           signing in again. If this keeps happening, try again later.
         </p>
-        <form action="/api/auth/logout" method="POST" className="mt-6">
-          <button
-            type="submit"
-            className="min-h-11 rounded-md border border-app-border bg-app-surface px-4 py-2 text-sm font-medium text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-          >
-            Log out
-          </button>
-        </form>
+        <div className="mt-6">
+          <PractitionerSignOutButton
+            className={PRACTITIONER_SIGN_OUT_BUTTON_CLASS}
+          />
+        </div>
       </div>
     );
   }
@@ -411,14 +412,11 @@ export default function Index() {
           This sign-in does not have an ABStrack profile yet. Practitioner
           accounts must be created through the correct invitation flow.
         </p>
-        <form action="/api/auth/logout" method="POST" className="mt-6">
-          <button
-            type="submit"
-            className="min-h-11 rounded-md border border-app-border bg-app-surface px-4 py-2 text-sm font-medium text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-          >
-            Log out
-          </button>
-        </form>
+        <div className="mt-6">
+          <PractitionerSignOutButton
+            className={PRACTITIONER_SIGN_OUT_BUTTON_CLASS}
+          />
+        </div>
       </div>
     );
   }
@@ -442,14 +440,11 @@ export default function Index() {
           Sign out to use a different account, or open the patient or caretaker
           app.
         </p>
-        <form action="/api/auth/logout" method="POST" className="mt-6">
-          <button
-            type="submit"
-            className="min-h-11 rounded-md border border-app-border bg-app-surface px-4 py-2 text-sm font-medium text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-          >
-            Log out
-          </button>
-        </form>
+        <div className="mt-6">
+          <PractitionerSignOutButton
+            className={PRACTITIONER_SIGN_OUT_BUTTON_CLASS}
+          />
+        </div>
       </div>
     );
   }
@@ -485,16 +480,11 @@ export default function Index() {
             Signed in as {userEmail}
           </p>
         ) : null}
-        <div className="mt-4">
+        <div className="mt-4 flex flex-wrap items-center gap-3">
           {isAuthenticated ? (
-            <form action="/api/auth/logout" method="POST">
-              <button
-                type="submit"
-                className="min-h-11 rounded-md border border-app-border bg-app-surface px-4 py-2 text-sm font-medium text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-              >
-                Log out
-              </button>
-            </form>
+            <PractitionerSignOutButton
+              className={PRACTITIONER_SIGN_OUT_BUTTON_CLASS}
+            />
           ) : (
             <Link
               href="/login"
@@ -503,6 +493,14 @@ export default function Index() {
               Log in
             </Link>
           )}
+          {mfaAssuranceReady && mfaReady ? (
+            <Link
+              href="/patients"
+              className="inline-flex min-h-11 items-center rounded-md bg-emerald-800 px-4 py-2 text-sm font-medium text-white transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:bg-emerald-700"
+            >
+              Patient workspace
+            </Link>
+          ) : null}
         </div>
       </header>
 

--- a/apps/practitioner/src/app/page.tsx
+++ b/apps/practitioner/src/app/page.tsx
@@ -75,7 +75,7 @@ async function otpauthUriToQrPngDataUrl(otpauthUri: string): Promise<string> {
 }
 
 /**
- * Practitioner security setup page for TOTP MFA enrollment and verification.
+ * Practitioner home: TOTP MFA enrollment and session verification.
  *
  * @returns Client page rendering enrollment status and setup actions.
  */
@@ -447,7 +447,7 @@ export default function Index() {
     <div id="practitioner-home" className="mx-auto max-w-2xl px-4 py-8 sm:px-6">
       <header className="mb-6">
         <h1 className="text-2xl font-semibold text-app-ink">
-          Practitioner security setup
+          Two-factor authentication
         </h1>
         <p className="mt-2 text-sm text-app-muted">
           Enroll at least one TOTP factor to make this practitioner account

--- a/apps/practitioner/src/app/patients/[patientId]/page.tsx
+++ b/apps/practitioner/src/app/patients/[patientId]/page.tsx
@@ -1,0 +1,28 @@
+type PatientDetailPageProps = {
+  params: Promise<{ patientId: string }>;
+};
+
+/**
+ * Per-patient practitioner view (placeholder). The parent layout enforces MFA before this renders.
+ *
+ * @param props - Dynamic route params.
+ * @returns Patient detail shell.
+ */
+export default async function PatientDetailPage({
+  params,
+}: PatientDetailPageProps) {
+  const { patientId } = await params;
+
+  return (
+    <div
+      id="practitioner-patient-detail"
+      className="mx-auto max-w-3xl px-4 py-8 sm:px-6"
+    >
+      <h1 className="text-2xl font-semibold text-app-ink">Patient</h1>
+      <p className="mt-2 font-mono text-sm text-app-muted">{patientId}</p>
+      <p className="mt-4 text-sm text-app-muted">
+        Detailed patient tools will appear here as they are implemented.
+      </p>
+    </div>
+  );
+}

--- a/apps/practitioner/src/app/patients/[patientId]/page.tsx
+++ b/apps/practitioner/src/app/patients/[patientId]/page.tsx
@@ -1,5 +1,5 @@
 type PatientDetailPageProps = {
-  params: Promise<{ patientId: string }>;
+  params: { patientId: string };
 };
 
 /**
@@ -8,10 +8,8 @@ type PatientDetailPageProps = {
  * @param props - Dynamic route params.
  * @returns Patient detail shell.
  */
-export default async function PatientDetailPage({
-  params,
-}: PatientDetailPageProps) {
-  const { patientId } = await params;
+export default function PatientDetailPage({ params }: PatientDetailPageProps) {
+  const { patientId } = params;
 
   return (
     <div

--- a/apps/practitioner/src/app/patients/layout.tsx
+++ b/apps/practitioner/src/app/patients/layout.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { ReactNode } from 'react';
 import { PractitionerPatientRoutesGate } from '@/components/practitioner-patient-routes-gate';
 

--- a/apps/practitioner/src/app/patients/layout.tsx
+++ b/apps/practitioner/src/app/patients/layout.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { PractitionerPatientRoutesGate } from '@/components/practitioner-patient-routes-gate';
+
+/**
+ * Patient-data routes require verified TOTP enrollment and an AAL2 session before rendering.
+ *
+ * @param props - Nested segment content.
+ * @returns Gate-wrapped subtree.
+ */
+export default function PatientsLayout({ children }: { children: ReactNode }) {
+  return (
+    <PractitionerPatientRoutesGate>{children}</PractitionerPatientRoutesGate>
+  );
+}

--- a/apps/practitioner/src/app/patients/page.tsx
+++ b/apps/practitioner/src/app/patients/page.tsx
@@ -1,0 +1,19 @@
+/**
+ * Practitioner patient directory entry point (placeholder). Authorization for PHI remains enforced
+ * by Supabase RLS; this route is gated in `patients/layout.tsx` until MFA requirements are met.
+ *
+ * @returns Patient workspace shell.
+ */
+export default function PatientsPage() {
+  return (
+    <div
+      id="practitioner-patients-home"
+      className="mx-auto max-w-3xl px-4 py-8 sm:px-6"
+    >
+      <h1 className="text-2xl font-semibold text-app-ink">Patients</h1>
+      <p className="mt-2 text-sm text-app-muted">
+        Patient workflows will appear here once connected to your account.
+      </p>
+    </div>
+  );
+}

--- a/apps/practitioner/src/components/practitioner-patient-routes-gate.tsx
+++ b/apps/practitioner/src/components/practitioner-patient-routes-gate.tsx
@@ -9,9 +9,6 @@ import { getPatientDataMfaBlockReason } from '@/lib/practitioner-patient-data-ac
 import { usePractitionerVerifiedTotpCount } from '@/lib/use-practitioner-verified-totp';
 import { PractitionerSignOutButton } from './practitioner-sign-out-button';
 
-const PRACTITIONER_SIGN_OUT_BUTTON_CLASS =
-  'min-h-11 rounded-md border border-app-border bg-app-surface px-4 py-2 text-sm font-medium text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg';
-
 const MFA_BLOCK_COPY = {
   enrollment: {
     title: 'Set up two-factor authentication first',
@@ -130,9 +127,7 @@ export function PractitionerPatientRoutesGate({
           >
             Try again
           </button>
-          <PractitionerSignOutButton
-            className={PRACTITIONER_SIGN_OUT_BUTTON_CLASS}
-          />
+          <PractitionerSignOutButton />
         </div>
       </div>
     );
@@ -222,10 +217,7 @@ export function PractitionerPatientRoutesGate({
             >
               Open security setup
             </Link>
-            <PractitionerSignOutButton
-              label="Sign out and try again"
-              className={PRACTITIONER_SIGN_OUT_BUTTON_CLASS}
-            />
+            <PractitionerSignOutButton label="Sign out and try again" />
           </div>
         </div>
       );
@@ -253,9 +245,7 @@ function IdentityBarrier({
       <h1 className="text-xl font-semibold text-app-ink">{title}</h1>
       <p className="mt-3 text-sm text-app-muted">{description}</p>
       <div className="mt-6">
-        <PractitionerSignOutButton
-          className={PRACTITIONER_SIGN_OUT_BUTTON_CLASS}
-        />
+        <PractitionerSignOutButton />
       </div>
     </div>
   );
@@ -272,9 +262,7 @@ function UnexpectedGateFallback({ gate }: { gate: PractitionerAppGate }) {
         Unexpected gate state: {gate.kind}. Please refresh or sign out.
       </p>
       <div className="mt-4">
-        <PractitionerSignOutButton
-          className={PRACTITIONER_SIGN_OUT_BUTTON_CLASS}
-        />
+        <PractitionerSignOutButton />
       </div>
     </div>
   );

--- a/apps/practitioner/src/components/practitioner-patient-routes-gate.tsx
+++ b/apps/practitioner/src/components/practitioner-patient-routes-gate.tsx
@@ -272,7 +272,9 @@ function UnexpectedGateFallback({ gate }: { gate: PractitionerAppGate }) {
         Unexpected gate state: {gate.kind}. Please refresh or sign out.
       </p>
       <div className="mt-4">
-        <PractitionerSignOutButton className="min-h-11 rounded-md border border-app-border bg-app-surface px-4 py-2 text-sm font-medium text-app-ink" />
+        <PractitionerSignOutButton
+          className={PRACTITIONER_SIGN_OUT_BUTTON_CLASS}
+        />
       </div>
     </div>
   );

--- a/apps/practitioner/src/components/practitioner-patient-routes-gate.tsx
+++ b/apps/practitioner/src/components/practitioner-patient-routes-gate.tsx
@@ -1,0 +1,279 @@
+'use client';
+
+import type { PractitionerAppGate } from '@abstrack/supabase';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import Link from 'next/link';
+import { useEffect, useRef, type ReactNode } from 'react';
+import { useAuth } from '../lib/auth-provider';
+import { getPatientDataMfaBlockReason } from '../lib/practitioner-patient-data-access';
+import { usePractitionerVerifiedTotpCount } from '../lib/use-practitioner-verified-totp';
+import { PractitionerSignOutButton } from './practitioner-sign-out-button';
+
+const PRACTITIONER_SIGN_OUT_BUTTON_CLASS =
+  'min-h-11 rounded-md border border-app-border bg-app-surface px-4 py-2 text-sm font-medium text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg';
+
+const MFA_BLOCK_COPY = {
+  enrollment: {
+    title: 'Set up two-factor authentication first',
+    body: 'Patient records are available only after you enroll and verify at least one TOTP factor, then complete the MFA step for this session.',
+    announce:
+      'Patient data is blocked. Enroll and verify TOTP on the security setup page before opening patient records.',
+  },
+  aal2: {
+    title: 'Complete two-factor sign-in for this session',
+    body: 'Your account has MFA, but this session is not verified to the level required for patient data. Sign out and sign in again, then complete the two-factor prompt. You can also return to security setup for guidance.',
+    announce:
+      'Patient data is blocked until this session completes two-factor authentication. Sign out and sign in again, or open security setup.',
+  },
+} as const;
+
+/**
+ * Blocks rendering of practitioner patient-data routes until the session has verified TOTP
+ * enrollment and JWT MFA assurance (AAL2). Announces blocking reasons for assistive technology
+ * and provides keyboard-reachable actions.
+ *
+ * @param props - React children rendered only when MFA requirements are satisfied.
+ * @returns Gate UI or nested routes.
+ */
+export function PractitionerPatientRoutesGate({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const { announce } = useAnnounce();
+  const { loading: authLoading, session, gate } = useAuth();
+  const practitionerGate = gate.kind === 'practitioner' ? gate : null;
+  const totpEnabled = gate.kind === 'practitioner';
+  const {
+    verifiedTotpCount,
+    loading: totpLoading,
+    error: totpError,
+    refresh: refreshTotpFactors,
+  } = usePractitionerVerifiedTotpCount(totpEnabled);
+
+  const awaitingProfile = gate.kind === 'profile_loading';
+  const showSpinner =
+    authLoading ||
+    awaitingProfile ||
+    (gate.kind === 'practitioner' && totpLoading);
+
+  const mfaGateHeadingRef = useRef<HTMLHeadingElement>(null);
+  const signInHeadingRef = useRef<HTMLHeadingElement>(null);
+  const lastMfaBlockAnnounced = useRef<'enrollment' | 'aal2' | null>(null);
+
+  const mfaBlockReason =
+    practitionerGate == null
+      ? null
+      : getPatientDataMfaBlockReason(practitionerGate, verifiedTotpCount);
+
+  useEffect(() => {
+    if (mfaBlockReason !== 'enrollment' && mfaBlockReason !== 'aal2') {
+      lastMfaBlockAnnounced.current = null;
+      return;
+    }
+    if (lastMfaBlockAnnounced.current === mfaBlockReason) {
+      return;
+    }
+    lastMfaBlockAnnounced.current = mfaBlockReason;
+    announce(MFA_BLOCK_COPY[mfaBlockReason].announce, {
+      politeness: 'assertive',
+    });
+    queueMicrotask(() => {
+      mfaGateHeadingRef.current?.focus();
+    });
+  }, [announce, mfaBlockReason]);
+
+  useEffect(() => {
+    const showSignInGate = gate.kind === 'signed_out' || !session?.access_token;
+    if (!showSignInGate || showSpinner) {
+      return;
+    }
+    queueMicrotask(() => {
+      signInHeadingRef.current?.focus();
+    });
+  }, [gate.kind, session?.access_token, showSpinner]);
+
+  if (showSpinner) {
+    return (
+      <div
+        id="practitioner-patient-gate-root"
+        className="flex min-h-screen flex-col items-center justify-center bg-app-bg bg-app-gradient px-4 py-12 sm:px-6 lg:px-8"
+        role="status"
+        aria-busy="true"
+        aria-live="polite"
+      >
+        <p className="text-center text-sm text-app-muted">
+          Checking access to patient data…
+        </p>
+      </div>
+    );
+  }
+
+  if (totpEnabled && totpError) {
+    return (
+      <div
+        id="practitioner-patient-gate-root"
+        className="mx-auto max-w-lg px-4 py-12 sm:px-6"
+        role="alert"
+      >
+        <h1 className="text-xl font-semibold text-app-ink">
+          Could not verify MFA status
+        </h1>
+        <p className="mt-3 text-sm text-app-muted">
+          Try again. If this continues, sign out and sign back in.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={() => void refreshTotpFactors()}
+            className="min-h-11 rounded-md bg-app-primary px-4 py-2 text-sm font-medium text-white transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          >
+            Try again
+          </button>
+          <PractitionerSignOutButton
+            className={PRACTITIONER_SIGN_OUT_BUTTON_CLASS}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (gate.kind === 'signed_out' || !session?.access_token) {
+    return (
+      <div
+        id="practitioner-patient-gate-root"
+        className="mx-auto max-w-lg px-4 py-12 sm:px-6"
+        role="region"
+        aria-labelledby="patient-gate-sign-in-heading"
+      >
+        <h1
+          id="patient-gate-sign-in-heading"
+          className="text-xl font-semibold text-app-ink"
+          tabIndex={-1}
+          ref={signInHeadingRef}
+        >
+          Sign in required
+        </h1>
+        <p className="mt-3 text-sm text-app-muted">
+          Sign in with your practitioner account to access patient workflows.
+        </p>
+        <div className="mt-6">
+          <Link
+            href="/login"
+            className="inline-flex min-h-11 items-center justify-center rounded-md bg-app-primary px-4 py-2 text-sm font-medium text-white transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          >
+            Go to sign in
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (gate.kind === 'profile_error') {
+    return (
+      <IdentityBarrier
+        title="Could not load your profile"
+        description="Something went wrong while loading your account. Try signing out and signing in again. If this keeps happening, try again later."
+      />
+    );
+  }
+
+  if (gate.kind === 'profile_missing') {
+    return (
+      <IdentityBarrier
+        title="No profile for this account"
+        description="This sign-in does not have an ABStrack profile yet. Practitioner accounts must be created through the correct invitation flow."
+      />
+    );
+  }
+
+  if (gate.kind === 'wrong_app_role') {
+    return (
+      <IdentityBarrier
+        title="Wrong account type for this app"
+        description={`This app is for healthcare practitioners. Your account is registered as ${gate.appRole}. Use the patient or caretaker app instead.`}
+      />
+    );
+  }
+
+  if (gate.kind === 'practitioner') {
+    if (mfaBlockReason === 'enrollment' || mfaBlockReason === 'aal2') {
+      const copy = MFA_BLOCK_COPY[mfaBlockReason];
+      return (
+        <div
+          id="practitioner-patient-gate-root"
+          className="mx-auto max-w-lg px-4 py-12 sm:px-6"
+          role="region"
+          aria-labelledby="patient-mfa-gate-heading"
+        >
+          <h1
+            id="patient-mfa-gate-heading"
+            ref={mfaGateHeadingRef}
+            tabIndex={-1}
+            className="text-xl font-semibold text-app-ink"
+          >
+            {copy.title}
+          </h1>
+          <p className="mt-3 text-sm text-app-muted">{copy.body}</p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Link
+              href="/"
+              className="inline-flex min-h-11 items-center justify-center rounded-md bg-app-primary px-4 py-2 text-sm font-medium text-white transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+            >
+              Open security setup
+            </Link>
+            <PractitionerSignOutButton
+              label="Sign out and try again"
+              className={PRACTITIONER_SIGN_OUT_BUTTON_CLASS}
+            />
+          </div>
+        </div>
+      );
+    }
+
+    return <>{children}</>;
+  }
+
+  return <UnexpectedGateFallback gate={gate} />;
+}
+
+function IdentityBarrier({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div
+      id="practitioner-patient-gate-root"
+      className="mx-auto max-w-lg px-4 py-12 sm:px-6"
+      role="alert"
+    >
+      <h1 className="text-xl font-semibold text-app-ink">{title}</h1>
+      <p className="mt-3 text-sm text-app-muted">{description}</p>
+      <div className="mt-6">
+        <PractitionerSignOutButton
+          className={PRACTITIONER_SIGN_OUT_BUTTON_CLASS}
+        />
+      </div>
+    </div>
+  );
+}
+
+function UnexpectedGateFallback({ gate }: { gate: PractitionerAppGate }) {
+  return (
+    <div
+      id="practitioner-patient-gate-root"
+      className="px-4 py-12"
+      role="alert"
+    >
+      <p className="text-sm text-app-muted">
+        Unexpected gate state: {gate.kind}. Please refresh or sign out.
+      </p>
+      <div className="mt-4">
+        <PractitionerSignOutButton className="min-h-11 rounded-md border border-app-border bg-app-surface px-4 py-2 text-sm font-medium text-app-ink" />
+      </div>
+    </div>
+  );
+}

--- a/apps/practitioner/src/components/practitioner-patient-routes-gate.tsx
+++ b/apps/practitioner/src/components/practitioner-patient-routes-gate.tsx
@@ -48,11 +48,8 @@ export function PractitionerPatientRoutesGate({
     refresh: refreshTotpFactors,
   } = usePractitionerVerifiedTotpCount(totpEnabled);
 
-  const awaitingProfile = gate.kind === 'profile_loading';
   const showSpinner =
-    authLoading ||
-    awaitingProfile ||
-    (gate.kind === 'practitioner' && totpLoading);
+    authLoading || (gate.kind === 'practitioner' && totpLoading);
 
   const mfaGateHeadingRef = useRef<HTMLHeadingElement>(null);
   const signInHeadingRef = useRef<HTMLHeadingElement>(null);

--- a/apps/practitioner/src/components/practitioner-patient-routes-gate.tsx
+++ b/apps/practitioner/src/components/practitioner-patient-routes-gate.tsx
@@ -14,13 +14,13 @@ const MFA_BLOCK_COPY = {
     title: 'Set up two-factor authentication first',
     body: 'Patient records are available only after you enroll and verify at least one TOTP factor, then complete the MFA step for this session.',
     announce:
-      'Patient data is blocked. Enroll and verify TOTP on the security setup page before opening patient records.',
+      'Patient data is blocked. Enroll and verify TOTP before opening patient records.',
   },
   aal2: {
     title: 'Complete two-factor sign-in for this session',
-    body: 'Your account has MFA, but this session is not verified to the level required for patient data. Sign out and sign in again, then complete the two-factor prompt. You can also return to security setup for guidance.',
+    body: 'Your account has MFA, but this session is not verified to the level required for patient data. Sign out, sign in again, and enter your authenticator code when prompted.',
     announce:
-      'Patient data is blocked until this session completes two-factor authentication. Sign out and sign in again, or open security setup.',
+      'Patient data is blocked until this session completes two-factor authentication. Sign out and sign in again.',
   },
 } as const;
 
@@ -208,12 +208,21 @@ export function PractitionerPatientRoutesGate({
           </h1>
           <p className="mt-3 text-sm text-app-muted">{copy.body}</p>
           <div className="mt-6 flex flex-wrap gap-3">
-            <Link
-              href="/"
-              className="inline-flex min-h-11 items-center justify-center rounded-md bg-app-primary px-4 py-2 text-sm font-medium text-white transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-            >
-              Open security setup
-            </Link>
+            {mfaBlockReason === 'enrollment' ? (
+              <Link
+                href="/"
+                className="inline-flex min-h-11 items-center justify-center rounded-md bg-app-primary px-4 py-2 text-sm font-medium text-white transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+              >
+                Set up two-factor authentication
+              </Link>
+            ) : (
+              <Link
+                href="/login"
+                className="inline-flex min-h-11 items-center justify-center rounded-md bg-app-primary px-4 py-2 text-sm font-medium text-white transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+              >
+                Go to sign in
+              </Link>
+            )}
             <PractitionerSignOutButton label="Sign out and try again" />
           </div>
         </div>

--- a/apps/practitioner/src/components/practitioner-patient-routes-gate.tsx
+++ b/apps/practitioner/src/components/practitioner-patient-routes-gate.tsx
@@ -4,9 +4,9 @@ import type { PractitionerAppGate } from '@abstrack/supabase';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import Link from 'next/link';
 import { useEffect, useRef, type ReactNode } from 'react';
-import { useAuth } from '../lib/auth-provider';
-import { getPatientDataMfaBlockReason } from '../lib/practitioner-patient-data-access';
-import { usePractitionerVerifiedTotpCount } from '../lib/use-practitioner-verified-totp';
+import { useAuth } from '@/lib/auth-provider';
+import { getPatientDataMfaBlockReason } from '@/lib/practitioner-patient-data-access';
+import { usePractitionerVerifiedTotpCount } from '@/lib/use-practitioner-verified-totp';
 import { PractitionerSignOutButton } from './practitioner-sign-out-button';
 
 const PRACTITIONER_SIGN_OUT_BUTTON_CLASS =

--- a/apps/practitioner/src/components/practitioner-sign-out-button.tsx
+++ b/apps/practitioner/src/components/practitioner-sign-out-button.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
+import { useMemo } from 'react';
+import { practitionerSignOut } from '@/lib/practitioner-device-trust';
+
+export type PractitionerSignOutButtonProps = {
+  /** Visible button label. */
+  label?: string;
+  /** Tailwind / layout classes (match previous `<form><button>` styling). */
+  className?: string;
+};
+
+/**
+ * Practitioner sign-out: respects MFA device trust (soft local clear) vs full Supabase revocation.
+ *
+ * @param props - Label and styling.
+ * @returns Accessible button that signs out and navigates to `/login`.
+ */
+export function PractitionerSignOutButton({
+  label = 'Log out',
+  className,
+}: PractitionerSignOutButtonProps) {
+  const supabase = useMemo(() => getSupabaseBrowserClient(), []);
+
+  return (
+    <button
+      type="button"
+      data-testid="practitioner-sign-out"
+      className={className}
+      onClick={() => void practitionerSignOut(supabase)}
+    >
+      {label}
+    </button>
+  );
+}

--- a/apps/practitioner/src/components/practitioner-sign-out-button.tsx
+++ b/apps/practitioner/src/components/practitioner-sign-out-button.tsx
@@ -80,6 +80,9 @@ export function PractitionerSignOutButton({
     void practitionerSignOut(supabase)
       .catch((err: unknown) => {
         console.error('Practitioner sign out failed', err);
+        if (!mountedRef.current) {
+          return;
+        }
         const message =
           err instanceof Error
             ? err.message

--- a/apps/practitioner/src/components/practitioner-sign-out-button.tsx
+++ b/apps/practitioner/src/components/practitioner-sign-out-button.tsx
@@ -9,19 +9,24 @@ import {
   practitionerSignOutEverywhere,
 } from '@/lib/practitioner-device-trust';
 
-const SECONDARY_SIGN_OUT_CLASS =
+/** Default surface styling for primary and secondary sign-out controls. */
+const SIGN_OUT_BUTTON_SURFACE_CLASS =
   'min-h-11 rounded-md border border-app-border bg-app-surface px-4 py-2 text-sm font-medium text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg';
 
 export type PractitionerSignOutButtonProps = {
   /** Visible button label for the default (session-aware) sign-out. */
   label?: string;
-  /** Tailwind / layout classes for the primary sign-out control. */
+  /**
+   * Tailwind / layout classes for the primary sign-out control. When omitted, a built-in surface
+   * style is used; pass a string to override completely.
+   */
   className?: string;
 };
 
 /**
  * Practitioner sign-out: default action respects MFA device trust (soft local clear) when active;
- * secondary action performs full server sign-out via `POST /api/auth/logout`.
+ * secondary action performs full server sign-out via `POST /api/auth/logout`. Primary and secondary
+ * buttons share a default surface style; pass `className` on the primary control only to override.
  *
  * @param props - Labels and styling.
  * @returns Accessible sign-out controls and optional trust explanation.
@@ -30,6 +35,7 @@ export function PractitionerSignOutButton({
   label = 'Log out',
   className,
 }: PractitionerSignOutButtonProps) {
+  const primaryClassName = className ?? SIGN_OUT_BUTTON_SURFACE_CLASS;
   const supabase = useMemo(() => getSupabaseBrowserClient(), []);
   const { announce } = useAnnounce();
   const [signingOut, setSigningOut] = useState(false);
@@ -125,7 +131,7 @@ export function PractitionerSignOutButton({
         <button
           type="button"
           data-testid="practitioner-sign-out"
-          className={className}
+          className={primaryClassName}
           disabled={busy}
           {...(busy ? { 'aria-busy': true as const } : {})}
           aria-describedby={
@@ -138,7 +144,7 @@ export function PractitionerSignOutButton({
         <button
           type="button"
           data-testid="practitioner-sign-out-everywhere"
-          className={SECONDARY_SIGN_OUT_CLASS}
+          className={SIGN_OUT_BUTTON_SURFACE_CLASS}
           disabled={busy}
           {...(signingOutEverywhere ? { 'aria-busy': true as const } : {})}
           onClick={handleSignOutEverywhere}

--- a/apps/practitioner/src/components/practitioner-sign-out-button.tsx
+++ b/apps/practitioner/src/components/practitioner-sign-out-button.tsx
@@ -54,13 +54,24 @@ export function PractitionerSignOutButton({
 
   useEffect(() => {
     const sync = async () => {
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
-      if (!mountedRef.current) {
-        return;
+      try {
+        const {
+          data: { session },
+        } = await supabase.auth.getSession();
+        if (!mountedRef.current) {
+          return;
+        }
+        setTrustActive(isPractitionerMfaDeviceTrustActive(session?.user?.id));
+      } catch (syncError) {
+        console.error(
+          'Practitioner sign-out button: session sync failed',
+          syncError,
+        );
+        if (!mountedRef.current) {
+          return;
+        }
+        setTrustActive(false);
       }
-      setTrustActive(isPractitionerMfaDeviceTrustActive(session?.user?.id));
     };
 
     void sync();

--- a/apps/practitioner/src/components/practitioner-sign-out-button.tsx
+++ b/apps/practitioner/src/components/practitioner-sign-out-button.tsx
@@ -51,6 +51,9 @@ export function PractitionerSignOutButton({
       const {
         data: { session },
       } = await supabase.auth.getSession();
+      if (!mountedRef.current) {
+        return;
+      }
       setTrustActive(isPractitionerMfaDeviceTrustActive(session?.user?.id));
     };
 
@@ -59,6 +62,9 @@ export function PractitionerSignOutButton({
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!mountedRef.current) {
+        return;
+      }
       setTrustActive(isPractitionerMfaDeviceTrustActive(session?.user?.id));
     });
 

--- a/apps/practitioner/src/components/practitioner-sign-out-button.tsx
+++ b/apps/practitioner/src/components/practitioner-sign-out-button.tsx
@@ -134,8 +134,8 @@ export function PractitionerSignOutButton({
           className="max-w-prose text-xs text-app-muted"
         >
           Device trust is on: &quot;{label}&quot; clears this browser session
-          but can let you skip TOTP on the next sign-in here. On a shared
-          computer, use Sign out everywhere.
+          without revoking the saved trust token so you can skip TOTP on the
+          next sign-in here. On a shared computer, use Sign out everywhere.
         </p>
       ) : null}
       <div className="flex flex-wrap gap-2">

--- a/apps/practitioner/src/components/practitioner-sign-out-button.tsx
+++ b/apps/practitioner/src/components/practitioner-sign-out-button.tsx
@@ -1,36 +1,150 @@
 'use client';
 
 import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
-import { useMemo } from 'react';
-import { practitionerSignOut } from '@/lib/practitioner-device-trust';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  isPractitionerMfaDeviceTrustActive,
+  practitionerSignOut,
+  practitionerSignOutEverywhere,
+} from '@/lib/practitioner-device-trust';
+
+const SECONDARY_SIGN_OUT_CLASS =
+  'min-h-11 rounded-md border border-app-border bg-app-surface px-4 py-2 text-sm font-medium text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg';
 
 export type PractitionerSignOutButtonProps = {
-  /** Visible button label. */
+  /** Visible button label for the default (session-aware) sign-out. */
   label?: string;
-  /** Tailwind / layout classes (match previous `<form><button>` styling). */
+  /** Tailwind / layout classes for the primary sign-out control. */
   className?: string;
 };
 
 /**
- * Practitioner sign-out: respects MFA device trust (soft local clear) vs full Supabase revocation.
+ * Practitioner sign-out: default action respects MFA device trust (soft local clear) when active;
+ * secondary action performs full server sign-out via `POST /api/auth/logout`.
  *
- * @param props - Label and styling.
- * @returns Accessible button that signs out and navigates to `/login`.
+ * @param props - Labels and styling.
+ * @returns Accessible sign-out controls and optional trust explanation.
  */
 export function PractitionerSignOutButton({
   label = 'Log out',
   className,
 }: PractitionerSignOutButtonProps) {
   const supabase = useMemo(() => getSupabaseBrowserClient(), []);
+  const { announce } = useAnnounce();
+  const [signingOut, setSigningOut] = useState(false);
+  /** True after choosing full server sign-out until navigation completes. */
+  const [signingOutEverywhere, setSigningOutEverywhere] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+  const [trustActive, setTrustActive] = useState(false);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const sync = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      setTrustActive(isPractitionerMfaDeviceTrustActive(session?.user?.id));
+    };
+
+    void sync();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setTrustActive(isPractitionerMfaDeviceTrustActive(session?.user?.id));
+    });
+
+    return () => subscription.unsubscribe();
+  }, [supabase]);
+
+  const handleLocalSignOut = () => {
+    if (signingOut) {
+      return;
+    }
+    setError(null);
+    setSigningOut(true);
+    void practitionerSignOut(supabase)
+      .catch((err: unknown) => {
+        console.error('Practitioner sign out failed', err);
+        const message =
+          err instanceof Error
+            ? err.message
+            : 'Sign out failed. Please try again.';
+        setError(message);
+        announce(message, { politeness: 'assertive' });
+      })
+      .finally(() => {
+        if (mountedRef.current) {
+          setSigningOut(false);
+        }
+      });
+  };
+
+  const handleSignOutEverywhere = () => {
+    if (signingOut || signingOutEverywhere) {
+      return;
+    }
+    setError(null);
+    setSigningOutEverywhere(true);
+    announce('Signing out from all sessions.', { politeness: 'polite' });
+    practitionerSignOutEverywhere();
+  };
+
+  const busy = signingOut || signingOutEverywhere;
 
   return (
-    <button
-      type="button"
-      data-testid="practitioner-sign-out"
-      className={className}
-      onClick={() => void practitionerSignOut(supabase)}
-    >
-      {label}
-    </button>
+    <div className="inline-flex max-w-full flex-col gap-2">
+      {trustActive ? (
+        <p
+          id="practitioner-sign-out-trust-hint"
+          className="max-w-prose text-xs text-app-muted"
+        >
+          Device trust is on: &quot;{label}&quot; clears this browser session
+          but can let you skip TOTP on the next sign-in here. On a shared
+          computer, use Sign out everywhere.
+        </p>
+      ) : null}
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          data-testid="practitioner-sign-out"
+          className={className}
+          disabled={busy}
+          {...(busy ? { 'aria-busy': true as const } : {})}
+          aria-describedby={
+            trustActive ? 'practitioner-sign-out-trust-hint' : undefined
+          }
+          onClick={handleLocalSignOut}
+        >
+          {busy ? 'Signing out…' : label}
+        </button>
+        <button
+          type="button"
+          data-testid="practitioner-sign-out-everywhere"
+          className={SECONDARY_SIGN_OUT_CLASS}
+          disabled={busy}
+          {...(signingOutEverywhere ? { 'aria-busy': true as const } : {})}
+          onClick={handleSignOutEverywhere}
+        >
+          {signingOutEverywhere ? 'Signing out…' : 'Sign out everywhere'}
+        </button>
+      </div>
+      {error ? (
+        <p
+          role="alert"
+          className="max-w-prose text-sm text-red-700 dark:text-red-200"
+        >
+          {error}
+        </p>
+      ) : null}
+    </div>
   );
 }

--- a/apps/practitioner/src/lib/auth-provider.tsx
+++ b/apps/practitioner/src/lib/auth-provider.tsx
@@ -18,6 +18,7 @@ import {
   useState,
   type ReactNode,
 } from 'react';
+import { syncMfaTrustBundleAfterTokenRefresh } from './practitioner-device-trust';
 
 type ProfileRow = Database['public']['Tables']['profiles']['Row'];
 
@@ -161,8 +162,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, nextSession) => {
+    } = supabase.auth.onAuthStateChange((event, nextSession) => {
       setSession(nextSession);
+      if (event === 'TOKEN_REFRESHED') {
+        void syncMfaTrustBundleAfterTokenRefresh(supabase, nextSession);
+      }
     });
 
     return () => {

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -15,6 +15,12 @@ function buildBundleJson(userId: string, trustedUntilMs: number) {
   });
 }
 
+function sessionForUser(id: string) {
+  return {
+    user: { id },
+  };
+}
+
 describe('tryRestoreTrustedMfaSession', () => {
   const userId = '00000000-0000-0000-0000-000000000042';
 
@@ -31,7 +37,9 @@ describe('tryRestoreTrustedMfaSession', () => {
     const supabase = {
       auth: {
         setSession: jest.fn().mockResolvedValue({ error: null }),
-        getSession: jest.fn(),
+        getSession: jest.fn().mockResolvedValue({
+          data: { session: sessionForUser(userId) },
+        }),
         mfa: {
           getAuthenticatorAssuranceLevel: jest
             .fn()
@@ -55,7 +63,9 @@ describe('tryRestoreTrustedMfaSession', () => {
     const supabase = {
       auth: {
         setSession: jest.fn().mockResolvedValue({ error: null }),
-        getSession: jest.fn(),
+        getSession: jest.fn().mockResolvedValue({
+          data: { session: sessionForUser(userId) },
+        }),
         mfa: {
           getAuthenticatorAssuranceLevel: jest.fn().mockResolvedValue({
             error: null,
@@ -69,5 +79,61 @@ describe('tryRestoreTrustedMfaSession', () => {
       false,
     );
     expect(localStorage.getItem(MFA_TRUST_STORAGE_KEY)).toBeNull();
+  });
+
+  it('clears the trust bundle when restored session user id does not match', async () => {
+    localStorage.setItem(
+      MFA_TRUST_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+
+    const otherId = '99999999-9999-9999-9999-999999999999';
+
+    const supabase = {
+      auth: {
+        setSession: jest.fn().mockResolvedValue({ error: null }),
+        getSession: jest.fn().mockResolvedValue({
+          data: { session: sessionForUser(otherId) },
+        }),
+        mfa: {
+          getAuthenticatorAssuranceLevel: jest.fn(),
+        },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
+      false,
+    );
+    expect(localStorage.getItem(MFA_TRUST_STORAGE_KEY)).toBeNull();
+    expect(
+      supabase.auth.mfa.getAuthenticatorAssuranceLevel,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('clears the trust bundle when there is no session after setSession', async () => {
+    localStorage.setItem(
+      MFA_TRUST_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+
+    const supabase = {
+      auth: {
+        setSession: jest.fn().mockResolvedValue({ error: null }),
+        getSession: jest.fn().mockResolvedValue({
+          data: { session: null },
+        }),
+        mfa: {
+          getAuthenticatorAssuranceLevel: jest.fn(),
+        },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
+      false,
+    );
+    expect(localStorage.getItem(MFA_TRUST_STORAGE_KEY)).toBeNull();
+    expect(
+      supabase.auth.mfa.getAuthenticatorAssuranceLevel,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -222,6 +222,134 @@ describe('tryRestoreTrustedMfaSession', () => {
     expect(signOut).not.toHaveBeenCalled();
   });
 
+  it('clears the trust bundle and signs out when initial getSession fails', async () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+
+    const setSession = jest.fn();
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+
+    const supabase = {
+      auth: {
+        setSession,
+        signOut,
+        getSession: jest.fn().mockResolvedValue({
+          error: new Error('getSession failed'),
+          data: { session: null },
+        }),
+      },
+    } as unknown as BrowserClient;
+
+    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
+      false,
+    );
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
+    expect(setSession).not.toHaveBeenCalled();
+    expect(signOut).toHaveBeenCalled();
+  });
+
+  it('clears the trust bundle and reverts when getSession fails after setSession', async () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+
+    const setSession = jest.fn().mockResolvedValue({ error: null });
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+
+    const supabase = {
+      auth: {
+        setSession,
+        signOut,
+        getSession: jest
+          .fn()
+          .mockResolvedValueOnce({
+            error: null,
+            data: { session: prePasswordSession(userId) },
+          })
+          .mockResolvedValueOnce({
+            error: new Error('cookie unreadable'),
+            data: { session: null },
+          }),
+        mfa: {
+          getAuthenticatorAssuranceLevel: jest.fn(),
+        },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
+      false,
+    );
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
+    expect(
+      supabase.auth.mfa.getAuthenticatorAssuranceLevel,
+    ).not.toHaveBeenCalled();
+    expect(setSession).toHaveBeenCalledWith({
+      refresh_token: 'refresh',
+      access_token: 'access',
+    });
+    expect(setSession).toHaveBeenCalledWith({
+      refresh_token: 'pre-refresh',
+      access_token: 'pre-access',
+    });
+    expect(signOut).not.toHaveBeenCalled();
+  });
+
+  it('clears the trust bundle and reverts when final getSession fails after AAL2', async () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+
+    const setSession = jest.fn().mockResolvedValue({ error: null });
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+
+    const supabase = {
+      auth: {
+        setSession,
+        signOut,
+        getSession: jest
+          .fn()
+          .mockResolvedValueOnce({
+            error: null,
+            data: { session: prePasswordSession(userId) },
+          })
+          .mockResolvedValueOnce({
+            error: null,
+            data: { session: prePasswordSession(userId) },
+          })
+          .mockResolvedValueOnce({
+            error: new Error('final getSession failed'),
+            data: { session: null },
+          }),
+        mfa: {
+          getAuthenticatorAssuranceLevel: jest.fn().mockResolvedValue({
+            error: null,
+            data: { currentLevel: 'aal2', nextLevel: 'aal2' },
+          }),
+        },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
+      false,
+    );
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
+    expect(setSession).toHaveBeenCalledWith({
+      refresh_token: 'pre-refresh',
+      access_token: 'pre-access',
+    });
+    expect(signOut).not.toHaveBeenCalled();
+  });
+
   it('signs out when revert setSession fails after a restore failure', async () => {
     localStorage.setItem(
       PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
@@ -402,6 +530,73 @@ describe('practitionerSignOut', () => {
     ).toBeNull();
     expect(signOut).toHaveBeenCalledTimes(1);
     expect(signOut).toHaveBeenCalledWith();
+  });
+
+  it('falls back to server logout when local sign-out returns an error', async () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+    localStorage.setItem('sb-proj-auth-token', '{"x":1}');
+
+    const submitSpy = jest
+      .spyOn(HTMLFormElement.prototype, 'submit')
+      .mockImplementation(() => undefined);
+
+    const signOut = jest
+      .fn()
+      .mockResolvedValue({ error: { message: 'local sign-out failed' } });
+    const supabase = {
+      auth: {
+        getSession: jest.fn().mockResolvedValue({
+          data: {
+            session: sessionForUser(userId),
+          },
+        }),
+        signOut,
+      },
+    } as unknown as BrowserClient;
+
+    await practitionerSignOut(supabase);
+
+    expect(signOut).toHaveBeenCalledWith({ scope: 'local' });
+    expect(submitSpy).toHaveBeenCalledTimes(1);
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
+    expect(localStorage.getItem('sb-proj-auth-token')).toBeNull();
+
+    submitSpy.mockRestore();
+  });
+
+  it('falls back to server logout when full sign-out returns an error', async () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() - 1000),
+    );
+
+    const submitSpy = jest
+      .spyOn(HTMLFormElement.prototype, 'submit')
+      .mockImplementation(() => undefined);
+
+    const signOut = jest
+      .fn()
+      .mockResolvedValue({ error: { message: 'sign-out failed' } });
+    const supabase = {
+      auth: {
+        getSession: jest.fn().mockResolvedValue({
+          data: { session: sessionForUser(userId) },
+        }),
+        signOut,
+      },
+    } as unknown as BrowserClient;
+
+    await practitionerSignOut(supabase);
+
+    expect(signOut).toHaveBeenCalledWith();
+    expect(submitSpy).toHaveBeenCalledTimes(1);
+
+    submitSpy.mockRestore();
   });
 });
 

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -5,7 +5,6 @@ import {
   PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
   practitionerSignOut,
   practitionerSignOutEverywhere,
-  refreshTrustedMfaBundleBeforePasswordSignIn,
   saveMfaTrustBundle,
   syncMfaTrustBundleAfterTokenRefresh,
   tryRestoreTrustedMfaSession,
@@ -1098,269 +1097,6 @@ describe('syncMfaTrustBundleAfterTokenRefresh', () => {
   });
 });
 
-describe('refreshTrustedMfaBundleBeforePasswordSignIn', () => {
-  const userId = '00000000-0000-0000-0000-000000000042';
-  const email = 'doc@example.com';
-
-  beforeEach(() => {
-    localStorage.clear();
-  });
-
-  it('returns false when there is no bundle', async () => {
-    const supabase = {
-      auth: {
-        refreshSession: jest.fn(),
-        signOut: jest.fn(),
-        mfa: { getAuthenticatorAssuranceLevel: jest.fn() },
-      },
-    } as unknown as BrowserClient;
-
-    await expect(
-      refreshTrustedMfaBundleBeforePasswordSignIn(supabase, email),
-    ).resolves.toBe(false);
-    expect(supabase.auth.refreshSession).not.toHaveBeenCalled();
-  });
-
-  it('returns false and clears storage when bundle trust window is expired', async () => {
-    localStorage.setItem(
-      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
-      buildBundleJsonWithEmail(userId, Date.now() - 1, email),
-    );
-    const supabase = {
-      auth: {
-        refreshSession: jest.fn(),
-        signOut: jest.fn(),
-        mfa: { getAuthenticatorAssuranceLevel: jest.fn() },
-      },
-    } as unknown as BrowserClient;
-
-    await expect(
-      refreshTrustedMfaBundleBeforePasswordSignIn(supabase, email),
-    ).resolves.toBe(false);
-    expect(supabase.auth.refreshSession).not.toHaveBeenCalled();
-    expect(
-      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
-    ).toBeNull();
-  });
-
-  it('returns false when bundle has no email (legacy)', async () => {
-    localStorage.setItem(
-      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
-      buildBundleJson(userId, Date.now() + 60_000),
-    );
-    const supabase = {
-      auth: {
-        refreshSession: jest.fn(),
-        signOut: jest.fn(),
-        mfa: { getAuthenticatorAssuranceLevel: jest.fn() },
-      },
-    } as unknown as BrowserClient;
-
-    await expect(
-      refreshTrustedMfaBundleBeforePasswordSignIn(supabase, email),
-    ).resolves.toBe(false);
-    expect(supabase.auth.refreshSession).not.toHaveBeenCalled();
-  });
-
-  it('matches email case-insensitively', async () => {
-    const trustedUntil = Date.now() + 60_000;
-    localStorage.setItem(
-      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
-      buildBundleJsonWithEmail(userId, trustedUntil, 'Doc@Example.COM'),
-    );
-    const refreshedSession = {
-      user: { id: userId, email: 'doc@example.com' },
-      refresh_token: 'new-r',
-      access_token: 'new-a',
-    };
-    const refreshSession = jest.fn().mockResolvedValue({
-      data: { session: refreshedSession },
-      error: null,
-    });
-    const getAuthenticatorAssuranceLevel = jest.fn().mockResolvedValue({
-      error: null,
-      data: { currentLevel: 'aal2', nextLevel: 'aal2' },
-    });
-    const supabase = {
-      auth: {
-        refreshSession,
-        signOut: jest.fn().mockResolvedValue({ error: null }),
-        mfa: { getAuthenticatorAssuranceLevel },
-      },
-    } as unknown as BrowserClient;
-
-    await expect(
-      refreshTrustedMfaBundleBeforePasswordSignIn(supabase, 'doc@example.com'),
-    ).resolves.toBe(true);
-    expect(refreshSession).toHaveBeenCalledWith({
-      refresh_token: 'refresh',
-    });
-  });
-
-  it('returns false when sign-in email does not match bundle email', async () => {
-    localStorage.setItem(
-      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
-      buildBundleJsonWithEmail(
-        userId,
-        Date.now() + 60_000,
-        'other@example.com',
-      ),
-    );
-    const supabase = {
-      auth: {
-        refreshSession: jest.fn(),
-        signOut: jest.fn(),
-        mfa: { getAuthenticatorAssuranceLevel: jest.fn() },
-      },
-    } as unknown as BrowserClient;
-
-    await expect(
-      refreshTrustedMfaBundleBeforePasswordSignIn(supabase, email),
-    ).resolves.toBe(false);
-    expect(supabase.auth.refreshSession).not.toHaveBeenCalled();
-  });
-
-  it('returns false and signs out when refresh succeeds but user id does not match bundle', async () => {
-    localStorage.setItem(
-      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
-      buildBundleJsonWithEmail(userId, Date.now() + 60_000, email),
-    );
-    const signOut = jest.fn().mockResolvedValue({ error: null });
-    const refreshSession = jest.fn().mockResolvedValue({
-      data: {
-        session: {
-          user: { id: '00000000-0000-0000-0000-000000000099' },
-          refresh_token: 'new-r',
-          access_token: 'new-a',
-        },
-      },
-      error: null,
-    });
-    const supabase = {
-      auth: {
-        refreshSession,
-        signOut,
-        mfa: { getAuthenticatorAssuranceLevel: jest.fn() },
-      },
-    } as unknown as BrowserClient;
-
-    await expect(
-      refreshTrustedMfaBundleBeforePasswordSignIn(supabase, email),
-    ).resolves.toBe(false);
-    expect(signOut).toHaveBeenCalled();
-    expect(
-      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
-    ).toBeNull();
-  });
-
-  it('clears the bundle when refreshSession fails', async () => {
-    localStorage.setItem(
-      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
-      buildBundleJsonWithEmail(userId, Date.now() + 60_000, email),
-    );
-    const refreshSession = jest.fn().mockResolvedValue({
-      data: { session: null },
-      error: { message: 'Invalid Refresh Token: Refresh Token Not Found' },
-    });
-    const supabase = {
-      auth: {
-        refreshSession,
-        signOut: jest.fn(),
-        mfa: { getAuthenticatorAssuranceLevel: jest.fn() },
-      },
-    } as unknown as BrowserClient;
-
-    await expect(
-      refreshTrustedMfaBundleBeforePasswordSignIn(supabase, email),
-    ).resolves.toBe(false);
-    expect(
-      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
-    ).toBeNull();
-  });
-
-  it('returns false and signs out when assurance is not aal2', async () => {
-    localStorage.setItem(
-      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
-      buildBundleJsonWithEmail(userId, Date.now() + 60_000, email),
-    );
-    const signOut = jest.fn().mockResolvedValue({ error: null });
-    const refreshSession = jest.fn().mockResolvedValue({
-      data: {
-        session: {
-          user: { id: userId },
-          refresh_token: 'new-r',
-          access_token: 'new-a',
-        },
-      },
-      error: null,
-    });
-    const getAuthenticatorAssuranceLevel = jest.fn().mockResolvedValue({
-      error: null,
-      data: { currentLevel: 'aal1', nextLevel: 'aal2' },
-    });
-    const supabase = {
-      auth: {
-        refreshSession,
-        signOut,
-        mfa: { getAuthenticatorAssuranceLevel },
-      },
-    } as unknown as BrowserClient;
-
-    await expect(
-      refreshTrustedMfaBundleBeforePasswordSignIn(supabase, email),
-    ).resolves.toBe(false);
-    expect(signOut).toHaveBeenCalled();
-    expect(
-      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
-    ).toBeNull();
-  });
-
-  it('returns true and persists refreshed session when refresh and aal2 succeed', async () => {
-    const trustedUntil = Date.now() + 60_000;
-    localStorage.setItem(
-      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
-      buildBundleJsonWithEmail(userId, trustedUntil, email),
-    );
-    const signOut = jest.fn().mockResolvedValue({ error: null });
-    const refreshedSession = {
-      user: { id: userId, email },
-      refresh_token: 'new-r',
-      access_token: 'new-a',
-    };
-    const refreshSession = jest.fn().mockResolvedValue({
-      data: { session: refreshedSession },
-      error: null,
-    });
-    const getAuthenticatorAssuranceLevel = jest.fn().mockResolvedValue({
-      error: null,
-      data: { currentLevel: 'aal2', nextLevel: 'aal2' },
-    });
-    const supabase = {
-      auth: {
-        refreshSession,
-        signOut,
-        mfa: { getAuthenticatorAssuranceLevel },
-      },
-    } as unknown as BrowserClient;
-
-    await expect(
-      refreshTrustedMfaBundleBeforePasswordSignIn(supabase, email),
-    ).resolves.toBe(true);
-
-    const raw = localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY);
-    expect(raw).toBeTruthy();
-    const parsed = JSON.parse(raw as string) as {
-      refresh_token: string;
-      userId: string;
-      email?: string;
-    };
-    expect(parsed.refresh_token).toBe('new-r');
-    expect(parsed.userId).toBe(userId);
-    expect(parsed.email).toBe(email);
-    expect(signOut).not.toHaveBeenCalled();
-  });
-});
-
 describe('saveMfaTrustBundle', () => {
   const userId = '00000000-0000-0000-0000-000000000042';
 
@@ -1402,6 +1138,19 @@ describe('MFA device trust deploy gate', () => {
     const prev = process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'];
     delete process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'];
     expect(isPractitionerMfaDeviceTrustEnabled()).toBe(true);
+    process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'] = prev ?? 'true';
+  });
+
+  it('reports enabled for true or 1 and disabled for unrecognized non-empty values', () => {
+    const prev = process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'];
+    process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'] = 'true';
+    expect(isPractitionerMfaDeviceTrustEnabled()).toBe(true);
+    process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'] = '1';
+    expect(isPractitionerMfaDeviceTrustEnabled()).toBe(true);
+    process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'] = 'yes';
+    expect(isPractitionerMfaDeviceTrustEnabled()).toBe(false);
+    process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'] = 'typo';
+    expect(isPractitionerMfaDeviceTrustEnabled()).toBe(false);
     process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'] = prev ?? 'true';
   });
 

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -1,0 +1,73 @@
+import type { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
+import { tryRestoreTrustedMfaSession } from './practitioner-device-trust';
+
+/** Must match `MFA_TRUST_KEY` in `practitioner-device-trust.ts`. */
+const MFA_TRUST_STORAGE_KEY = 'abstrack.practitioner.mfaTrustBundle.v1';
+
+type BrowserClient = ReturnType<typeof getSupabaseBrowserClient>;
+
+function buildBundleJson(userId: string, trustedUntilMs: number) {
+  return JSON.stringify({
+    userId,
+    refresh_token: 'refresh',
+    access_token: 'access',
+    trustedUntilMs,
+  });
+}
+
+describe('tryRestoreTrustedMfaSession', () => {
+  const userId = '00000000-0000-0000-0000-000000000042';
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('clears the trust bundle when assurance cannot be read', async () => {
+    localStorage.setItem(
+      MFA_TRUST_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+
+    const supabase = {
+      auth: {
+        setSession: jest.fn().mockResolvedValue({ error: null }),
+        getSession: jest.fn(),
+        mfa: {
+          getAuthenticatorAssuranceLevel: jest
+            .fn()
+            .mockResolvedValue({ error: new Error('network'), data: null }),
+        },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
+      false,
+    );
+    expect(localStorage.getItem(MFA_TRUST_STORAGE_KEY)).toBeNull();
+  });
+
+  it('clears the trust bundle when current assurance level is not aal2', async () => {
+    localStorage.setItem(
+      MFA_TRUST_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+
+    const supabase = {
+      auth: {
+        setSession: jest.fn().mockResolvedValue({ error: null }),
+        getSession: jest.fn(),
+        mfa: {
+          getAuthenticatorAssuranceLevel: jest.fn().mockResolvedValue({
+            error: null,
+            data: { currentLevel: 'aal1', nextLevel: 'aal2' },
+          }),
+        },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
+      false,
+    );
+    expect(localStorage.getItem(MFA_TRUST_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -21,6 +21,15 @@ function sessionForUser(id: string) {
   };
 }
 
+/** Password session before `setSession(bundle)` — includes tokens used to revert on failure. */
+function prePasswordSession(id: string) {
+  return {
+    user: { id },
+    refresh_token: 'pre-refresh',
+    access_token: 'pre-access',
+  };
+}
+
 describe('tryRestoreTrustedMfaSession', () => {
   const userId = '00000000-0000-0000-0000-000000000042';
 
@@ -34,12 +43,21 @@ describe('tryRestoreTrustedMfaSession', () => {
       buildBundleJson(userId, Date.now() + 60_000),
     );
 
+    const setSession = jest.fn().mockResolvedValue({ error: null });
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+
     const supabase = {
       auth: {
-        setSession: jest.fn().mockResolvedValue({ error: null }),
-        getSession: jest.fn().mockResolvedValue({
-          data: { session: sessionForUser(userId) },
-        }),
+        setSession,
+        signOut,
+        getSession: jest
+          .fn()
+          .mockResolvedValueOnce({
+            data: { session: prePasswordSession(userId) },
+          })
+          .mockResolvedValue({
+            data: { session: prePasswordSession(userId) },
+          }),
         mfa: {
           getAuthenticatorAssuranceLevel: jest
             .fn()
@@ -52,6 +70,15 @@ describe('tryRestoreTrustedMfaSession', () => {
       false,
     );
     expect(localStorage.getItem(MFA_TRUST_STORAGE_KEY)).toBeNull();
+    expect(setSession).toHaveBeenCalledWith({
+      refresh_token: 'refresh',
+      access_token: 'access',
+    });
+    expect(setSession).toHaveBeenCalledWith({
+      refresh_token: 'pre-refresh',
+      access_token: 'pre-access',
+    });
+    expect(signOut).not.toHaveBeenCalled();
   });
 
   it('clears the trust bundle when current assurance level is not aal2', async () => {
@@ -60,12 +87,21 @@ describe('tryRestoreTrustedMfaSession', () => {
       buildBundleJson(userId, Date.now() + 60_000),
     );
 
+    const setSession = jest.fn().mockResolvedValue({ error: null });
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+
     const supabase = {
       auth: {
-        setSession: jest.fn().mockResolvedValue({ error: null }),
-        getSession: jest.fn().mockResolvedValue({
-          data: { session: sessionForUser(userId) },
-        }),
+        setSession,
+        signOut,
+        getSession: jest
+          .fn()
+          .mockResolvedValueOnce({
+            data: { session: prePasswordSession(userId) },
+          })
+          .mockResolvedValue({
+            data: { session: prePasswordSession(userId) },
+          }),
         mfa: {
           getAuthenticatorAssuranceLevel: jest.fn().mockResolvedValue({
             error: null,
@@ -79,9 +115,14 @@ describe('tryRestoreTrustedMfaSession', () => {
       false,
     );
     expect(localStorage.getItem(MFA_TRUST_STORAGE_KEY)).toBeNull();
+    expect(setSession).toHaveBeenCalledWith({
+      refresh_token: 'pre-refresh',
+      access_token: 'pre-access',
+    });
+    expect(signOut).not.toHaveBeenCalled();
   });
 
-  it('clears the trust bundle when restored session user id does not match', async () => {
+  it('clears the trust bundle when restored session user id does not match and reverts session', async () => {
     localStorage.setItem(
       MFA_TRUST_STORAGE_KEY,
       buildBundleJson(userId, Date.now() + 60_000),
@@ -89,12 +130,21 @@ describe('tryRestoreTrustedMfaSession', () => {
 
     const otherId = '99999999-9999-9999-9999-999999999999';
 
+    const setSession = jest.fn().mockResolvedValue({ error: null });
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+
     const supabase = {
       auth: {
-        setSession: jest.fn().mockResolvedValue({ error: null }),
-        getSession: jest.fn().mockResolvedValue({
-          data: { session: sessionForUser(otherId) },
-        }),
+        setSession,
+        signOut,
+        getSession: jest
+          .fn()
+          .mockResolvedValueOnce({
+            data: { session: prePasswordSession(userId) },
+          })
+          .mockResolvedValueOnce({
+            data: { session: sessionForUser(otherId) },
+          }),
         mfa: {
           getAuthenticatorAssuranceLevel: jest.fn(),
         },
@@ -108,20 +158,39 @@ describe('tryRestoreTrustedMfaSession', () => {
     expect(
       supabase.auth.mfa.getAuthenticatorAssuranceLevel,
     ).not.toHaveBeenCalled();
+    expect(setSession).toHaveBeenCalledTimes(2);
+    expect(setSession).toHaveBeenNthCalledWith(1, {
+      refresh_token: 'refresh',
+      access_token: 'access',
+    });
+    expect(setSession).toHaveBeenNthCalledWith(2, {
+      refresh_token: 'pre-refresh',
+      access_token: 'pre-access',
+    });
+    expect(signOut).not.toHaveBeenCalled();
   });
 
-  it('clears the trust bundle when there is no session after setSession', async () => {
+  it('clears the trust bundle when there is no session after setSession and reverts', async () => {
     localStorage.setItem(
       MFA_TRUST_STORAGE_KEY,
       buildBundleJson(userId, Date.now() + 60_000),
     );
 
+    const setSession = jest.fn().mockResolvedValue({ error: null });
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+
     const supabase = {
       auth: {
-        setSession: jest.fn().mockResolvedValue({ error: null }),
-        getSession: jest.fn().mockResolvedValue({
-          data: { session: null },
-        }),
+        setSession,
+        signOut,
+        getSession: jest
+          .fn()
+          .mockResolvedValueOnce({
+            data: { session: prePasswordSession(userId) },
+          })
+          .mockResolvedValueOnce({
+            data: { session: null },
+          }),
         mfa: {
           getAuthenticatorAssuranceLevel: jest.fn(),
         },
@@ -135,5 +204,50 @@ describe('tryRestoreTrustedMfaSession', () => {
     expect(
       supabase.auth.mfa.getAuthenticatorAssuranceLevel,
     ).not.toHaveBeenCalled();
+    expect(setSession).toHaveBeenCalledWith({
+      refresh_token: 'pre-refresh',
+      access_token: 'pre-access',
+    });
+    expect(signOut).not.toHaveBeenCalled();
+  });
+
+  it('signs out when revert setSession fails after a restore failure', async () => {
+    localStorage.setItem(
+      MFA_TRUST_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+
+    const setSession = jest
+      .fn()
+      .mockResolvedValueOnce({ error: null })
+      .mockResolvedValueOnce({
+        error: { message: 'revert failed' },
+      });
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+
+    const supabase = {
+      auth: {
+        setSession,
+        signOut,
+        getSession: jest
+          .fn()
+          .mockResolvedValueOnce({
+            data: { session: prePasswordSession(userId) },
+          })
+          .mockResolvedValue({
+            data: { session: prePasswordSession(userId) },
+          }),
+        mfa: {
+          getAuthenticatorAssuranceLevel: jest
+            .fn()
+            .mockResolvedValue({ error: new Error('network'), data: null }),
+        },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
+      false,
+    );
+    expect(signOut).toHaveBeenCalled();
   });
 });

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -1,4 +1,4 @@
-import type { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
+import type { AbstrackSupabaseClient } from '@abstrack/supabase';
 import {
   isPractitionerMfaDeviceTrustActive,
   practitionerSignOut,
@@ -9,7 +9,7 @@ import {
 /** Must match `MFA_TRUST_KEY` in `practitioner-device-trust.ts`. */
 const MFA_TRUST_STORAGE_KEY = 'abstrack.practitioner.mfaTrustBundle.v1';
 
-type BrowserClient = ReturnType<typeof getSupabaseBrowserClient>;
+type BrowserClient = AbstrackSupabaseClient;
 
 function buildBundleJson(userId: string, trustedUntilMs: number) {
   return JSON.stringify({

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -1,11 +1,29 @@
-import type { AbstrackSupabaseClient } from '@abstrack/supabase';
+import type { AbstrackSupabaseClient, Session } from '@abstrack/supabase';
 import {
   isPractitionerMfaDeviceTrustActive,
+  isPractitionerMfaDeviceTrustEnabled,
   PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
   practitionerSignOut,
   practitionerSignOutEverywhere,
+  saveMfaTrustBundle,
   tryRestoreTrustedMfaSession,
 } from './practitioner-device-trust';
+
+const prevPractitionerDeviceTrustEnv =
+  process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'];
+
+beforeAll(() => {
+  process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'] = 'true';
+});
+
+afterAll(() => {
+  if (prevPractitionerDeviceTrustEnv === undefined) {
+    delete process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'];
+  } else {
+    process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'] =
+      prevPractitionerDeviceTrustEnv;
+  }
+});
 
 type BrowserClient = AbstrackSupabaseClient;
 
@@ -867,5 +885,48 @@ describe('practitionerSignOutEverywhere', () => {
     ).toBeNull();
     expect(localStorage.getItem('sb-proj-auth-token')).toBeNull();
     expect(submitSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('MFA device trust deploy gate', () => {
+  const userId = '00000000-0000-0000-0000-000000000042';
+
+  it('reports disabled when env is unset', () => {
+    const prev = process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'];
+    delete process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'];
+    expect(isPractitionerMfaDeviceTrustEnabled()).toBe(false);
+    process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'] = prev ?? 'true';
+  });
+
+  it('does not write localStorage when disabled', () => {
+    const prev = process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'];
+    delete process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'];
+    localStorage.clear();
+    saveMfaTrustBundle(
+      {
+        user: { id: userId },
+        refresh_token: 'r',
+        access_token: 'a',
+      } as Session,
+      Date.now() + 60_000,
+    );
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
+    process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'] = prev ?? 'true';
+  });
+
+  it('clears existing bundle on read when disabled', () => {
+    const prev = process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'];
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+    delete process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'];
+    expect(isPractitionerMfaDeviceTrustActive(userId)).toBe(false);
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
+    process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'] = prev ?? 'true';
   });
 });

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -1,5 +1,10 @@
 import type { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
-import { tryRestoreTrustedMfaSession } from './practitioner-device-trust';
+import {
+  isPractitionerMfaDeviceTrustActive,
+  practitionerSignOut,
+  practitionerSignOutEverywhere,
+  tryRestoreTrustedMfaSession,
+} from './practitioner-device-trust';
 
 /** Must match `MFA_TRUST_KEY` in `practitioner-device-trust.ts`. */
 const MFA_TRUST_STORAGE_KEY = 'abstrack.practitioner.mfaTrustBundle.v1';
@@ -249,5 +254,170 @@ describe('tryRestoreTrustedMfaSession', () => {
       false,
     );
     expect(signOut).toHaveBeenCalled();
+  });
+});
+
+describe('isPractitionerMfaDeviceTrustActive', () => {
+  const userId = '00000000-0000-0000-0000-000000000099';
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns false when userId is missing or empty', () => {
+    expect(isPractitionerMfaDeviceTrustActive(undefined)).toBe(false);
+    expect(isPractitionerMfaDeviceTrustActive('')).toBe(false);
+  });
+
+  it('returns false when there is no bundle or user does not match', () => {
+    expect(isPractitionerMfaDeviceTrustActive(userId)).toBe(false);
+    localStorage.setItem(
+      MFA_TRUST_STORAGE_KEY,
+      buildBundleJson(
+        '00000000-0000-0000-0000-000000000001',
+        Date.now() + 60_000,
+      ),
+    );
+    expect(isPractitionerMfaDeviceTrustActive(userId)).toBe(false);
+  });
+
+  it('returns false when the trust window has expired', () => {
+    localStorage.setItem(
+      MFA_TRUST_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() - 1000),
+    );
+    expect(isPractitionerMfaDeviceTrustActive(userId)).toBe(false);
+  });
+
+  it('returns true when a non-expired bundle exists for the user', () => {
+    localStorage.setItem(
+      MFA_TRUST_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+    expect(isPractitionerMfaDeviceTrustActive(userId)).toBe(true);
+  });
+});
+
+describe('practitionerSignOut', () => {
+  const userId = '00000000-0000-0000-0000-000000000088';
+
+  /** jsdom does not implement navigation; `practitionerSignOut` calls `location.assign`. */
+  const origConsoleError = console.error;
+  beforeAll(() => {
+    jest.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      const text = args
+        .map((a) => (a instanceof Error ? a.message : String(a)))
+        .join(' ');
+      if (text.includes('Not implemented: navigation')) {
+        return;
+      }
+      origConsoleError.apply(console, args as Parameters<typeof console.error>);
+    });
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('soft sign-out: clears sb-* auth storage, keeps MFA bundle, does not call auth.signOut', async () => {
+    localStorage.setItem(
+      MFA_TRUST_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+    localStorage.setItem('sb-example-auth-token', '{"persisted":true}');
+
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+    const supabase = {
+      auth: {
+        getSession: jest.fn().mockResolvedValue({
+          data: {
+            session: sessionForUser(userId),
+          },
+        }),
+        signOut,
+      },
+    } as unknown as BrowserClient;
+
+    await practitionerSignOut(supabase);
+
+    expect(localStorage.getItem(MFA_TRUST_STORAGE_KEY)).not.toBeNull();
+    expect(localStorage.getItem('sb-example-auth-token')).toBeNull();
+    expect(signOut).not.toHaveBeenCalled();
+  });
+
+  it('full sign-out: clears MFA bundle and calls auth.signOut (expired trust window)', async () => {
+    localStorage.setItem(
+      MFA_TRUST_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() - 1000),
+    );
+
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+    const supabase = {
+      auth: {
+        getSession: jest.fn().mockResolvedValue({
+          data: { session: sessionForUser(userId) },
+        }),
+        signOut,
+      },
+    } as unknown as BrowserClient;
+
+    await practitionerSignOut(supabase);
+
+    expect(localStorage.getItem(MFA_TRUST_STORAGE_KEY)).toBeNull();
+    expect(signOut).toHaveBeenCalled();
+  });
+
+  it('full sign-out when no session: clears bundle and calls auth.signOut', async () => {
+    localStorage.setItem(
+      MFA_TRUST_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+    const supabase = {
+      auth: {
+        getSession: jest.fn().mockResolvedValue({ data: { session: null } }),
+        signOut,
+      },
+    } as unknown as BrowserClient;
+
+    await practitionerSignOut(supabase);
+
+    expect(localStorage.getItem(MFA_TRUST_STORAGE_KEY)).toBeNull();
+    expect(signOut).toHaveBeenCalled();
+  });
+});
+
+describe('practitionerSignOutEverywhere', () => {
+  const userId = '00000000-0000-0000-0000-000000000077';
+  let submitSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    localStorage.clear();
+    submitSpy = jest
+      .spyOn(HTMLFormElement.prototype, 'submit')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    submitSpy.mockRestore();
+  });
+
+  it('clears MFA bundle and sb-* auth storage and POSTs logout form', () => {
+    localStorage.setItem(
+      MFA_TRUST_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+    localStorage.setItem('sb-proj-auth-token', '{"refresh":true}');
+
+    practitionerSignOutEverywhere();
+
+    expect(localStorage.getItem(MFA_TRUST_STORAGE_KEY)).toBeNull();
+    expect(localStorage.getItem('sb-proj-auth-token')).toBeNull();
+    expect(submitSpy).toHaveBeenCalled();
   });
 });

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -499,6 +499,17 @@ describe('stored trust bundle validation', () => {
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
     ).toBeNull();
   });
+
+  it('removes storage when JSON.parse fails', () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      '{"truncated":',
+    );
+    expect(isPractitionerMfaDeviceTrustActive(userId)).toBe(false);
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
+  });
 });
 
 describe('isPractitionerMfaDeviceTrustActive', () => {

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -428,6 +428,79 @@ describe('tryRestoreTrustedMfaSession', () => {
   });
 });
 
+describe('stored trust bundle validation', () => {
+  const userId = '00000000-0000-0000-0000-000000000099';
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('removes invalid bundle with empty refresh_token and reports inactive', () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      JSON.stringify({
+        userId,
+        refresh_token: '',
+        access_token: 'access',
+        trustedUntilMs: Date.now() + 60_000,
+      }),
+    );
+    expect(isPractitionerMfaDeviceTrustActive(userId)).toBe(false);
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
+  });
+
+  it('removes invalid bundle with NaN trustedUntilMs', () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      JSON.stringify({
+        userId,
+        refresh_token: 'refresh',
+        access_token: 'access',
+        trustedUntilMs: Number.NaN,
+      }),
+    );
+    expect(isPractitionerMfaDeviceTrustActive(userId)).toBe(false);
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
+  });
+
+  it('removes invalid bundle when expires_at is non-finite', () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      JSON.stringify({
+        userId,
+        refresh_token: 'refresh',
+        access_token: 'access',
+        trustedUntilMs: Date.now() + 60_000,
+        expires_at: Number.NaN,
+      }),
+    );
+    expect(isPractitionerMfaDeviceTrustActive(userId)).toBe(false);
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
+  });
+
+  it('removes invalid bundle with blank userId', () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      JSON.stringify({
+        userId: '   ',
+        refresh_token: 'refresh',
+        access_token: 'access',
+        trustedUntilMs: Date.now() + 60_000,
+      }),
+    );
+    expect(isPractitionerMfaDeviceTrustActive(userId)).toBe(false);
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
+  });
+});
+
 describe('isPractitionerMfaDeviceTrustActive', () => {
   const userId = '00000000-0000-0000-0000-000000000099';
 
@@ -440,7 +513,7 @@ describe('isPractitionerMfaDeviceTrustActive', () => {
     expect(isPractitionerMfaDeviceTrustActive('')).toBe(false);
   });
 
-  it('returns false when there is no bundle or user does not match', () => {
+  it('returns false when there is no bundle or user does not match, and clears bundle on mismatch', () => {
     expect(isPractitionerMfaDeviceTrustActive(userId)).toBe(false);
     localStorage.setItem(
       PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
@@ -450,14 +523,20 @@ describe('isPractitionerMfaDeviceTrustActive', () => {
       ),
     );
     expect(isPractitionerMfaDeviceTrustActive(userId)).toBe(false);
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
   });
 
-  it('returns false when the trust window has expired', () => {
+  it('returns false when the trust window has expired and removes the bundle', () => {
     localStorage.setItem(
       PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() - 1000),
     );
     expect(isPractitionerMfaDeviceTrustActive(userId)).toBe(false);
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
   });
 
   it('returns true when a non-expired bundle exists for the user', () => {

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -1121,6 +1121,28 @@ describe('refreshTrustedMfaBundleBeforePasswordSignIn', () => {
     expect(supabase.auth.refreshSession).not.toHaveBeenCalled();
   });
 
+  it('returns false and clears storage when bundle trust window is expired', async () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJsonWithEmail(userId, Date.now() - 1, email),
+    );
+    const supabase = {
+      auth: {
+        refreshSession: jest.fn(),
+        signOut: jest.fn(),
+        mfa: { getAuthenticatorAssuranceLevel: jest.fn() },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(
+      refreshTrustedMfaBundleBeforePasswordSignIn(supabase, email),
+    ).resolves.toBe(false);
+    expect(supabase.auth.refreshSession).not.toHaveBeenCalled();
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
+  });
+
   it('returns false when bundle has no email (legacy)', async () => {
     localStorage.setItem(
       PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -329,12 +329,11 @@ describe('practitionerSignOut', () => {
     localStorage.clear();
   });
 
-  it('soft sign-out: clears sb-* auth storage, keeps MFA bundle, does not call auth.signOut', async () => {
+  it('soft sign-out: calls auth.signOut with local scope, keeps MFA bundle', async () => {
     localStorage.setItem(
       PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() + 60_000),
     );
-    localStorage.setItem('sb-example-auth-token', '{"persisted":true}');
 
     const signOut = jest.fn().mockResolvedValue({ error: null });
     const supabase = {
@@ -353,11 +352,11 @@ describe('practitionerSignOut', () => {
     expect(
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
     ).not.toBeNull();
-    expect(localStorage.getItem('sb-example-auth-token')).toBeNull();
-    expect(signOut).not.toHaveBeenCalled();
+    expect(signOut).toHaveBeenCalledTimes(1);
+    expect(signOut).toHaveBeenCalledWith({ scope: 'local' });
   });
 
-  it('full sign-out: clears MFA bundle and calls auth.signOut (expired trust window)', async () => {
+  it('full sign-out: clears MFA bundle and calls auth.signOut without local scope (expired trust window)', async () => {
     localStorage.setItem(
       PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() - 1000),
@@ -378,7 +377,8 @@ describe('practitionerSignOut', () => {
     expect(
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
     ).toBeNull();
-    expect(signOut).toHaveBeenCalled();
+    expect(signOut).toHaveBeenCalledTimes(1);
+    expect(signOut).toHaveBeenCalledWith();
   });
 
   it('full sign-out when no session: clears bundle and calls auth.signOut', async () => {
@@ -400,7 +400,8 @@ describe('practitionerSignOut', () => {
     expect(
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
     ).toBeNull();
-    expect(signOut).toHaveBeenCalled();
+    expect(signOut).toHaveBeenCalledTimes(1);
+    expect(signOut).toHaveBeenCalledWith();
   });
 });
 
@@ -419,7 +420,7 @@ describe('practitionerSignOutEverywhere', () => {
     submitSpy.mockRestore();
   });
 
-  it('clears MFA bundle and sb-* auth storage and POSTs logout form', () => {
+  it('clears MFA bundle, scrubs sb-* localStorage keys, and POSTs logout form', () => {
     localStorage.setItem(
       PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() + 60_000),
@@ -432,6 +433,6 @@ describe('practitionerSignOutEverywhere', () => {
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
     ).toBeNull();
     expect(localStorage.getItem('sb-proj-auth-token')).toBeNull();
-    expect(submitSpy).toHaveBeenCalled();
+    expect(submitSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -40,6 +40,32 @@ describe('tryRestoreTrustedMfaSession', () => {
     localStorage.clear();
   });
 
+  it('clears the trust bundle when stored bundle user id does not match current user', async () => {
+    const otherUserId = '99999999-9999-9999-9999-999999999999';
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(otherUserId, Date.now() + 60_000),
+    );
+
+    const getSession = jest.fn();
+    const supabase = {
+      auth: {
+        getSession,
+        setSession: jest.fn(),
+        signOut: jest.fn(),
+        mfa: {},
+      },
+    } as unknown as BrowserClient;
+
+    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
+      false,
+    );
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
+    expect(getSession).not.toHaveBeenCalled();
+  });
+
   it('clears the trust bundle when assurance cannot be read', async () => {
     localStorage.setItem(
       PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -413,6 +413,55 @@ describe('tryRestoreTrustedMfaSession', () => {
     expect(signOut).not.toHaveBeenCalled();
   });
 
+  it('clears the trust bundle and reverts when final getSession returns no session after AAL2', async () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+
+    const setSession = jest.fn().mockResolvedValue({ error: null });
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+
+    const supabase = {
+      auth: {
+        setSession,
+        signOut,
+        getSession: jest
+          .fn()
+          .mockResolvedValueOnce({
+            error: null,
+            data: { session: prePasswordSession(userId) },
+          })
+          .mockResolvedValueOnce({
+            error: null,
+            data: { session: prePasswordSession(userId) },
+          })
+          .mockResolvedValueOnce({
+            error: null,
+            data: { session: null },
+          }),
+        mfa: {
+          getAuthenticatorAssuranceLevel: jest.fn().mockResolvedValue({
+            error: null,
+            data: { currentLevel: 'aal2', nextLevel: 'aal2' },
+          }),
+        },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
+      false,
+    );
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
+    expect(setSession).toHaveBeenCalledWith({
+      refresh_token: 'pre-refresh',
+      access_token: 'pre-access',
+    });
+    expect(signOut).not.toHaveBeenCalled();
+  });
+
   it('signs out when revert setSession fails after a restore failure', async () => {
     localStorage.setItem(
       PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -1,13 +1,11 @@
 import type { AbstrackSupabaseClient } from '@abstrack/supabase';
 import {
   isPractitionerMfaDeviceTrustActive,
+  PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
   practitionerSignOut,
   practitionerSignOutEverywhere,
   tryRestoreTrustedMfaSession,
 } from './practitioner-device-trust';
-
-/** Must match `MFA_TRUST_KEY` in `practitioner-device-trust.ts`. */
-const MFA_TRUST_STORAGE_KEY = 'abstrack.practitioner.mfaTrustBundle.v1';
 
 type BrowserClient = AbstrackSupabaseClient;
 
@@ -44,7 +42,7 @@ describe('tryRestoreTrustedMfaSession', () => {
 
   it('clears the trust bundle when assurance cannot be read', async () => {
     localStorage.setItem(
-      MFA_TRUST_STORAGE_KEY,
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() + 60_000),
     );
 
@@ -74,7 +72,9 @@ describe('tryRestoreTrustedMfaSession', () => {
     await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
       false,
     );
-    expect(localStorage.getItem(MFA_TRUST_STORAGE_KEY)).toBeNull();
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
     expect(setSession).toHaveBeenCalledWith({
       refresh_token: 'refresh',
       access_token: 'access',
@@ -88,7 +88,7 @@ describe('tryRestoreTrustedMfaSession', () => {
 
   it('clears the trust bundle when current assurance level is not aal2', async () => {
     localStorage.setItem(
-      MFA_TRUST_STORAGE_KEY,
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() + 60_000),
     );
 
@@ -119,7 +119,9 @@ describe('tryRestoreTrustedMfaSession', () => {
     await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
       false,
     );
-    expect(localStorage.getItem(MFA_TRUST_STORAGE_KEY)).toBeNull();
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
     expect(setSession).toHaveBeenCalledWith({
       refresh_token: 'pre-refresh',
       access_token: 'pre-access',
@@ -129,7 +131,7 @@ describe('tryRestoreTrustedMfaSession', () => {
 
   it('clears the trust bundle when restored session user id does not match and reverts session', async () => {
     localStorage.setItem(
-      MFA_TRUST_STORAGE_KEY,
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() + 60_000),
     );
 
@@ -159,7 +161,9 @@ describe('tryRestoreTrustedMfaSession', () => {
     await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
       false,
     );
-    expect(localStorage.getItem(MFA_TRUST_STORAGE_KEY)).toBeNull();
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
     expect(
       supabase.auth.mfa.getAuthenticatorAssuranceLevel,
     ).not.toHaveBeenCalled();
@@ -177,7 +181,7 @@ describe('tryRestoreTrustedMfaSession', () => {
 
   it('clears the trust bundle when there is no session after setSession and reverts', async () => {
     localStorage.setItem(
-      MFA_TRUST_STORAGE_KEY,
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() + 60_000),
     );
 
@@ -205,7 +209,9 @@ describe('tryRestoreTrustedMfaSession', () => {
     await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
       false,
     );
-    expect(localStorage.getItem(MFA_TRUST_STORAGE_KEY)).toBeNull();
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
     expect(
       supabase.auth.mfa.getAuthenticatorAssuranceLevel,
     ).not.toHaveBeenCalled();
@@ -218,7 +224,7 @@ describe('tryRestoreTrustedMfaSession', () => {
 
   it('signs out when revert setSession fails after a restore failure', async () => {
     localStorage.setItem(
-      MFA_TRUST_STORAGE_KEY,
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() + 60_000),
     );
 
@@ -272,7 +278,7 @@ describe('isPractitionerMfaDeviceTrustActive', () => {
   it('returns false when there is no bundle or user does not match', () => {
     expect(isPractitionerMfaDeviceTrustActive(userId)).toBe(false);
     localStorage.setItem(
-      MFA_TRUST_STORAGE_KEY,
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(
         '00000000-0000-0000-0000-000000000001',
         Date.now() + 60_000,
@@ -283,7 +289,7 @@ describe('isPractitionerMfaDeviceTrustActive', () => {
 
   it('returns false when the trust window has expired', () => {
     localStorage.setItem(
-      MFA_TRUST_STORAGE_KEY,
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() - 1000),
     );
     expect(isPractitionerMfaDeviceTrustActive(userId)).toBe(false);
@@ -291,7 +297,7 @@ describe('isPractitionerMfaDeviceTrustActive', () => {
 
   it('returns true when a non-expired bundle exists for the user', () => {
     localStorage.setItem(
-      MFA_TRUST_STORAGE_KEY,
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() + 60_000),
     );
     expect(isPractitionerMfaDeviceTrustActive(userId)).toBe(true);
@@ -325,7 +331,7 @@ describe('practitionerSignOut', () => {
 
   it('soft sign-out: clears sb-* auth storage, keeps MFA bundle, does not call auth.signOut', async () => {
     localStorage.setItem(
-      MFA_TRUST_STORAGE_KEY,
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() + 60_000),
     );
     localStorage.setItem('sb-example-auth-token', '{"persisted":true}');
@@ -344,14 +350,16 @@ describe('practitionerSignOut', () => {
 
     await practitionerSignOut(supabase);
 
-    expect(localStorage.getItem(MFA_TRUST_STORAGE_KEY)).not.toBeNull();
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).not.toBeNull();
     expect(localStorage.getItem('sb-example-auth-token')).toBeNull();
     expect(signOut).not.toHaveBeenCalled();
   });
 
   it('full sign-out: clears MFA bundle and calls auth.signOut (expired trust window)', async () => {
     localStorage.setItem(
-      MFA_TRUST_STORAGE_KEY,
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() - 1000),
     );
 
@@ -367,13 +375,15 @@ describe('practitionerSignOut', () => {
 
     await practitionerSignOut(supabase);
 
-    expect(localStorage.getItem(MFA_TRUST_STORAGE_KEY)).toBeNull();
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
     expect(signOut).toHaveBeenCalled();
   });
 
   it('full sign-out when no session: clears bundle and calls auth.signOut', async () => {
     localStorage.setItem(
-      MFA_TRUST_STORAGE_KEY,
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() + 60_000),
     );
 
@@ -387,7 +397,9 @@ describe('practitionerSignOut', () => {
 
     await practitionerSignOut(supabase);
 
-    expect(localStorage.getItem(MFA_TRUST_STORAGE_KEY)).toBeNull();
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
     expect(signOut).toHaveBeenCalled();
   });
 });
@@ -409,14 +421,16 @@ describe('practitionerSignOutEverywhere', () => {
 
   it('clears MFA bundle and sb-* auth storage and POSTs logout form', () => {
     localStorage.setItem(
-      MFA_TRUST_STORAGE_KEY,
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() + 60_000),
     );
     localStorage.setItem('sb-proj-auth-token', '{"refresh":true}');
 
     practitionerSignOutEverywhere();
 
-    expect(localStorage.getItem(MFA_TRUST_STORAGE_KEY)).toBeNull();
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
     expect(localStorage.getItem('sb-proj-auth-token')).toBeNull();
     expect(submitSpy).toHaveBeenCalled();
   });

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -129,6 +129,43 @@ describe('tryRestoreTrustedMfaSession', () => {
     expect(signOut).not.toHaveBeenCalled();
   });
 
+  it('clears the trust bundle and signs out when initial session user id does not match', async () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+
+    const otherId = '99999999-9999-9999-9999-999999999999';
+
+    const setSession = jest.fn();
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+
+    const supabase = {
+      auth: {
+        setSession,
+        signOut,
+        getSession: jest.fn().mockResolvedValue({
+          data: { session: prePasswordSession(otherId) },
+        }),
+        mfa: {
+          getAuthenticatorAssuranceLevel: jest.fn(),
+        },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
+      false,
+    );
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
+    expect(setSession).not.toHaveBeenCalled();
+    expect(signOut).toHaveBeenCalled();
+    expect(
+      supabase.auth.mfa.getAuthenticatorAssuranceLevel,
+    ).not.toHaveBeenCalled();
+  });
+
   it('clears the trust bundle when restored session user id does not match and reverts session', async () => {
     localStorage.setItem(
       PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -5,7 +5,9 @@ import {
   PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
   practitionerSignOut,
   practitionerSignOutEverywhere,
+  refreshTrustedMfaBundleBeforePasswordSignIn,
   saveMfaTrustBundle,
+  syncMfaTrustBundleAfterTokenRefresh,
   tryRestoreTrustedMfaSession,
 } from './practitioner-device-trust';
 
@@ -30,6 +32,20 @@ type BrowserClient = AbstrackSupabaseClient;
 function buildBundleJson(userId: string, trustedUntilMs: number) {
   return JSON.stringify({
     userId,
+    refresh_token: 'refresh',
+    access_token: 'access',
+    trustedUntilMs,
+  });
+}
+
+function buildBundleJsonWithEmail(
+  userId: string,
+  trustedUntilMs: number,
+  email: string,
+) {
+  return JSON.stringify({
+    userId,
+    email,
     refresh_token: 'refresh',
     access_token: 'access',
     trustedUntilMs,
@@ -64,16 +80,20 @@ describe('tryRestoreTrustedMfaSession', () => {
       buildBundleJson(userId, Date.now() + 60_000),
     );
 
-    const setSession = jest.fn().mockResolvedValue({ error: null });
+    const refreshSession = jest.fn().mockResolvedValue({
+      data: {
+        session: prePasswordSession(userId),
+        user: { id: userId },
+      },
+      error: null,
+    });
     const supabase = {
       auth: {
-        setSession,
+        refreshSession,
+        setSession: jest.fn().mockResolvedValue({ error: null }),
         signOut: jest.fn(),
         getSession: jest
           .fn()
-          .mockResolvedValueOnce({
-            data: { session: prePasswordSession(userId) },
-          })
           .mockResolvedValueOnce({
             data: { session: prePasswordSession(userId) },
           })
@@ -92,6 +112,10 @@ describe('tryRestoreTrustedMfaSession', () => {
     await expect(
       tryRestoreTrustedMfaSession(supabase, userId),
     ).resolves.toEqual({ status: 'restored' });
+
+    expect(refreshSession).toHaveBeenCalledWith({
+      refresh_token: 'refresh',
+    });
   });
 
   it('clears the trust bundle when stored bundle user id does not match current user', async () => {
@@ -105,6 +129,7 @@ describe('tryRestoreTrustedMfaSession', () => {
     const supabase = {
       auth: {
         getSession,
+        refreshSession: jest.fn(),
         setSession: jest.fn(),
         signOut: jest.fn(),
         mfa: {},
@@ -126,11 +151,19 @@ describe('tryRestoreTrustedMfaSession', () => {
       buildBundleJson(userId, Date.now() + 60_000),
     );
 
+    const refreshSession = jest.fn().mockResolvedValue({
+      data: {
+        session: prePasswordSession(userId),
+        user: { id: userId },
+      },
+      error: null,
+    });
     const setSession = jest.fn().mockResolvedValue({ error: null });
     const signOut = jest.fn().mockResolvedValue({ error: null });
 
     const supabase = {
       auth: {
+        refreshSession,
         setSession,
         signOut,
         getSession: jest
@@ -155,9 +188,8 @@ describe('tryRestoreTrustedMfaSession', () => {
     expect(
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
     ).toBeNull();
-    expect(setSession).toHaveBeenCalledWith({
+    expect(refreshSession).toHaveBeenCalledWith({
       refresh_token: 'refresh',
-      access_token: 'access',
     });
     expect(setSession).toHaveBeenCalledWith({
       refresh_token: 'pre-refresh',
@@ -172,11 +204,19 @@ describe('tryRestoreTrustedMfaSession', () => {
       buildBundleJson(userId, Date.now() + 60_000),
     );
 
+    const refreshSession = jest.fn().mockResolvedValue({
+      data: {
+        session: prePasswordSession(userId),
+        user: { id: userId },
+      },
+      error: null,
+    });
     const setSession = jest.fn().mockResolvedValue({ error: null });
     const signOut = jest.fn().mockResolvedValue({ error: null });
 
     const supabase = {
       auth: {
+        refreshSession,
         setSession,
         signOut,
         getSession: jest
@@ -254,21 +294,24 @@ describe('tryRestoreTrustedMfaSession', () => {
 
     const otherId = '99999999-9999-9999-9999-999999999999';
 
+    const refreshSession = jest.fn().mockResolvedValue({
+      data: {
+        session: prePasswordSession(otherId),
+        user: { id: otherId },
+      },
+      error: null,
+    });
     const setSession = jest.fn().mockResolvedValue({ error: null });
     const signOut = jest.fn().mockResolvedValue({ error: null });
 
     const supabase = {
       auth: {
+        refreshSession,
         setSession,
         signOut,
-        getSession: jest
-          .fn()
-          .mockResolvedValueOnce({
-            data: { session: prePasswordSession(userId) },
-          })
-          .mockResolvedValueOnce({
-            data: { session: sessionForUser(otherId) },
-          }),
+        getSession: jest.fn().mockResolvedValueOnce({
+          data: { session: prePasswordSession(userId) },
+        }),
         mfa: {
           getAuthenticatorAssuranceLevel: jest.fn(),
         },
@@ -284,39 +327,37 @@ describe('tryRestoreTrustedMfaSession', () => {
     expect(
       supabase.auth.mfa.getAuthenticatorAssuranceLevel,
     ).not.toHaveBeenCalled();
-    expect(setSession).toHaveBeenCalledTimes(2);
-    expect(setSession).toHaveBeenNthCalledWith(1, {
+    expect(refreshSession).toHaveBeenCalledWith({
       refresh_token: 'refresh',
-      access_token: 'access',
     });
-    expect(setSession).toHaveBeenNthCalledWith(2, {
+    expect(setSession).toHaveBeenCalledWith({
       refresh_token: 'pre-refresh',
       access_token: 'pre-access',
     });
     expect(signOut).not.toHaveBeenCalled();
   });
 
-  it('clears the trust bundle when there is no session after setSession and reverts', async () => {
+  it('clears the trust bundle when refreshSession returns no session and reverts', async () => {
     localStorage.setItem(
       PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() + 60_000),
     );
 
+    const refreshSession = jest.fn().mockResolvedValue({
+      data: { session: null, user: null },
+      error: null,
+    });
     const setSession = jest.fn().mockResolvedValue({ error: null });
     const signOut = jest.fn().mockResolvedValue({ error: null });
 
     const supabase = {
       auth: {
+        refreshSession,
         setSession,
         signOut,
-        getSession: jest
-          .fn()
-          .mockResolvedValueOnce({
-            data: { session: prePasswordSession(userId) },
-          })
-          .mockResolvedValueOnce({
-            data: { session: null },
-          }),
+        getSession: jest.fn().mockResolvedValueOnce({
+          data: { session: prePasswordSession(userId) },
+        }),
         mfa: {
           getAuthenticatorAssuranceLevel: jest.fn(),
         },
@@ -350,6 +391,7 @@ describe('tryRestoreTrustedMfaSession', () => {
 
     const supabase = {
       auth: {
+        refreshSession: jest.fn(),
         setSession,
         signOut,
         getSession: jest.fn().mockResolvedValue({
@@ -369,29 +411,28 @@ describe('tryRestoreTrustedMfaSession', () => {
     expect(signOut).toHaveBeenCalled();
   });
 
-  it('clears the trust bundle and reverts when getSession fails after setSession', async () => {
+  it('clears the trust bundle and reverts when refreshSession fails', async () => {
     localStorage.setItem(
       PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() + 60_000),
     );
 
+    const refreshSession = jest.fn().mockResolvedValue({
+      data: { session: null, user: null },
+      error: { message: 'invalid refresh token' },
+    });
     const setSession = jest.fn().mockResolvedValue({ error: null });
     const signOut = jest.fn().mockResolvedValue({ error: null });
 
     const supabase = {
       auth: {
+        refreshSession,
         setSession,
         signOut,
-        getSession: jest
-          .fn()
-          .mockResolvedValueOnce({
-            error: null,
-            data: { session: prePasswordSession(userId) },
-          })
-          .mockResolvedValueOnce({
-            error: new Error('cookie unreadable'),
-            data: { session: null },
-          }),
+        getSession: jest.fn().mockResolvedValueOnce({
+          error: null,
+          data: { session: prePasswordSession(userId) },
+        }),
         mfa: {
           getAuthenticatorAssuranceLevel: jest.fn(),
         },
@@ -407,9 +448,8 @@ describe('tryRestoreTrustedMfaSession', () => {
     expect(
       supabase.auth.mfa.getAuthenticatorAssuranceLevel,
     ).not.toHaveBeenCalled();
-    expect(setSession).toHaveBeenCalledWith({
+    expect(refreshSession).toHaveBeenCalledWith({
       refresh_token: 'refresh',
-      access_token: 'access',
     });
     expect(setSession).toHaveBeenCalledWith({
       refresh_token: 'pre-refresh',
@@ -424,19 +464,23 @@ describe('tryRestoreTrustedMfaSession', () => {
       buildBundleJson(userId, Date.now() + 60_000),
     );
 
+    const refreshSession = jest.fn().mockResolvedValue({
+      data: {
+        session: prePasswordSession(userId),
+        user: { id: userId },
+      },
+      error: null,
+    });
     const setSession = jest.fn().mockResolvedValue({ error: null });
     const signOut = jest.fn().mockResolvedValue({ error: null });
 
     const supabase = {
       auth: {
+        refreshSession,
         setSession,
         signOut,
         getSession: jest
           .fn()
-          .mockResolvedValueOnce({
-            error: null,
-            data: { session: prePasswordSession(userId) },
-          })
           .mockResolvedValueOnce({
             error: null,
             data: { session: prePasswordSession(userId) },
@@ -473,19 +517,23 @@ describe('tryRestoreTrustedMfaSession', () => {
       buildBundleJson(userId, Date.now() + 60_000),
     );
 
+    const refreshSession = jest.fn().mockResolvedValue({
+      data: {
+        session: prePasswordSession(userId),
+        user: { id: userId },
+      },
+      error: null,
+    });
     const setSession = jest.fn().mockResolvedValue({ error: null });
     const signOut = jest.fn().mockResolvedValue({ error: null });
 
     const supabase = {
       auth: {
+        refreshSession,
         setSession,
         signOut,
         getSession: jest
           .fn()
-          .mockResolvedValueOnce({
-            error: null,
-            data: { session: prePasswordSession(userId) },
-          })
           .mockResolvedValueOnce({
             error: null,
             data: { session: prePasswordSession(userId) },
@@ -522,26 +570,26 @@ describe('tryRestoreTrustedMfaSession', () => {
       buildBundleJson(userId, Date.now() + 60_000),
     );
 
-    const setSession = jest
-      .fn()
-      .mockResolvedValueOnce({ error: null })
-      .mockResolvedValueOnce({
-        error: { message: 'revert failed' },
-      });
+    const refreshSession = jest.fn().mockResolvedValue({
+      data: {
+        session: prePasswordSession(userId),
+        user: { id: userId },
+      },
+      error: null,
+    });
+    const setSession = jest.fn().mockResolvedValueOnce({
+      error: { message: 'revert failed' },
+    });
     const signOut = jest.fn().mockResolvedValue({ error: null });
 
     const supabase = {
       auth: {
+        refreshSession,
         setSession,
         signOut,
-        getSession: jest
-          .fn()
-          .mockResolvedValueOnce({
-            data: { session: prePasswordSession(userId) },
-          })
-          .mockResolvedValue({
-            data: { session: prePasswordSession(userId) },
-          }),
+        getSession: jest.fn().mockResolvedValueOnce({
+          data: { session: prePasswordSession(userId) },
+        }),
         mfa: {
           getAuthenticatorAssuranceLevel: jest
             .fn()
@@ -698,7 +746,10 @@ describe('practitionerSignOut', () => {
       const text = args
         .map((a) => (a instanceof Error ? a.message : String(a)))
         .join(' ');
-      if (text.includes('Not implemented: navigation')) {
+      if (
+        text.includes('Not implemented: navigation') ||
+        text.includes('soft session clear failed')
+      ) {
         return;
       }
       origConsoleError.apply(console, args as Parameters<typeof console.error>);
@@ -713,12 +764,13 @@ describe('practitionerSignOut', () => {
     localStorage.clear();
   });
 
-  it('soft sign-out: calls auth.signOut with local scope, keeps MFA bundle', async () => {
+  it('soft sign-out: clears auth storage without POST /logout, keeps MFA bundle', async () => {
     localStorage.setItem(
       PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() + 60_000),
     );
 
+    const removeItem = jest.fn().mockResolvedValue(undefined);
     const signOut = jest.fn().mockResolvedValue({ error: null });
     const supabase = {
       auth: {
@@ -728,6 +780,8 @@ describe('practitionerSignOut', () => {
           },
         }),
         signOut,
+        storage: { removeItem },
+        storageKey: 'sb-test-auth-token',
       },
     } as unknown as BrowserClient;
 
@@ -736,8 +790,10 @@ describe('practitionerSignOut', () => {
     expect(
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
     ).not.toBeNull();
-    expect(signOut).toHaveBeenCalledTimes(1);
-    expect(signOut).toHaveBeenCalledWith({ scope: 'local' });
+    expect(signOut).not.toHaveBeenCalled();
+    expect(removeItem).toHaveBeenCalledWith('sb-test-auth-token');
+    expect(removeItem).toHaveBeenCalledWith('sb-test-auth-token-code-verifier');
+    expect(removeItem).toHaveBeenCalledWith('sb-test-auth-token-user');
   });
 
   it('full sign-out: clears MFA bundle and calls auth.signOut without local scope (expired trust window)', async () => {
@@ -788,7 +844,7 @@ describe('practitionerSignOut', () => {
     expect(signOut).toHaveBeenCalledWith();
   });
 
-  it('falls back to server logout when local sign-out returns an error', async () => {
+  it('falls back to server logout when soft session clear fails', async () => {
     localStorage.setItem(
       PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() + 60_000),
@@ -799,9 +855,10 @@ describe('practitionerSignOut', () => {
       .spyOn(HTMLFormElement.prototype, 'submit')
       .mockImplementation(() => undefined);
 
-    const signOut = jest
+    const removeItem = jest
       .fn()
-      .mockResolvedValue({ error: { message: 'local sign-out failed' } });
+      .mockRejectedValue(new Error('storage remove failed'));
+    const signOut = jest.fn().mockResolvedValue({ error: null });
     const supabase = {
       auth: {
         getSession: jest.fn().mockResolvedValue({
@@ -810,12 +867,14 @@ describe('practitionerSignOut', () => {
           },
         }),
         signOut,
+        storage: { removeItem },
+        storageKey: 'sb-test-auth-token',
       },
     } as unknown as BrowserClient;
 
     await practitionerSignOut(supabase);
 
-    expect(signOut).toHaveBeenCalledWith({ scope: 'local' });
+    expect(signOut).not.toHaveBeenCalled();
     expect(submitSpy).toHaveBeenCalledTimes(1);
     expect(
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
@@ -888,19 +947,344 @@ describe('practitionerSignOutEverywhere', () => {
   });
 });
 
+describe('syncMfaTrustBundleAfterTokenRefresh', () => {
+  const userId = '00000000-0000-0000-0000-000000000042';
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('rewrites bundle with rotated tokens when assurance is aal2', async () => {
+    const trustedUntil = Date.now() + 86_400_000;
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, trustedUntil),
+    );
+
+    const supabase = {
+      auth: {
+        mfa: {
+          getAuthenticatorAssuranceLevel: jest.fn().mockResolvedValue({
+            data: { currentLevel: 'aal2', nextLevel: null },
+            error: null,
+          }),
+        },
+      },
+    };
+
+    const session = {
+      user: { id: userId },
+      refresh_token: 'rotated-refresh',
+      access_token: 'rotated-access',
+    } as Session;
+
+    await syncMfaTrustBundleAfterTokenRefresh(
+      supabase as unknown as BrowserClient,
+      session,
+    );
+
+    const raw = localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw!) as {
+      refresh_token: string;
+      access_token: string;
+      trustedUntilMs: number;
+    };
+    expect(parsed.refresh_token).toBe('rotated-refresh');
+    expect(parsed.access_token).toBe('rotated-access');
+    expect(parsed.trustedUntilMs).toBe(trustedUntil);
+  });
+
+  it('does not update bundle when assurance is aal1', async () => {
+    const trustedUntil = Date.now() + 86_400_000;
+    const initial = buildBundleJson(userId, trustedUntil);
+    localStorage.setItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY, initial);
+
+    const supabase = {
+      auth: {
+        mfa: {
+          getAuthenticatorAssuranceLevel: jest.fn().mockResolvedValue({
+            data: { currentLevel: 'aal1', nextLevel: 'aal2' },
+            error: null,
+          }),
+        },
+      },
+    };
+
+    const session = {
+      user: { id: userId },
+      refresh_token: 'pwd-refresh',
+      access_token: 'pwd-access',
+    } as Session;
+
+    await syncMfaTrustBundleAfterTokenRefresh(
+      supabase as unknown as BrowserClient,
+      session,
+    );
+
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBe(initial);
+  });
+});
+
+describe('refreshTrustedMfaBundleBeforePasswordSignIn', () => {
+  const userId = '00000000-0000-0000-0000-000000000042';
+  const email = 'doc@example.com';
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns false when there is no bundle', async () => {
+    const supabase = {
+      auth: {
+        refreshSession: jest.fn(),
+        signOut: jest.fn(),
+        mfa: { getAuthenticatorAssuranceLevel: jest.fn() },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(
+      refreshTrustedMfaBundleBeforePasswordSignIn(supabase, email),
+    ).resolves.toBe(false);
+    expect(supabase.auth.refreshSession).not.toHaveBeenCalled();
+  });
+
+  it('returns false when bundle has no email (legacy)', async () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+    const supabase = {
+      auth: {
+        refreshSession: jest.fn(),
+        signOut: jest.fn(),
+        mfa: { getAuthenticatorAssuranceLevel: jest.fn() },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(
+      refreshTrustedMfaBundleBeforePasswordSignIn(supabase, email),
+    ).resolves.toBe(false);
+    expect(supabase.auth.refreshSession).not.toHaveBeenCalled();
+  });
+
+  it('matches email case-insensitively', async () => {
+    const trustedUntil = Date.now() + 60_000;
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJsonWithEmail(userId, trustedUntil, 'Doc@Example.COM'),
+    );
+    const refreshedSession = {
+      user: { id: userId, email: 'doc@example.com' },
+      refresh_token: 'new-r',
+      access_token: 'new-a',
+    };
+    const refreshSession = jest.fn().mockResolvedValue({
+      data: { session: refreshedSession },
+      error: null,
+    });
+    const getAuthenticatorAssuranceLevel = jest.fn().mockResolvedValue({
+      error: null,
+      data: { currentLevel: 'aal2', nextLevel: 'aal2' },
+    });
+    const supabase = {
+      auth: {
+        refreshSession,
+        signOut: jest.fn().mockResolvedValue({ error: null }),
+        mfa: { getAuthenticatorAssuranceLevel },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(
+      refreshTrustedMfaBundleBeforePasswordSignIn(supabase, 'doc@example.com'),
+    ).resolves.toBe(true);
+    expect(refreshSession).toHaveBeenCalledWith({
+      refresh_token: 'refresh',
+    });
+  });
+
+  it('returns false when sign-in email does not match bundle email', async () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJsonWithEmail(
+        userId,
+        Date.now() + 60_000,
+        'other@example.com',
+      ),
+    );
+    const supabase = {
+      auth: {
+        refreshSession: jest.fn(),
+        signOut: jest.fn(),
+        mfa: { getAuthenticatorAssuranceLevel: jest.fn() },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(
+      refreshTrustedMfaBundleBeforePasswordSignIn(supabase, email),
+    ).resolves.toBe(false);
+    expect(supabase.auth.refreshSession).not.toHaveBeenCalled();
+  });
+
+  it('returns false and signs out when refresh succeeds but user id does not match bundle', async () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJsonWithEmail(userId, Date.now() + 60_000, email),
+    );
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+    const refreshSession = jest.fn().mockResolvedValue({
+      data: {
+        session: {
+          user: { id: '00000000-0000-0000-0000-000000000099' },
+          refresh_token: 'new-r',
+          access_token: 'new-a',
+        },
+      },
+      error: null,
+    });
+    const supabase = {
+      auth: {
+        refreshSession,
+        signOut,
+        mfa: { getAuthenticatorAssuranceLevel: jest.fn() },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(
+      refreshTrustedMfaBundleBeforePasswordSignIn(supabase, email),
+    ).resolves.toBe(false);
+    expect(signOut).toHaveBeenCalled();
+  });
+
+  it('returns false and signs out when assurance is not aal2', async () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJsonWithEmail(userId, Date.now() + 60_000, email),
+    );
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+    const refreshSession = jest.fn().mockResolvedValue({
+      data: {
+        session: {
+          user: { id: userId },
+          refresh_token: 'new-r',
+          access_token: 'new-a',
+        },
+      },
+      error: null,
+    });
+    const getAuthenticatorAssuranceLevel = jest.fn().mockResolvedValue({
+      error: null,
+      data: { currentLevel: 'aal1', nextLevel: 'aal2' },
+    });
+    const supabase = {
+      auth: {
+        refreshSession,
+        signOut,
+        mfa: { getAuthenticatorAssuranceLevel },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(
+      refreshTrustedMfaBundleBeforePasswordSignIn(supabase, email),
+    ).resolves.toBe(false);
+    expect(signOut).toHaveBeenCalled();
+  });
+
+  it('returns true and persists refreshed session when refresh and aal2 succeed', async () => {
+    const trustedUntil = Date.now() + 60_000;
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJsonWithEmail(userId, trustedUntil, email),
+    );
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+    const refreshedSession = {
+      user: { id: userId, email },
+      refresh_token: 'new-r',
+      access_token: 'new-a',
+    };
+    const refreshSession = jest.fn().mockResolvedValue({
+      data: { session: refreshedSession },
+      error: null,
+    });
+    const getAuthenticatorAssuranceLevel = jest.fn().mockResolvedValue({
+      error: null,
+      data: { currentLevel: 'aal2', nextLevel: 'aal2' },
+    });
+    const supabase = {
+      auth: {
+        refreshSession,
+        signOut,
+        mfa: { getAuthenticatorAssuranceLevel },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(
+      refreshTrustedMfaBundleBeforePasswordSignIn(supabase, email),
+    ).resolves.toBe(true);
+
+    const raw = localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw as string) as {
+      refresh_token: string;
+      userId: string;
+      email?: string;
+    };
+    expect(parsed.refresh_token).toBe('new-r');
+    expect(parsed.userId).toBe(userId);
+    expect(parsed.email).toBe(email);
+    expect(signOut).not.toHaveBeenCalled();
+  });
+});
+
+describe('saveMfaTrustBundle', () => {
+  const userId = '00000000-0000-0000-0000-000000000042';
+
+  beforeEach(() => {
+    localStorage.clear();
+    process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'] = 'true';
+  });
+
+  it('preserves email from existing bundle when session user omits email (same user id)', () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJsonWithEmail(userId, Date.now() + 60_000, 'keep@example.com'),
+    );
+    saveMfaTrustBundle(
+      {
+        user: { id: userId },
+        refresh_token: 'new-refresh',
+        access_token: 'new-access',
+      } as Session,
+      Date.now() + 120_000,
+    );
+    const raw = localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw as string) as {
+      email?: string;
+      refresh_token: string;
+      userId: string;
+    };
+    expect(parsed.userId).toBe(userId);
+    expect(parsed.email).toBe('keep@example.com');
+    expect(parsed.refresh_token).toBe('new-refresh');
+  });
+});
+
 describe('MFA device trust deploy gate', () => {
   const userId = '00000000-0000-0000-0000-000000000042';
 
-  it('reports disabled when env is unset', () => {
+  it('reports enabled when env is unset', () => {
     const prev = process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'];
     delete process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'];
-    expect(isPractitionerMfaDeviceTrustEnabled()).toBe(false);
+    expect(isPractitionerMfaDeviceTrustEnabled()).toBe(true);
     process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'] = prev ?? 'true';
   });
 
   it('does not write localStorage when disabled', () => {
     const prev = process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'];
-    delete process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'];
+    process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'] = 'false';
     localStorage.clear();
     saveMfaTrustBundle(
       {
@@ -922,7 +1306,7 @@ describe('MFA device trust deploy gate', () => {
       PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() + 60_000),
     );
-    delete process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'];
+    process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'] = 'false';
     expect(isPractitionerMfaDeviceTrustActive(userId)).toBe(false);
     expect(
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -40,6 +40,42 @@ describe('tryRestoreTrustedMfaSession', () => {
     localStorage.clear();
   });
 
+  it('returns restored when trust bundle applies and assurance is aal2', async () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+
+    const setSession = jest.fn().mockResolvedValue({ error: null });
+    const supabase = {
+      auth: {
+        setSession,
+        signOut: jest.fn(),
+        getSession: jest
+          .fn()
+          .mockResolvedValueOnce({
+            data: { session: prePasswordSession(userId) },
+          })
+          .mockResolvedValueOnce({
+            data: { session: prePasswordSession(userId) },
+          })
+          .mockResolvedValueOnce({
+            data: { session: prePasswordSession(userId) },
+          }),
+        mfa: {
+          getAuthenticatorAssuranceLevel: jest.fn().mockResolvedValue({
+            error: null,
+            data: { currentLevel: 'aal2', nextLevel: 'aal2' },
+          }),
+        },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'restored' });
+  });
+
   it('clears the trust bundle when stored bundle user id does not match current user', async () => {
     const otherUserId = '99999999-9999-9999-9999-999999999999';
     localStorage.setItem(
@@ -57,9 +93,9 @@ describe('tryRestoreTrustedMfaSession', () => {
       },
     } as unknown as BrowserClient;
 
-    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
-      false,
-    );
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'not_restored' });
     expect(
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
     ).toBeNull();
@@ -95,9 +131,9 @@ describe('tryRestoreTrustedMfaSession', () => {
       },
     } as unknown as BrowserClient;
 
-    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
-      false,
-    );
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'not_restored' });
     expect(
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
     ).toBeNull();
@@ -142,9 +178,9 @@ describe('tryRestoreTrustedMfaSession', () => {
       },
     } as unknown as BrowserClient;
 
-    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
-      false,
-    );
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'not_restored' });
     expect(
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
     ).toBeNull();
@@ -179,9 +215,9 @@ describe('tryRestoreTrustedMfaSession', () => {
       },
     } as unknown as BrowserClient;
 
-    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
-      false,
-    );
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'signed_out' });
     expect(
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
     ).toBeNull();
@@ -221,9 +257,9 @@ describe('tryRestoreTrustedMfaSession', () => {
       },
     } as unknown as BrowserClient;
 
-    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
-      false,
-    );
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'not_restored' });
     expect(
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
     ).toBeNull();
@@ -269,9 +305,9 @@ describe('tryRestoreTrustedMfaSession', () => {
       },
     } as unknown as BrowserClient;
 
-    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
-      false,
-    );
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'not_restored' });
     expect(
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
     ).toBeNull();
@@ -305,9 +341,9 @@ describe('tryRestoreTrustedMfaSession', () => {
       },
     } as unknown as BrowserClient;
 
-    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
-      false,
-    );
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'signed_out' });
     expect(
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
     ).toBeNull();
@@ -344,9 +380,9 @@ describe('tryRestoreTrustedMfaSession', () => {
       },
     } as unknown as BrowserClient;
 
-    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
-      false,
-    );
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'not_restored' });
     expect(
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
     ).toBeNull();
@@ -400,9 +436,9 @@ describe('tryRestoreTrustedMfaSession', () => {
       },
     } as unknown as BrowserClient;
 
-    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
-      false,
-    );
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'not_restored' });
     expect(
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
     ).toBeNull();
@@ -449,9 +485,9 @@ describe('tryRestoreTrustedMfaSession', () => {
       },
     } as unknown as BrowserClient;
 
-    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
-      false,
-    );
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'not_restored' });
     expect(
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
     ).toBeNull();
@@ -496,9 +532,9 @@ describe('tryRestoreTrustedMfaSession', () => {
       },
     } as unknown as BrowserClient;
 
-    await expect(tryRestoreTrustedMfaSession(supabase, userId)).resolves.toBe(
-      false,
-    );
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'signed_out' });
     expect(signOut).toHaveBeenCalled();
   });
 });

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -1026,6 +1026,76 @@ describe('syncMfaTrustBundleAfterTokenRefresh', () => {
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
     ).toBe(initial);
   });
+
+  it('clears bundle when trust window is expired', async () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() - 1000),
+    );
+
+    const supabase = {
+      auth: {
+        mfa: {
+          getAuthenticatorAssuranceLevel: jest.fn().mockResolvedValue({
+            data: { currentLevel: 'aal2', nextLevel: null },
+            error: null,
+          }),
+        },
+      },
+    };
+
+    const session = {
+      user: { id: userId },
+      refresh_token: 'rotated-refresh',
+      access_token: 'rotated-access',
+    } as Session;
+
+    await syncMfaTrustBundleAfterTokenRefresh(
+      supabase as unknown as BrowserClient,
+      session,
+    );
+
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
+    expect(
+      supabase.auth.mfa.getAuthenticatorAssuranceLevel,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('clears bundle when session user does not match bundle userId', async () => {
+    const otherId = '00000000-0000-0000-0000-000000000099';
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+
+    const supabase = {
+      auth: {
+        mfa: {
+          getAuthenticatorAssuranceLevel: jest.fn(),
+        },
+      },
+    };
+
+    const session = {
+      user: { id: otherId },
+      refresh_token: 'rotated-refresh',
+      access_token: 'rotated-access',
+    } as Session;
+
+    await syncMfaTrustBundleAfterTokenRefresh(
+      supabase as unknown as BrowserClient,
+      session,
+    );
+
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
+    expect(
+      supabase.auth.mfa.getAuthenticatorAssuranceLevel,
+    ).not.toHaveBeenCalled();
+  });
 });
 
 describe('refreshTrustedMfaBundleBeforePasswordSignIn', () => {
@@ -1156,6 +1226,34 @@ describe('refreshTrustedMfaBundleBeforePasswordSignIn', () => {
       refreshTrustedMfaBundleBeforePasswordSignIn(supabase, email),
     ).resolves.toBe(false);
     expect(signOut).toHaveBeenCalled();
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
+  });
+
+  it('clears the bundle when refreshSession fails', async () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJsonWithEmail(userId, Date.now() + 60_000, email),
+    );
+    const refreshSession = jest.fn().mockResolvedValue({
+      data: { session: null },
+      error: { message: 'Invalid Refresh Token: Refresh Token Not Found' },
+    });
+    const supabase = {
+      auth: {
+        refreshSession,
+        signOut: jest.fn(),
+        mfa: { getAuthenticatorAssuranceLevel: jest.fn() },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(
+      refreshTrustedMfaBundleBeforePasswordSignIn(supabase, email),
+    ).resolves.toBe(false);
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
   });
 
   it('returns false and signs out when assurance is not aal2', async () => {
@@ -1190,6 +1288,9 @@ describe('refreshTrustedMfaBundleBeforePasswordSignIn', () => {
       refreshTrustedMfaBundleBeforePasswordSignIn(supabase, email),
     ).resolves.toBe(false);
     expect(signOut).toHaveBeenCalled();
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
   });
 
   it('returns true and persists refreshed session when refresh and aal2 succeed', async () => {

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -1,0 +1,180 @@
+import type { Session } from '@abstrack/supabase';
+import type { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
+
+type PractitionerBrowserClient = ReturnType<typeof getSupabaseBrowserClient>;
+
+const MFA_TRUST_KEY = 'abstrack.practitioner.mfaTrustBundle.v1';
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+export type PractitionerMfaTrustBundle = {
+  userId: string;
+  refresh_token: string;
+  access_token: string;
+  expires_at?: number;
+  /** Wall-clock time after which we stop attempting session restore (user must enter TOTP again). */
+  trustedUntilMs: number;
+};
+
+/**
+ * Removes persisted Supabase browser session keys without calling Auth sign-out (no server-side
+ * refresh revocation). Used for “trusted device” sign-out so the next sign-in can restore AAL2.
+ */
+export function clearSupabaseBrowserAuthStorage(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const toRemove: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && key.startsWith('sb-') && key.endsWith('-auth-token')) {
+      toRemove.push(key);
+    }
+  }
+  for (const key of toRemove) {
+    localStorage.removeItem(key);
+  }
+}
+
+function readBundle(): PractitionerMfaTrustBundle | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  const raw = window.localStorage.getItem(MFA_TRUST_KEY);
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as PractitionerMfaTrustBundle;
+    if (
+      typeof parsed.userId === 'string' &&
+      typeof parsed.refresh_token === 'string' &&
+      typeof parsed.access_token === 'string' &&
+      typeof parsed.trustedUntilMs === 'number'
+    ) {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persists refresh/access tokens for a verified MFA session so this browser can restore AAL2
+ * within the trust window. Sensitive: only call when the user opted in.
+ *
+ * @param session - Active Supabase session after successful `mfa.verify`.
+ * @param trustedUntilMs - Absolute expiry for the trust window.
+ */
+export function saveMfaTrustBundle(
+  session: Session,
+  trustedUntilMs: number,
+): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  if (
+    session.refresh_token == null ||
+    session.refresh_token === '' ||
+    session.access_token == null ||
+    session.access_token === ''
+  ) {
+    return;
+  }
+  const bundle: PractitionerMfaTrustBundle = {
+    userId: session.user.id,
+    refresh_token: session.refresh_token,
+    access_token: session.access_token,
+    expires_at: session.expires_at,
+    trustedUntilMs,
+  };
+  window.localStorage.setItem(MFA_TRUST_KEY, JSON.stringify(bundle));
+}
+
+export function clearMfaTrustBundle(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.removeItem(MFA_TRUST_KEY);
+}
+
+/**
+ * After email/password sign-in, attempts to restore a prior AAL2 session from the trust bundle.
+ * On failure (revoked or expired), clears the bundle.
+ *
+ * @param supabase - Browser Supabase client.
+ * @param userId - Authenticated user id from the new password session.
+ * @returns Whether navigation to patient routes should skip the TOTP step.
+ */
+export async function tryRestoreTrustedMfaSession(
+  supabase: PractitionerBrowserClient,
+  userId: string,
+): Promise<boolean> {
+  const bundle = readBundle();
+  if (!bundle || bundle.userId !== userId) {
+    return false;
+  }
+  if (bundle.trustedUntilMs <= Date.now()) {
+    clearMfaTrustBundle();
+    return false;
+  }
+
+  const { error } = await supabase.auth.setSession({
+    refresh_token: bundle.refresh_token,
+    access_token: bundle.access_token,
+  });
+  if (error) {
+    clearMfaTrustBundle();
+    return false;
+  }
+
+  const assurance = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+  if (assurance.error) {
+    return false;
+  }
+  if (assurance.data.currentLevel !== 'aal2') {
+    return false;
+  }
+
+  const { data: sessionData } = await supabase.auth.getSession();
+  const session = sessionData.session;
+  if (session) {
+    saveMfaTrustBundle(session, bundle.trustedUntilMs);
+  }
+
+  return true;
+}
+
+/**
+ * Signs the user out. If MFA device trust is still valid, clears only local Supabase storage so the
+ * refresh token is not revoked server-side (allows AAL2 restore on next visit). Otherwise performs
+ * a full Supabase sign-out and clears the trust bundle.
+ *
+ * @param supabase - Browser Supabase client.
+ */
+export async function practitionerSignOut(
+  supabase: PractitionerBrowserClient,
+): Promise<void> {
+  const { data: sessionData } = await supabase.auth.getSession();
+  const session = sessionData.session;
+  const bundle = readBundle();
+  const trustActiveForUser =
+    session &&
+    bundle &&
+    bundle.userId === session.user.id &&
+    bundle.trustedUntilMs > Date.now();
+
+  if (trustActiveForUser) {
+    clearSupabaseBrowserAuthStorage();
+    window.location.assign('/login');
+    return;
+  }
+
+  clearMfaTrustBundle();
+  await supabase.auth.signOut();
+  window.location.assign('/login');
+}
+
+export function getTrustedUntilMsAfterVerification(): number {
+  return Date.now() + THIRTY_DAYS_MS;
+}

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -260,7 +260,8 @@ async function revertToPreRestoreSession(
  * If the stored bundle’s `userId` does not match the current password session’s user, clears the
  * bundle and returns (avoids keeping another user’s tokens after account switch).
  * On failure (revoked or expired tokens, **session user mismatch** after restore, assurance error,
- * **getSession error**, or session not at **aal2**), clears the bundle and restores the pre-restore
+ * **getSession error**, **missing session** after a successful `getSession()` call, or session not at
+ * **aal2**), clears the bundle and restores the pre-restore
  * password session (or signs out) so the client is not left authenticated as the wrong user. If the
  * **initial** `getSession()` user id does not match `userId`, clears the bundle and **signs out**
  * (there is no safe pre-restore token pair for the expected user).
@@ -356,9 +357,13 @@ export async function tryRestoreTrustedMfaSession(
   }
 
   const session = finalSessionResult.data.session;
-  if (session) {
-    saveMfaTrustBundle(session, bundle.trustedUntilMs);
+  if (session == null) {
+    clearMfaTrustBundle();
+    await revertToPreRestoreSession(supabase, preSessionTokens);
+    return false;
   }
+
+  saveMfaTrustBundle(session, bundle.trustedUntilMs);
 
   return true;
 }

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -207,8 +207,8 @@ async function revertToPreRestoreSession(
 /**
  * After email/password sign-in, attempts to restore a prior AAL2 session from the trust bundle.
  * On failure (revoked or expired tokens, **session user mismatch** after restore, assurance error,
- * or session not at **aal2**), clears the bundle and restores the pre-restore password session (or
- * signs out) so the client is not left authenticated as the wrong user.
+ * **getSession error**, or session not at **aal2**), clears the bundle and restores the pre-restore
+ * password session (or signs out) so the client is not left authenticated as the wrong user.
  *
  * @param supabase - Browser Supabase client.
  * @param userId - Authenticated user id from the new password session.
@@ -227,9 +227,14 @@ export async function tryRestoreTrustedMfaSession(
     return false;
   }
 
-  const {
-    data: { session: preRestoreSession },
-  } = await supabase.auth.getSession();
+  const preSessionResult = await supabase.auth.getSession();
+  if (preSessionResult.error) {
+    clearMfaTrustBundle();
+    await revertToPreRestoreSession(supabase, null);
+    return false;
+  }
+
+  const preRestoreSession = preSessionResult.data.session;
 
   if (preRestoreSession?.user?.id !== userId) {
     clearMfaTrustBundle();
@@ -257,9 +262,14 @@ export async function tryRestoreTrustedMfaSession(
     return false;
   }
 
-  const {
-    data: { session: sessionAfterSet },
-  } = await supabase.auth.getSession();
+  const afterSetResult = await supabase.auth.getSession();
+  if (afterSetResult.error) {
+    clearMfaTrustBundle();
+    await revertToPreRestoreSession(supabase, preSessionTokens);
+    return false;
+  }
+
+  const sessionAfterSet = afterSetResult.data.session;
   if (sessionAfterSet?.user?.id == null || sessionAfterSet.user.id !== userId) {
     clearMfaTrustBundle();
     await revertToPreRestoreSession(supabase, preSessionTokens);
@@ -278,8 +288,14 @@ export async function tryRestoreTrustedMfaSession(
     return false;
   }
 
-  const { data: sessionData } = await supabase.auth.getSession();
-  const session = sessionData.session;
+  const finalSessionResult = await supabase.auth.getSession();
+  if (finalSessionResult.error) {
+    clearMfaTrustBundle();
+    await revertToPreRestoreSession(supabase, preSessionTokens);
+    return false;
+  }
+
+  const session = finalSessionResult.data.session;
   if (session) {
     saveMfaTrustBundle(session, bundle.trustedUntilMs);
   }
@@ -319,9 +335,12 @@ export function practitionerSignOutEverywhere(): void {
  * Otherwise performs a full Supabase sign-out and clears the trust bundle. For a **full** revoke
  * while trust is active, use {@link practitionerSignOutEverywhere} instead.
  *
- * Navigation to `/login` runs only in the browser (`window` present). In non-browser environments
- * (SSR, tests without `window`), storage and `signOut` still run when applicable, but there is no
- * redirect.
+ * If `auth.signOut` returns an error, falls back to {@link practitionerSignOutEverywhere} in the
+ * browser (server logout + form POST) so cookies are not left in an ambiguous state; in
+ * non-browser contexts only `console.error` is used (no redirect).
+ *
+ * Navigation to `/login` via `location.assign` runs only after a successful client sign-out when
+ * `window` is present.
  *
  * @param supabase - Browser Supabase client.
  */
@@ -338,7 +357,20 @@ export async function practitionerSignOut(
     bundle.trustedUntilMs > Date.now();
 
   if (trustActiveForUser) {
-    await supabase.auth.signOut({ scope: 'local' });
+    const { error: localSignOutError } = await supabase.auth.signOut({
+      scope: 'local',
+    });
+    if (localSignOutError) {
+      if (typeof document !== 'undefined') {
+        practitionerSignOutEverywhere();
+      } else {
+        console.error(
+          'practitionerSignOut: local sign-out failed; cannot fall back to server logout without a document.',
+          localSignOutError,
+        );
+      }
+      return;
+    }
     if (typeof window !== 'undefined') {
       window.location.assign('/login');
     }
@@ -346,7 +378,18 @@ export async function practitionerSignOut(
   }
 
   clearMfaTrustBundle();
-  await supabase.auth.signOut();
+  const { error: signOutError } = await supabase.auth.signOut();
+  if (signOutError) {
+    if (typeof document !== 'undefined') {
+      practitionerSignOutEverywhere();
+    } else {
+      console.error(
+        'practitionerSignOut: sign-out failed; cannot fall back to server logout without a document.',
+        signOutError,
+      );
+    }
+    return;
+  }
   if (typeof window !== 'undefined') {
     window.location.assign('/login');
   }

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -52,18 +52,17 @@ const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
  *
  * @returns Whether device trust reads/writes are allowed for this process.
  *
- * **Use bracket access** for this key: `process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST']`.
- * An earlier change to dotted `process.env.NEXT_PUBLIC_…` relied on compile-time inlining; when
- * the flag was missing from the inlining pass (wrong app `.env` path, cache, or first build), the
- * flag read as always-off and the trust read path scrubbed `localStorage` on every read — breaking
- * device trust. Bracket reads resolve like other runtime `NEXT_PUBLIC_*` usage in Next dev.
+ * **Next.js client bundles:** `NEXT_PUBLIC_*` values are substituted at build time when the key is
+ * referenced as **`process.env.NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST`** (dot access). Bracket
+ * access (`process.env['…']`) is often **not** inlined, which can leave the runtime value missing
+ * and incorrectly fall back to the “unset” default — so per-environment disable would not apply.
  */
 export function isPractitionerMfaDeviceTrustEnabled(): boolean {
   let raw: string | undefined;
   try {
     raw =
       typeof process !== 'undefined' && process.env != null
-        ? process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST']
+        ? process.env.NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST
         : undefined;
   } catch {
     return false;

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -27,7 +27,13 @@ import type { AbstrackSupabaseClient, Session } from '@abstrack/supabase';
 
 type PractitionerBrowserClient = AbstrackSupabaseClient;
 
-const MFA_TRUST_KEY = 'abstrack.practitioner.mfaTrustBundle.v1';
+/**
+ * `localStorage` key for the practitioner MFA device-trust bundle. **Bundle holds session
+ * secrets** — see module warning.
+ */
+export const PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY =
+  'abstrack.practitioner.mfaTrustBundle.v1';
+
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
 /**
@@ -74,7 +80,9 @@ function readBundle(): PractitionerMfaTrustBundle | null {
   }
   let raw: string | null;
   try {
-    raw = window.localStorage.getItem(MFA_TRUST_KEY);
+    raw = window.localStorage.getItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+    );
   } catch {
     return null;
   }
@@ -145,7 +153,10 @@ export function saveMfaTrustBundle(
     trustedUntilMs,
   };
   try {
-    window.localStorage.setItem(MFA_TRUST_KEY, JSON.stringify(bundle));
+    window.localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      JSON.stringify(bundle),
+    );
   } catch {
     // Blocked or full storage; trust bundle is optional UX — session is already valid in memory.
   }
@@ -156,7 +167,7 @@ export function clearMfaTrustBundle(): void {
     return;
   }
   try {
-    window.localStorage.removeItem(MFA_TRUST_KEY);
+    window.localStorage.removeItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY);
   } catch {
     // Same environments as `readBundle` / theme storage.
   }

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -233,6 +233,9 @@ export function readMfaTrustBundle(): PractitionerMfaTrustBundle | null {
  * returns a session, or **non-AAL2** assurance, clears the stored bundle **before** `signOut` so
  * wrong or unusable tokens are not kept in storage (and storage is scrubbed even if `signOut`
  * rejects).
+ *
+ * When the bundle’s **trust window has ended** (`trustedUntilMs`), clears storage before returning
+ * `false` so expired session material is not retained.
  */
 export async function refreshTrustedMfaBundleBeforePasswordSignIn(
   supabase: PractitionerBrowserClient,
@@ -242,7 +245,11 @@ export async function refreshTrustedMfaBundleBeforePasswordSignIn(
     return false;
   }
   const bundle = readBundle();
-  if (!bundle || bundle.trustedUntilMs <= Date.now()) {
+  if (!bundle) {
+    return false;
+  }
+  if (bundle.trustedUntilMs <= Date.now()) {
+    clearMfaTrustBundle();
     return false;
   }
   const want = emailForSignIn.trim().toLowerCase();

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -208,7 +208,9 @@ async function revertToPreRestoreSession(
  * After email/password sign-in, attempts to restore a prior AAL2 session from the trust bundle.
  * On failure (revoked or expired tokens, **session user mismatch** after restore, assurance error,
  * **getSession error**, or session not at **aal2**), clears the bundle and restores the pre-restore
- * password session (or signs out) so the client is not left authenticated as the wrong user.
+ * password session (or signs out) so the client is not left authenticated as the wrong user. If the
+ * **initial** `getSession()` user id does not match `userId`, clears the bundle and **signs out**
+ * (there is no safe pre-restore token pair for the expected user).
  *
  * @param supabase - Browser Supabase client.
  * @param userId - Authenticated user id from the new password session.
@@ -238,6 +240,7 @@ export async function tryRestoreTrustedMfaSession(
 
   if (preRestoreSession?.user?.id !== userId) {
     clearMfaTrustBundle();
+    await supabase.auth.signOut();
     return false;
   }
 

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -228,6 +228,11 @@ export function readMfaTrustBundle(): PractitionerMfaTrustBundle | null {
  * @param emailForSignIn - Email from the login form (trimmed comparison).
  * @returns `true` if an AAL2 session was established from the bundle and persisted with
  *   `saveMfaTrustBundle`; `false` to continue with password-first sign-in only.
+ *
+ * On **refresh failure** (revoked/invalid token, empty session), **user mismatch** after a refresh
+ * returns a session, or **non-AAL2** assurance, clears the stored bundle **before** `signOut` so
+ * wrong or unusable tokens are not kept in storage (and storage is scrubbed even if `signOut`
+ * rejects).
  */
 export async function refreshTrustedMfaBundleBeforePasswordSignIn(
   supabase: PractitionerBrowserClient,
@@ -251,15 +256,18 @@ export async function refreshTrustedMfaBundleBeforePasswordSignIn(
       refresh_token: bundle.refresh_token,
     });
   if (refreshError || refreshData?.session == null) {
+    clearMfaTrustBundle();
     return false;
   }
   if (refreshData.session.user?.id !== bundle.userId) {
+    clearMfaTrustBundle();
     await supabase.auth.signOut();
     return false;
   }
 
   const assurance = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
   if (assurance.error || assurance.data.currentLevel !== 'aal2') {
+    clearMfaTrustBundle();
     await supabase.auth.signOut();
     return false;
   }
@@ -370,6 +378,10 @@ export function saveMfaTrustBundle(
  * the window has not expired, and **MFA assurance is AAL2** — so password-only (AAL1) sessions never
  * overwrite a prior AAL2 bundle.
  *
+ * **`readBundle()` does not drop expired rows** (only validates shape). If the stored bundle’s
+ * trust window has ended, or its `userId` does not match the refreshed session, clears the bundle so
+ * stale secrets are not retained until another code path runs.
+ *
  * @param supabase - Browser Supabase client.
  * @param session - Session from the auth callback (null clears nothing).
  */
@@ -389,9 +401,11 @@ export async function syncMfaTrustBundleAfterTokenRefresh(
     return;
   }
   if (bundle.userId !== session.user.id) {
+    clearMfaTrustBundle();
     return;
   }
   if (bundle.trustedUntilMs <= Date.now()) {
+    clearMfaTrustBundle();
     return;
   }
   if (

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -20,10 +20,10 @@
  *
  * RLS and MFA fail-closed rules remain authoritative for PHI; this module is UX-only.
  *
- * **Deploy gate:** Token persistence and restore are **on by default** for expected practitioner login
- * UX. Set `NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST` to `false` or `0` to disable the feature (no
- * writes; reads scrub any existing bundle key)—e.g. if you want zero localStorage session material
- * until server-managed trust ships.
+ * **Deploy gate:** Token persistence and restore are **on by default** when the env var is unset or
+ * blank. Set it to **`true` or `1`** (case-insensitive) to enable explicitly, or **`false` or `0`**
+ * to disable (no writes; reads scrub any existing bundle key). **Any other non-empty value is
+ * treated as disabled** (fail-closed) so typos do not silently keep the feature on.
  *
  * @module practitioner-device-trust
  */
@@ -43,9 +43,14 @@ const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
 /**
  * Whether practitioner MFA “trusted device” (localStorage token bundle) is allowed for this build.
- * Defaults to **true** when unset or empty. Set to **`false` or `0`** (case-insensitive) to disable.
  *
- * @returns False when the env var is explicitly `false` or `0`; otherwise true (including unset).
+ * **Parsing (fail-closed for non-whitelisted values):**
+ * - Unset, `null`, or empty/whitespace → **enabled** (default practitioner UX).
+ * - `false` or `0` (case-insensitive) → **disabled**.
+ * - `true` or `1` (case-insensitive) → **enabled**.
+ * - Any other non-empty string (e.g. `yes`) → **disabled** — avoids treating typos as “on”.
+ *
+ * @returns Whether device trust reads/writes are allowed for this process.
  *
  * **Use bracket access** for this key: `process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST']`.
  * An earlier change to dotted `process.env.NEXT_PUBLIC_…` relied on compile-time inlining; when
@@ -83,9 +88,9 @@ export function isPractitionerMfaDeviceTrustEnabled(): boolean {
 export type PractitionerMfaTrustBundle = {
   userId: string;
   /**
-   * Sign-in email for this account, stored so the login page can refresh from the bundle **before**
-   * `signInWithPassword` — a new password grant typically revokes the previous refresh token, so
-   * post-password restore would fail without this ordering.
+   * Sign-in email for this account, used to correlate the bundle with the next login attempt (see
+   * {@link tryRestoreTrustedMfaSession} and `saveMfaTrustBundle` merge rules when `user.email` is
+   * absent on the session).
    */
   email?: string;
   refresh_token: string;
@@ -215,75 +220,6 @@ export function readMfaTrustBundle(): PractitionerMfaTrustBundle | null {
 }
 
 /**
- * Run **before** `signInWithEmailPassword` on the practitioner login form when a stored bundle
- * exists for this sign-in email. A new password grant usually **invalidates** the prior refresh
- * token on the server, so `tryRestoreTrustedMfaSession` **after** password cannot exchange the
- * bundle token. Refreshing from the bundle first establishes AAL2; the caller then verifies the
- * password as usual.
- *
- * Legacy bundles without `email` skip this path and rely on post-password restore (may fail until
- * the user completes MFA once with a fresh save).
- *
- * @param supabase - Browser Supabase client.
- * @param emailForSignIn - Email from the login form (trimmed comparison).
- * @returns `true` if an AAL2 session was established from the bundle and persisted with
- *   `saveMfaTrustBundle`; `false` to continue with password-first sign-in only.
- *
- * On **refresh failure** (revoked/invalid token, empty session), **user mismatch** after a refresh
- * returns a session, or **non-AAL2** assurance, clears the stored bundle **before** `signOut` so
- * wrong or unusable tokens are not kept in storage (and storage is scrubbed even if `signOut`
- * rejects).
- *
- * When the bundle’s **trust window has ended** (`trustedUntilMs`), clears storage before returning
- * `false` so expired session material is not retained.
- */
-export async function refreshTrustedMfaBundleBeforePasswordSignIn(
-  supabase: PractitionerBrowserClient,
-  emailForSignIn: string,
-): Promise<boolean> {
-  if (!isPractitionerMfaDeviceTrustEnabled()) {
-    return false;
-  }
-  const bundle = readBundle();
-  if (!bundle) {
-    return false;
-  }
-  if (bundle.trustedUntilMs <= Date.now()) {
-    clearMfaTrustBundle();
-    return false;
-  }
-  const want = emailForSignIn.trim().toLowerCase();
-  const got = bundle.email?.trim().toLowerCase();
-  if (!got || got !== want) {
-    return false;
-  }
-
-  const { data: refreshData, error: refreshError } =
-    await supabase.auth.refreshSession({
-      refresh_token: bundle.refresh_token,
-    });
-  if (refreshError || refreshData?.session == null) {
-    clearMfaTrustBundle();
-    return false;
-  }
-  if (refreshData.session.user?.id !== bundle.userId) {
-    clearMfaTrustBundle();
-    await supabase.auth.signOut();
-    return false;
-  }
-
-  const assurance = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
-  if (assurance.error || assurance.data.currentLevel !== 'aal2') {
-    clearMfaTrustBundle();
-    await supabase.auth.signOut();
-    return false;
-  }
-
-  saveMfaTrustBundle(refreshData.session, bundle.trustedUntilMs);
-  return true;
-}
-
-/**
  * Whether a non-expired MFA device-trust bundle exists for this user (soft sign-out path).
  * Clears stored tokens when the bundle is **expired** or for a **different** user so session
  * material is not left in `localStorage` after trust has lapsed or the account changed.
@@ -318,8 +254,8 @@ export function isPractitionerMfaDeviceTrustActive(
  *
  * **`user.email` may be missing** on some Supabase session payloads (for example after
  * `refreshSession` / token rotation). In that case, for the **same** `userId`, we **keep** the
- * email already stored in the bundle so {@link refreshTrustedMfaBundleBeforePasswordSignIn} can
- * still match the next sign-in (see Supabase refresh-token rotation docs).
+ * email already stored in the bundle so the next login can still correlate storage with the
+ * account (see Supabase refresh-token rotation docs).
  *
  * @param session - Active Supabase session after successful `mfa.verify`.
  * @param trustedUntilMs - Absolute expiry for the trust window (must be finite).
@@ -509,6 +445,8 @@ export type TryRestoreTrustedMfaSessionResult =
 
 /**
  * After email/password sign-in, attempts to restore a prior AAL2 session from the trust bundle.
+ * **Security:** intentionally runs only after a successful password grant so `refreshSession` does
+ * not authenticate the browser before the user proves possession of the password.
  * If the stored bundle’s `userId` does not match the current password session’s user, clears the
  * bundle and returns (avoids keeping another user’s tokens after account switch).
  * Restore uses `auth.refreshSession({ refresh_token })` with the stored refresh token, not

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -46,13 +46,16 @@ const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
  *
  * @returns True only when `NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST` is the string `true` or `1`
  *   (case-insensitive, trimmed).
+ *
+ * Uses **dot** `process.env.NEXT_PUBLIC_…` access only — Next.js inlines public env at build time for
+ * static references; bracket or dynamic lookups are not replaced (see Next.js env docs).
  */
 export function isPractitionerMfaDeviceTrustEnabled(): boolean {
   let raw: string | undefined;
   try {
     raw =
       typeof process !== 'undefined' && process.env != null
-        ? process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST']
+        ? process.env.NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST
         : undefined;
   } catch {
     return false;

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -116,8 +116,8 @@ export function clearSupabaseBrowserAuthStorage(): void {
 }
 
 /**
- * Reads the MFA trust bundle from storage. Corrupt or invalid payloads are removed so tokens are
- * not left in `localStorage` indefinitely.
+ * Reads the MFA trust bundle from storage. Corrupt, unparseable, or invalid payloads are removed
+ * so tokens are not left in `localStorage` indefinitely.
  */
 function readBundle(): PractitionerMfaTrustBundle | null {
   if (typeof window === 'undefined') {
@@ -142,6 +142,7 @@ function readBundle(): PractitionerMfaTrustBundle | null {
     }
     return parsed;
   } catch {
+    clearMfaTrustBundle();
     return null;
   }
 }

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -23,10 +23,9 @@
  * @module practitioner-device-trust
  */
 
-import type { Session } from '@abstrack/supabase';
-import type { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
+import type { AbstrackSupabaseClient, Session } from '@abstrack/supabase';
 
-type PractitionerBrowserClient = ReturnType<typeof getSupabaseBrowserClient>;
+type PractitionerBrowserClient = AbstrackSupabaseClient;
 
 const MFA_TRUST_KEY = 'abstrack.practitioner.mfaTrustBundle.v1';
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -49,6 +49,44 @@ export type PractitionerMfaTrustBundle = {
   trustedUntilMs: number;
 };
 
+function isNonEmptyTrimmedString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim() !== '';
+}
+
+/**
+ * Validates JSON parsed from {@link PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY}. Rejects empty
+ * tokens, blank `userId`, non-finite `trustedUntilMs` / `expires_at`, and malformed shapes.
+ *
+ * @param parsed - Value from `JSON.parse`.
+ * @returns Whether the object is safe to use as a trust bundle.
+ */
+function isValidStoredTrustBundle(
+  parsed: unknown,
+): parsed is PractitionerMfaTrustBundle {
+  if (parsed === null || typeof parsed !== 'object') {
+    return false;
+  }
+  const o = parsed as Record<string, unknown>;
+  if (
+    !isNonEmptyTrimmedString(o['userId']) ||
+    !isNonEmptyTrimmedString(o['refresh_token']) ||
+    !isNonEmptyTrimmedString(o['access_token'])
+  ) {
+    return false;
+  }
+  const trustedUntilMs = o['trustedUntilMs'];
+  if (typeof trustedUntilMs !== 'number' || !Number.isFinite(trustedUntilMs)) {
+    return false;
+  }
+  if (o['expires_at'] !== undefined) {
+    const exp = o['expires_at'];
+    if (typeof exp !== 'number' || !Number.isFinite(exp)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /**
  * Removes `sb-*-auth-token` keys from `localStorage` when present. The practitioner browser client
  * uses **`@supabase/ssr` cookie-backed sessions**; ending the session is done with
@@ -77,6 +115,10 @@ export function clearSupabaseBrowserAuthStorage(): void {
   }
 }
 
+/**
+ * Reads the MFA trust bundle from storage. Corrupt or invalid payloads are removed so tokens are
+ * not left in `localStorage` indefinitely.
+ */
 function readBundle(): PractitionerMfaTrustBundle | null {
   if (typeof window === 'undefined') {
     return null;
@@ -93,16 +135,12 @@ function readBundle(): PractitionerMfaTrustBundle | null {
     return null;
   }
   try {
-    const parsed = JSON.parse(raw) as PractitionerMfaTrustBundle;
-    if (
-      typeof parsed.userId === 'string' &&
-      typeof parsed.refresh_token === 'string' &&
-      typeof parsed.access_token === 'string' &&
-      typeof parsed.trustedUntilMs === 'number'
-    ) {
-      return parsed;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isValidStoredTrustBundle(parsed)) {
+      clearMfaTrustBundle();
+      return null;
     }
-    return null;
+    return parsed;
   } catch {
     return null;
   }
@@ -111,6 +149,8 @@ function readBundle(): PractitionerMfaTrustBundle | null {
 /**
  * @param userId - Authenticated user id from the current session, if any.
  * @returns Whether a non-expired MFA device-trust bundle exists for this user (soft sign-out path).
+ * Clears stored tokens when the bundle is **expired** or for a **different** user so session
+ * material is not left in `localStorage` after trust has lapsed or the account changed.
  */
 export function isPractitionerMfaDeviceTrustActive(
   userId: string | undefined,
@@ -119,11 +159,18 @@ export function isPractitionerMfaDeviceTrustActive(
     return false;
   }
   const bundle = readBundle();
-  return (
-    bundle !== null &&
-    bundle.userId === userId &&
-    bundle.trustedUntilMs > Date.now()
-  );
+  if (bundle === null) {
+    return false;
+  }
+  if (bundle.userId !== userId) {
+    clearMfaTrustBundle();
+    return false;
+  }
+  if (bundle.trustedUntilMs <= Date.now()) {
+    clearMfaTrustBundle();
+    return false;
+  }
+  return true;
 }
 
 /**
@@ -131,13 +178,16 @@ export function isPractitionerMfaDeviceTrustActive(
  * within the trust window. **Only call after explicit user opt-in**; see module XSS warning.
  *
  * @param session - Active Supabase session after successful `mfa.verify`.
- * @param trustedUntilMs - Absolute expiry for the trust window.
+ * @param trustedUntilMs - Absolute expiry for the trust window (must be finite).
  */
 export function saveMfaTrustBundle(
   session: Session,
   trustedUntilMs: number,
 ): void {
   if (typeof window === 'undefined') {
+    return;
+  }
+  if (!Number.isFinite(trustedUntilMs)) {
     return;
   }
   if (

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -50,9 +50,12 @@ export type PractitionerMfaTrustBundle = {
 };
 
 /**
- * Removes persisted Supabase browser session keys without calling Auth sign-out (no server-side
- * refresh revocation). Used for “trusted device” sign-out so the next sign-in can restore AAL2.
- * Swallows `localStorage` errors (blocked storage, privacy mode, quota) so sign-out still proceeds.
+ * Removes `sb-*-auth-token` keys from `localStorage` when present. The practitioner browser client
+ * uses **`@supabase/ssr` cookie-backed sessions**; ending the session is done with
+ * `auth.signOut` or `POST /api/auth/logout`. This sweep still matters because the Supabase client
+ * may persist auth-related material under those keys in some cases, and {@link practitionerSignOutEverywhere}
+ * pairs it with server logout so nothing session-like is left in browser storage for this origin.
+ * Swallows `localStorage` errors (blocked storage, privacy mode, quota).
  */
 export function clearSupabaseBrowserAuthStorage(): void {
   if (typeof window === 'undefined') {
@@ -310,10 +313,11 @@ export function practitionerSignOutEverywhere(): void {
 }
 
 /**
- * Signs the user out. If MFA device trust is still valid, clears only local Supabase storage so the
- * refresh token is not revoked server-side (allows AAL2 restore on next visit). Otherwise performs
- * a full Supabase sign-out and clears the trust bundle. For a **full** revoke while trust is active,
- * use {@link practitionerSignOutEverywhere} instead.
+ * Signs the user out. If MFA device trust is still valid, ends the browser session with
+ * **`auth.signOut({ scope: 'local' })`** so cookie-backed `@supabase/ssr` state is cleared without
+ * revoking the refresh token server-side (allows AAL2 restore from the trust bundle on next visit).
+ * Otherwise performs a full Supabase sign-out and clears the trust bundle. For a **full** revoke
+ * while trust is active, use {@link practitionerSignOutEverywhere} instead.
  *
  * Navigation to `/login` runs only in the browser (`window` present). In non-browser environments
  * (SSR, tests without `window`), storage and `signOut` still run when applicable, but there is no
@@ -334,7 +338,7 @@ export async function practitionerSignOut(
     bundle.trustedUntilMs > Date.now();
 
   if (trustActiveForUser) {
-    clearSupabaseBrowserAuthStorage();
+    await supabase.auth.signOut({ scope: 'local' });
     if (typeof window !== 'undefined') {
       window.location.assign('/login');
     }

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -20,6 +20,10 @@
  *
  * RLS and MFA fail-closed rules remain authoritative for PHI; this module is UX-only.
  *
+ * **Deploy gate:** Token persistence and restore are **off by default**. Set
+ * `NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST` to `true` or `1` only after an explicit security
+ * decision. When disabled, this module does not write tokens; reads scrub any existing bundle key.
+ *
  * @module practitioner-device-trust
  */
 
@@ -35,6 +39,30 @@ export const PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY =
   'abstrack.practitioner.mfaTrustBundle.v1';
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Whether practitioner MFA “trusted device” (localStorage token bundle) is allowed for this build.
+ * Defaults to **false** when unset so high-impact XSS surface is not enabled accidentally.
+ *
+ * @returns True only when `NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST` is the string `true` or `1`
+ *   (case-insensitive, trimmed).
+ */
+export function isPractitionerMfaDeviceTrustEnabled(): boolean {
+  let raw: string | undefined;
+  try {
+    raw =
+      typeof process !== 'undefined' && process.env != null
+        ? process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST']
+        : undefined;
+  } catch {
+    return false;
+  }
+  if (raw == null || String(raw).trim() === '') {
+    return false;
+  }
+  const v = String(raw).trim().toLowerCase();
+  return v === 'true' || v === '1';
+}
 
 /**
  * Serialized trust bundle. **Contains long-lived session secrets** readable by any script on the
@@ -123,6 +151,14 @@ function readBundle(): PractitionerMfaTrustBundle | null {
   if (typeof window === 'undefined') {
     return null;
   }
+  if (!isPractitionerMfaDeviceTrustEnabled()) {
+    try {
+      window.localStorage.removeItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY);
+    } catch {
+      // Blocked storage — same as `clearMfaTrustBundle`.
+    }
+    return null;
+  }
   let raw: string | null;
   try {
     raw = window.localStorage.getItem(
@@ -186,6 +222,9 @@ export function saveMfaTrustBundle(
   trustedUntilMs: number,
 ): void {
   if (typeof window === 'undefined') {
+    return;
+  }
+  if (!isPractitionerMfaDeviceTrustEnabled()) {
     return;
   }
   if (!Number.isFinite(trustedUntilMs)) {

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -257,6 +257,8 @@ async function revertToPreRestoreSession(
 
 /**
  * After email/password sign-in, attempts to restore a prior AAL2 session from the trust bundle.
+ * If the stored bundle’s `userId` does not match the current password session’s user, clears the
+ * bundle and returns (avoids keeping another user’s tokens after account switch).
  * On failure (revoked or expired tokens, **session user mismatch** after restore, assurance error,
  * **getSession error**, or session not at **aal2**), clears the bundle and restores the pre-restore
  * password session (or signs out) so the client is not left authenticated as the wrong user. If the
@@ -272,7 +274,11 @@ export async function tryRestoreTrustedMfaSession(
   userId: string,
 ): Promise<boolean> {
   const bundle = readBundle();
-  if (!bundle || bundle.userId !== userId) {
+  if (!bundle) {
+    return false;
+  }
+  if (bundle.userId !== userId) {
+    clearMfaTrustBundle();
     return false;
   }
   if (bundle.trustedUntilMs <= Date.now()) {

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -315,6 +315,10 @@ export function practitionerSignOutEverywhere(): void {
  * a full Supabase sign-out and clears the trust bundle. For a **full** revoke while trust is active,
  * use {@link practitionerSignOutEverywhere} instead.
  *
+ * Navigation to `/login` runs only in the browser (`window` present). In non-browser environments
+ * (SSR, tests without `window`), storage and `signOut` still run when applicable, but there is no
+ * redirect.
+ *
  * @param supabase - Browser Supabase client.
  */
 export async function practitionerSignOut(
@@ -331,13 +335,17 @@ export async function practitionerSignOut(
 
   if (trustActiveForUser) {
     clearSupabaseBrowserAuthStorage();
-    window.location.assign('/login');
+    if (typeof window !== 'undefined') {
+      window.location.assign('/login');
+    }
     return;
   }
 
   clearMfaTrustBundle();
   await supabase.auth.signOut();
-  window.location.assign('/login');
+  if (typeof window !== 'undefined') {
+    window.location.assign('/login');
+  }
 }
 
 export function getTrustedUntilMsAfterVerification(): number {

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -1,3 +1,28 @@
+/**
+ * Practitioner MFA “trusted device” helpers — **browser `localStorage` only**.
+ *
+ * **XSS / token exposure (high impact on patient-data surfaces):** When the user opts in after
+ * successful TOTP verification, we persist a JSON bundle that includes Supabase **`refresh_token`**
+ * and **`access_token`**. Any successful XSS in this origin can read `localStorage`, exfiltrate those
+ * secrets, and mint sessions until tokens expire or are revoked—materially larger blast radius than
+ * the default Supabase session key alone.
+ *
+ * **Operational mitigations (required, not sufficient):** Ship a **strict Content-Security-Policy**
+ * (e.g. at the CDN / edge / host; include `connect-src` for your Supabase project and websocket
+ * endpoints), avoid inline script injection (`dangerouslySetInnerHTML`, unsanitized HTML), keep
+ * dependencies patched, and treat XSS prevention as part of the security boundary for this
+ * feature.
+ *
+ * **Preferred direction:** Replace this pattern with **server-managed** device trust (e.g.
+ * HttpOnly, `Secure`, `SameSite` cookie holding an opaque device id + server-side validation, or a
+ * short-lived scoped token exchanged only on the server). Documented at repo level in
+ * `docs/SECURITY_BASELINE.md`.
+ *
+ * RLS and MFA fail-closed rules remain authoritative for PHI; this module is UX-only.
+ *
+ * @module practitioner-device-trust
+ */
+
 import type { Session } from '@abstrack/supabase';
 import type { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
 
@@ -6,6 +31,10 @@ type PractitionerBrowserClient = ReturnType<typeof getSupabaseBrowserClient>;
 const MFA_TRUST_KEY = 'abstrack.practitioner.mfaTrustBundle.v1';
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
+/**
+ * Serialized trust bundle. **Contains long-lived session secrets** readable by any script on the
+ * origin—see module warning.
+ */
 export type PractitionerMfaTrustBundle = {
   userId: string;
   refresh_token: string;
@@ -18,20 +47,25 @@ export type PractitionerMfaTrustBundle = {
 /**
  * Removes persisted Supabase browser session keys without calling Auth sign-out (no server-side
  * refresh revocation). Used for “trusted device” sign-out so the next sign-in can restore AAL2.
+ * Swallows `localStorage` errors (blocked storage, privacy mode, quota) so sign-out still proceeds.
  */
 export function clearSupabaseBrowserAuthStorage(): void {
   if (typeof window === 'undefined') {
     return;
   }
-  const toRemove: string[] = [];
-  for (let i = 0; i < localStorage.length; i++) {
-    const key = localStorage.key(i);
-    if (key && key.startsWith('sb-') && key.endsWith('-auth-token')) {
-      toRemove.push(key);
+  try {
+    const toRemove: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith('sb-') && key.endsWith('-auth-token')) {
+        toRemove.push(key);
+      }
     }
-  }
-  for (const key of toRemove) {
-    localStorage.removeItem(key);
+    for (const key of toRemove) {
+      localStorage.removeItem(key);
+    }
+  } catch {
+    // `localStorage` can throw when blocked or in some privacy modes (see `theme-storage.ts`).
   }
 }
 
@@ -39,7 +73,12 @@ function readBundle(): PractitionerMfaTrustBundle | null {
   if (typeof window === 'undefined') {
     return null;
   }
-  const raw = window.localStorage.getItem(MFA_TRUST_KEY);
+  let raw: string | null;
+  try {
+    raw = window.localStorage.getItem(MFA_TRUST_KEY);
+  } catch {
+    return null;
+  }
   if (!raw) {
     return null;
   }
@@ -60,8 +99,26 @@ function readBundle(): PractitionerMfaTrustBundle | null {
 }
 
 /**
+ * @param userId - Authenticated user id from the current session, if any.
+ * @returns Whether a non-expired MFA device-trust bundle exists for this user (soft sign-out path).
+ */
+export function isPractitionerMfaDeviceTrustActive(
+  userId: string | undefined,
+): boolean {
+  if (userId == null || userId === '') {
+    return false;
+  }
+  const bundle = readBundle();
+  return (
+    bundle !== null &&
+    bundle.userId === userId &&
+    bundle.trustedUntilMs > Date.now()
+  );
+}
+
+/**
  * Persists refresh/access tokens for a verified MFA session so this browser can restore AAL2
- * within the trust window. Sensitive: only call when the user opted in.
+ * within the trust window. **Only call after explicit user opt-in**; see module XSS warning.
  *
  * @param session - Active Supabase session after successful `mfa.verify`.
  * @param trustedUntilMs - Absolute expiry for the trust window.
@@ -88,19 +145,28 @@ export function saveMfaTrustBundle(
     expires_at: session.expires_at,
     trustedUntilMs,
   };
-  window.localStorage.setItem(MFA_TRUST_KEY, JSON.stringify(bundle));
+  try {
+    window.localStorage.setItem(MFA_TRUST_KEY, JSON.stringify(bundle));
+  } catch {
+    // Blocked or full storage; trust bundle is optional UX — session is already valid in memory.
+  }
 }
 
 export function clearMfaTrustBundle(): void {
   if (typeof window === 'undefined') {
     return;
   }
-  window.localStorage.removeItem(MFA_TRUST_KEY);
+  try {
+    window.localStorage.removeItem(MFA_TRUST_KEY);
+  } catch {
+    // Same environments as `readBundle` / theme storage.
+  }
 }
 
 /**
  * After email/password sign-in, attempts to restore a prior AAL2 session from the trust bundle.
- * On failure (revoked or expired), clears the bundle.
+ * On failure (revoked or expired tokens, assurance error, or session not at **aal2**), clears the
+ * bundle so later logins do not repeat a useless restore.
  *
  * @param supabase - Browser Supabase client.
  * @param userId - Authenticated user id from the new password session.
@@ -130,9 +196,11 @@ export async function tryRestoreTrustedMfaSession(
 
   const assurance = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
   if (assurance.error) {
+    clearMfaTrustBundle();
     return false;
   }
   if (assurance.data.currentLevel !== 'aal2') {
+    clearMfaTrustBundle();
     return false;
   }
 
@@ -146,9 +214,35 @@ export async function tryRestoreTrustedMfaSession(
 }
 
 /**
+ * Full sign-out: clears the MFA trust bundle and browser `sb-*` auth storage, then POSTs to
+ * `/api/auth/logout` so the server revokes refresh tokens and clears auth cookies. Prefer this on
+ * shared machines, after credential compromise, or whenever all sessions must end. Navigation happens
+ * via the redirect response (this function does not return in normal browsers).
+ */
+export function practitionerSignOutEverywhere(): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  clearMfaTrustBundle();
+  try {
+    clearSupabaseBrowserAuthStorage();
+  } catch {
+    // ignore
+  }
+  const form = document.createElement('form');
+  form.method = 'POST';
+  form.action = '/api/auth/logout';
+  form.setAttribute('aria-hidden', 'true');
+  form.style.display = 'none';
+  document.body.appendChild(form);
+  form.submit();
+}
+
+/**
  * Signs the user out. If MFA device trust is still valid, clears only local Supabase storage so the
  * refresh token is not revoked server-side (allows AAL2 restore on next visit). Otherwise performs
- * a full Supabase sign-out and clears the trust bundle.
+ * a full Supabase sign-out and clears the trust bundle. For a **full** revoke while trust is active,
+ * use {@link practitionerSignOutEverywhere} instead.
  *
  * @param supabase - Browser Supabase client.
  */

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -234,11 +234,12 @@ export function clearMfaTrustBundle(): void {
  *
  * @param supabase - Browser Supabase client.
  * @param preSessionTokens - Refresh/access pair from before `setSession(bundle)`, if any.
+ * @returns Whether the password session was re-applied (`reverted`) or the client was signed out.
  */
 async function revertToPreRestoreSession(
   supabase: PractitionerBrowserClient,
   preSessionTokens: { refresh_token: string; access_token: string } | null,
-): Promise<void> {
+): Promise<'reverted' | 'signed_out'> {
   if (
     preSessionTokens &&
     preSessionTokens.refresh_token !== '' &&
@@ -249,11 +250,46 @@ async function revertToPreRestoreSession(
       access_token: preSessionTokens.access_token,
     });
     if (!error) {
-      return;
+      return 'reverted';
     }
   }
   await supabase.auth.signOut();
+  return 'signed_out';
 }
+
+/**
+ * Clears the trust bundle after a failed apply step, reverts to the password session when possible,
+ * and maps {@link revertToPreRestoreSession}’s outcome to the public union.
+ */
+async function finishFailedBundleRestore(
+  supabase: PractitionerBrowserClient,
+  preSessionTokens: { refresh_token: string; access_token: string } | null,
+): Promise<{ status: 'not_restored' } | { status: 'signed_out' }> {
+  clearMfaTrustBundle();
+  const revertOutcome = await revertToPreRestoreSession(
+    supabase,
+    preSessionTokens,
+  );
+  return revertOutcome === 'reverted'
+    ? { status: 'not_restored' }
+    : { status: 'signed_out' };
+}
+
+/**
+ * Outcome of {@link tryRestoreTrustedMfaSession}.
+ *
+ * - **`restored`**: AAL2 session was re-established from the trust bundle; caller may skip TOTP.
+ * - **`not_restored`**: No AAL2 restore (no/expired/invalid bundle, or restore failed but the
+ *   password session was re-applied). The user typically remains signed in at AAL1; caller should
+ *   continue MFA flow.
+ * - **`signed_out`**: Auth state was cleared during failure handling (e.g. unsafe mismatch,
+ *   `getSession` error before tokens were captured, or reversion to the password session failed).
+ *   Caller must not assume a session.
+ */
+export type TryRestoreTrustedMfaSessionResult =
+  | { status: 'restored' }
+  | { status: 'not_restored' }
+  | { status: 'signed_out' };
 
 /**
  * After email/password sign-in, attempts to restore a prior AAL2 session from the trust bundle.
@@ -268,30 +304,30 @@ async function revertToPreRestoreSession(
  *
  * @param supabase - Browser Supabase client.
  * @param userId - Authenticated user id from the new password session.
- * @returns Whether navigation to patient routes should skip the TOTP step.
+ * @returns Discriminated result — see {@link TryRestoreTrustedMfaSessionResult}.
  */
 export async function tryRestoreTrustedMfaSession(
   supabase: PractitionerBrowserClient,
   userId: string,
-): Promise<boolean> {
+): Promise<TryRestoreTrustedMfaSessionResult> {
   const bundle = readBundle();
   if (!bundle) {
-    return false;
+    return { status: 'not_restored' };
   }
   if (bundle.userId !== userId) {
     clearMfaTrustBundle();
-    return false;
+    return { status: 'not_restored' };
   }
   if (bundle.trustedUntilMs <= Date.now()) {
     clearMfaTrustBundle();
-    return false;
+    return { status: 'not_restored' };
   }
 
   const preSessionResult = await supabase.auth.getSession();
   if (preSessionResult.error) {
     clearMfaTrustBundle();
     await revertToPreRestoreSession(supabase, null);
-    return false;
+    return { status: 'signed_out' };
   }
 
   const preRestoreSession = preSessionResult.data.session;
@@ -299,7 +335,7 @@ export async function tryRestoreTrustedMfaSession(
   if (preRestoreSession?.user?.id !== userId) {
     clearMfaTrustBundle();
     await supabase.auth.signOut();
-    return false;
+    return { status: 'signed_out' };
   }
 
   const preSessionTokens =
@@ -318,54 +354,40 @@ export async function tryRestoreTrustedMfaSession(
     access_token: bundle.access_token,
   });
   if (error) {
-    clearMfaTrustBundle();
-    await revertToPreRestoreSession(supabase, preSessionTokens);
-    return false;
+    return finishFailedBundleRestore(supabase, preSessionTokens);
   }
 
   const afterSetResult = await supabase.auth.getSession();
   if (afterSetResult.error) {
-    clearMfaTrustBundle();
-    await revertToPreRestoreSession(supabase, preSessionTokens);
-    return false;
+    return finishFailedBundleRestore(supabase, preSessionTokens);
   }
 
   const sessionAfterSet = afterSetResult.data.session;
   if (sessionAfterSet?.user?.id == null || sessionAfterSet.user.id !== userId) {
-    clearMfaTrustBundle();
-    await revertToPreRestoreSession(supabase, preSessionTokens);
-    return false;
+    return finishFailedBundleRestore(supabase, preSessionTokens);
   }
 
   const assurance = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
   if (assurance.error) {
-    clearMfaTrustBundle();
-    await revertToPreRestoreSession(supabase, preSessionTokens);
-    return false;
+    return finishFailedBundleRestore(supabase, preSessionTokens);
   }
   if (assurance.data.currentLevel !== 'aal2') {
-    clearMfaTrustBundle();
-    await revertToPreRestoreSession(supabase, preSessionTokens);
-    return false;
+    return finishFailedBundleRestore(supabase, preSessionTokens);
   }
 
   const finalSessionResult = await supabase.auth.getSession();
   if (finalSessionResult.error) {
-    clearMfaTrustBundle();
-    await revertToPreRestoreSession(supabase, preSessionTokens);
-    return false;
+    return finishFailedBundleRestore(supabase, preSessionTokens);
   }
 
   const session = finalSessionResult.data.session;
   if (session == null) {
-    clearMfaTrustBundle();
-    await revertToPreRestoreSession(supabase, preSessionTokens);
-    return false;
+    return finishFailedBundleRestore(supabase, preSessionTokens);
   }
 
   saveMfaTrustBundle(session, bundle.trustedUntilMs);
 
-  return true;
+  return { status: 'restored' };
 }
 
 /**

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -165,8 +165,8 @@ export function clearMfaTrustBundle(): void {
 
 /**
  * After email/password sign-in, attempts to restore a prior AAL2 session from the trust bundle.
- * On failure (revoked or expired tokens, assurance error, or session not at **aal2**), clears the
- * bundle so later logins do not repeat a useless restore.
+ * On failure (revoked or expired tokens, **session user mismatch** after restore, assurance error,
+ * or session not at **aal2**), clears the bundle so later logins do not repeat a useless restore.
  *
  * @param supabase - Browser Supabase client.
  * @param userId - Authenticated user id from the new password session.
@@ -190,6 +190,14 @@ export async function tryRestoreTrustedMfaSession(
     access_token: bundle.access_token,
   });
   if (error) {
+    clearMfaTrustBundle();
+    return false;
+  }
+
+  const {
+    data: { session: sessionAfterSet },
+  } = await supabase.auth.getSession();
+  if (sessionAfterSet?.user?.id == null || sessionAfterSet.user.id !== userId) {
     clearMfaTrustBundle();
     return false;
   }

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -164,9 +164,38 @@ export function clearMfaTrustBundle(): void {
 }
 
 /**
+ * After a failed trust-bundle restore, re-applies the password session’s tokens so the client is
+ * not left on a mismatched or half-applied session. If reversion fails or no tokens were
+ * captured, signs out.
+ *
+ * @param supabase - Browser Supabase client.
+ * @param preSessionTokens - Refresh/access pair from before `setSession(bundle)`, if any.
+ */
+async function revertToPreRestoreSession(
+  supabase: PractitionerBrowserClient,
+  preSessionTokens: { refresh_token: string; access_token: string } | null,
+): Promise<void> {
+  if (
+    preSessionTokens &&
+    preSessionTokens.refresh_token !== '' &&
+    preSessionTokens.access_token !== ''
+  ) {
+    const { error } = await supabase.auth.setSession({
+      refresh_token: preSessionTokens.refresh_token,
+      access_token: preSessionTokens.access_token,
+    });
+    if (!error) {
+      return;
+    }
+  }
+  await supabase.auth.signOut();
+}
+
+/**
  * After email/password sign-in, attempts to restore a prior AAL2 session from the trust bundle.
  * On failure (revoked or expired tokens, **session user mismatch** after restore, assurance error,
- * or session not at **aal2**), clears the bundle so later logins do not repeat a useless restore.
+ * or session not at **aal2**), clears the bundle and restores the pre-restore password session (or
+ * signs out) so the client is not left authenticated as the wrong user.
  *
  * @param supabase - Browser Supabase client.
  * @param userId - Authenticated user id from the new password session.
@@ -185,12 +214,33 @@ export async function tryRestoreTrustedMfaSession(
     return false;
   }
 
+  const {
+    data: { session: preRestoreSession },
+  } = await supabase.auth.getSession();
+
+  if (preRestoreSession?.user?.id !== userId) {
+    clearMfaTrustBundle();
+    return false;
+  }
+
+  const preSessionTokens =
+    preRestoreSession.refresh_token &&
+    preRestoreSession.refresh_token !== '' &&
+    preRestoreSession.access_token &&
+    preRestoreSession.access_token !== ''
+      ? {
+          refresh_token: preRestoreSession.refresh_token,
+          access_token: preRestoreSession.access_token,
+        }
+      : null;
+
   const { error } = await supabase.auth.setSession({
     refresh_token: bundle.refresh_token,
     access_token: bundle.access_token,
   });
   if (error) {
     clearMfaTrustBundle();
+    await revertToPreRestoreSession(supabase, preSessionTokens);
     return false;
   }
 
@@ -199,16 +249,19 @@ export async function tryRestoreTrustedMfaSession(
   } = await supabase.auth.getSession();
   if (sessionAfterSet?.user?.id == null || sessionAfterSet.user.id !== userId) {
     clearMfaTrustBundle();
+    await revertToPreRestoreSession(supabase, preSessionTokens);
     return false;
   }
 
   const assurance = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
   if (assurance.error) {
     clearMfaTrustBundle();
+    await revertToPreRestoreSession(supabase, preSessionTokens);
     return false;
   }
   if (assurance.data.currentLevel !== 'aal2') {
     clearMfaTrustBundle();
+    await revertToPreRestoreSession(supabase, preSessionTokens);
     return false;
   }
 

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -20,9 +20,10 @@
  *
  * RLS and MFA fail-closed rules remain authoritative for PHI; this module is UX-only.
  *
- * **Deploy gate:** Token persistence and restore are **off by default**. Set
- * `NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST` to `true` or `1` only after an explicit security
- * decision. When disabled, this module does not write tokens; reads scrub any existing bundle key.
+ * **Deploy gate:** Token persistence and restore are **on by default** for expected practitioner login
+ * UX. Set `NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST` to `false` or `0` to disable the feature (no
+ * writes; reads scrub any existing bundle key)—e.g. if you want zero localStorage session material
+ * until server-managed trust ships.
  *
  * @module practitioner-device-trust
  */
@@ -42,29 +43,37 @@ const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
 /**
  * Whether practitioner MFA “trusted device” (localStorage token bundle) is allowed for this build.
- * Defaults to **false** when unset so high-impact XSS surface is not enabled accidentally.
+ * Defaults to **true** when unset or empty. Set to **`false` or `0`** (case-insensitive) to disable.
  *
- * @returns True only when `NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST` is the string `true` or `1`
- *   (case-insensitive, trimmed).
+ * @returns False when the env var is explicitly `false` or `0`; otherwise true (including unset).
  *
- * Uses **dot** `process.env.NEXT_PUBLIC_…` access only — Next.js inlines public env at build time for
- * static references; bracket or dynamic lookups are not replaced (see Next.js env docs).
+ * **Use bracket access** for this key: `process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST']`.
+ * An earlier change to dotted `process.env.NEXT_PUBLIC_…` relied on compile-time inlining; when
+ * the flag was missing from the inlining pass (wrong app `.env` path, cache, or first build), the
+ * flag read as always-off and the trust read path scrubbed `localStorage` on every read — breaking
+ * device trust. Bracket reads resolve like other runtime `NEXT_PUBLIC_*` usage in Next dev.
  */
 export function isPractitionerMfaDeviceTrustEnabled(): boolean {
   let raw: string | undefined;
   try {
     raw =
       typeof process !== 'undefined' && process.env != null
-        ? process.env.NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST
+        ? process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST']
         : undefined;
   } catch {
     return false;
   }
   if (raw == null || String(raw).trim() === '') {
-    return false;
+    return true;
   }
   const v = String(raw).trim().toLowerCase();
-  return v === 'true' || v === '1';
+  if (v === 'false' || v === '0') {
+    return false;
+  }
+  if (v === 'true' || v === '1') {
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -73,6 +82,12 @@ export function isPractitionerMfaDeviceTrustEnabled(): boolean {
  */
 export type PractitionerMfaTrustBundle = {
   userId: string;
+  /**
+   * Sign-in email for this account, stored so the login page can refresh from the bundle **before**
+   * `signInWithPassword` — a new password grant typically revokes the previous refresh token, so
+   * post-password restore would fail without this ordering.
+   */
+  email?: string;
   refresh_token: string;
   access_token: string;
   expires_at?: number;
@@ -114,6 +129,9 @@ function isValidStoredTrustBundle(
     if (typeof exp !== 'number' || !Number.isFinite(exp)) {
       return false;
     }
+  }
+  if (o['email'] !== undefined && !isNonEmptyTrimmedString(o['email'])) {
+    return false;
   }
   return true;
 }
@@ -187,10 +205,76 @@ function readBundle(): PractitionerMfaTrustBundle | null {
 }
 
 /**
- * @param userId - Authenticated user id from the current session, if any.
- * @returns Whether a non-expired MFA device-trust bundle exists for this user (soft sign-out path).
+ * Reads the MFA trust bundle for callers that need metadata (e.g. `trustedUntilMs`) without
+ * duplicating storage logic.
+ *
+ * @returns Parsed bundle or `null`.
+ */
+export function readMfaTrustBundle(): PractitionerMfaTrustBundle | null {
+  return readBundle();
+}
+
+/**
+ * Run **before** `signInWithEmailPassword` on the practitioner login form when a stored bundle
+ * exists for this sign-in email. A new password grant usually **invalidates** the prior refresh
+ * token on the server, so `tryRestoreTrustedMfaSession` **after** password cannot exchange the
+ * bundle token. Refreshing from the bundle first establishes AAL2; the caller then verifies the
+ * password as usual.
+ *
+ * Legacy bundles without `email` skip this path and rely on post-password restore (may fail until
+ * the user completes MFA once with a fresh save).
+ *
+ * @param supabase - Browser Supabase client.
+ * @param emailForSignIn - Email from the login form (trimmed comparison).
+ * @returns `true` if an AAL2 session was established from the bundle and persisted with
+ *   `saveMfaTrustBundle`; `false` to continue with password-first sign-in only.
+ */
+export async function refreshTrustedMfaBundleBeforePasswordSignIn(
+  supabase: PractitionerBrowserClient,
+  emailForSignIn: string,
+): Promise<boolean> {
+  if (!isPractitionerMfaDeviceTrustEnabled()) {
+    return false;
+  }
+  const bundle = readBundle();
+  if (!bundle || bundle.trustedUntilMs <= Date.now()) {
+    return false;
+  }
+  const want = emailForSignIn.trim().toLowerCase();
+  const got = bundle.email?.trim().toLowerCase();
+  if (!got || got !== want) {
+    return false;
+  }
+
+  const { data: refreshData, error: refreshError } =
+    await supabase.auth.refreshSession({
+      refresh_token: bundle.refresh_token,
+    });
+  if (refreshError || refreshData?.session == null) {
+    return false;
+  }
+  if (refreshData.session.user?.id !== bundle.userId) {
+    await supabase.auth.signOut();
+    return false;
+  }
+
+  const assurance = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+  if (assurance.error || assurance.data.currentLevel !== 'aal2') {
+    await supabase.auth.signOut();
+    return false;
+  }
+
+  saveMfaTrustBundle(refreshData.session, bundle.trustedUntilMs);
+  return true;
+}
+
+/**
+ * Whether a non-expired MFA device-trust bundle exists for this user (soft sign-out path).
  * Clears stored tokens when the bundle is **expired** or for a **different** user so session
  * material is not left in `localStorage` after trust has lapsed or the account changed.
+ *
+ * @param userId - Authenticated user id from the current session, if any.
+ * @returns Whether a non-expired MFA device-trust bundle exists for this user.
  */
 export function isPractitionerMfaDeviceTrustActive(
   userId: string | undefined,
@@ -217,6 +301,11 @@ export function isPractitionerMfaDeviceTrustActive(
  * Persists refresh/access tokens for a verified MFA session so this browser can restore AAL2
  * within the trust window. **Only call after explicit user opt-in**; see module XSS warning.
  *
+ * **`user.email` may be missing** on some Supabase session payloads (for example after
+ * `refreshSession` / token rotation). In that case, for the **same** `userId`, we **keep** the
+ * email already stored in the bundle so {@link refreshTrustedMfaBundleBeforePasswordSignIn} can
+ * still match the next sign-in (see Supabase refresh-token rotation docs).
+ *
  * @param session - Active Supabase session after successful `mfa.verify`.
  * @param trustedUntilMs - Absolute expiry for the trust window (must be finite).
  */
@@ -241,8 +330,24 @@ export function saveMfaTrustBundle(
   ) {
     return;
   }
+  const emailRaw = session.user.email;
+  const emailFromSession =
+    typeof emailRaw === 'string' && emailRaw.trim() !== ''
+      ? emailRaw.trim()
+      : undefined;
+
+  const previous = readMfaTrustBundle();
+  const email =
+    emailFromSession ??
+    (previous?.userId === session.user.id &&
+    typeof previous.email === 'string' &&
+    previous.email.trim() !== ''
+      ? previous.email.trim()
+      : undefined);
+
   const bundle: PractitionerMfaTrustBundle = {
     userId: session.user.id,
+    ...(email != null ? { email } : {}),
     refresh_token: session.refresh_token,
     access_token: session.access_token,
     expires_at: session.expires_at,
@@ -256,6 +361,54 @@ export function saveMfaTrustBundle(
   } catch {
     // Blocked or full storage; trust bundle is optional UX — session is already valid in memory.
   }
+}
+
+/**
+ * Call from `onAuthStateChange` when `event === 'TOKEN_REFRESHED'`. Supabase **rotates refresh tokens**; the bundle written at MFA
+ * verify time would otherwise go stale, so the next sign-in’s {@link tryRestoreTrustedMfaSession}
+ * would fail and clear storage. Only updates the bundle when a trust row still exists for this user,
+ * the window has not expired, and **MFA assurance is AAL2** — so password-only (AAL1) sessions never
+ * overwrite a prior AAL2 bundle.
+ *
+ * @param supabase - Browser Supabase client.
+ * @param session - Session from the auth callback (null clears nothing).
+ */
+export async function syncMfaTrustBundleAfterTokenRefresh(
+  supabase: PractitionerBrowserClient,
+  session: Session | null,
+): Promise<void> {
+  if (typeof window === 'undefined' || session?.user?.id == null) {
+    return;
+  }
+  if (!isPractitionerMfaDeviceTrustEnabled()) {
+    return;
+  }
+
+  const bundle = readBundle();
+  if (!bundle) {
+    return;
+  }
+  if (bundle.userId !== session.user.id) {
+    return;
+  }
+  if (bundle.trustedUntilMs <= Date.now()) {
+    return;
+  }
+  if (
+    session.refresh_token == null ||
+    session.refresh_token === '' ||
+    session.access_token == null ||
+    session.access_token === ''
+  ) {
+    return;
+  }
+
+  const assurance = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+  if (assurance.error || assurance.data.currentLevel !== 'aal2') {
+    return;
+  }
+
+  saveMfaTrustBundle(session, bundle.trustedUntilMs);
 }
 
 export function clearMfaTrustBundle(): void {
@@ -337,6 +490,8 @@ export type TryRestoreTrustedMfaSessionResult =
  * After email/password sign-in, attempts to restore a prior AAL2 session from the trust bundle.
  * If the stored bundle’s `userId` does not match the current password session’s user, clears the
  * bundle and returns (avoids keeping another user’s tokens after account switch).
+ * Restore uses `auth.refreshSession({ refresh_token })` with the stored refresh token, not
+ * `setSession({ access_token, refresh_token })` alone (see implementation comment).
  * On failure (revoked or expired tokens, **session user mismatch** after restore, assurance error,
  * **getSession error**, **missing session** after a successful `getSession()` call, or session not at
  * **aal2**), clears the bundle and restores the pre-restore
@@ -391,21 +546,26 @@ export async function tryRestoreTrustedMfaSession(
         }
       : null;
 
-  const { error } = await supabase.auth.setSession({
-    refresh_token: bundle.refresh_token,
-    access_token: bundle.access_token,
-  });
-  if (error) {
+  /**
+   * Always exchange the stored **refresh** token via the refresh endpoint — do not use
+   * `setSession({ access_token, refresh_token })` alone: if the access JWT is still within expiry,
+   * GoTrue **skips** `_callRefreshToken` and persists the **same** refresh token from the bundle.
+   * After normal use, Supabase may have rotated that refresh token, so the stored pair is stale and
+   * restore fails (and the bundle was cleared). `refreshSession({ refresh_token })` always refreshes.
+   */
+  const { data: refreshData, error: refreshError } =
+    await supabase.auth.refreshSession({
+      refresh_token: bundle.refresh_token,
+    });
+  if (refreshError || refreshData?.session == null) {
     return finishFailedBundleRestore(supabase, preSessionTokens);
   }
 
-  const afterSetResult = await supabase.auth.getSession();
-  if (afterSetResult.error) {
-    return finishFailedBundleRestore(supabase, preSessionTokens);
-  }
-
-  const sessionAfterSet = afterSetResult.data.session;
-  if (sessionAfterSet?.user?.id == null || sessionAfterSet.user.id !== userId) {
+  const sessionAfterRefresh = refreshData.session;
+  if (
+    sessionAfterRefresh.user?.id == null ||
+    sessionAfterRefresh.user.id !== userId
+  ) {
     return finishFailedBundleRestore(supabase, preSessionTokens);
   }
 
@@ -458,18 +618,49 @@ export function practitionerSignOutEverywhere(): void {
 }
 
 /**
- * Signs the user out. If MFA device trust is still valid, ends the browser session with
- * **`auth.signOut({ scope: 'local' })`** so cookie-backed `@supabase/ssr` state is cleared without
- * revoking the refresh token server-side (allows AAL2 restore from the trust bundle on next visit).
- * Otherwise performs a full Supabase sign-out and clears the trust bundle. For a **full** revoke
- * while trust is active, use {@link practitionerSignOutEverywhere} instead.
+ * Clears the browser auth session **without** calling GoTrue’s `POST /logout` endpoint.
  *
- * If `auth.signOut` returns an error, falls back to {@link practitionerSignOutEverywhere} in the
- * browser (server logout + form POST) so cookies are not left in an ambiguous state; in
- * non-browser contexts only `console.error` is used (no redirect).
+ * **`signOut({ scope: 'local' })` still revokes the current session’s refresh token on the server**
+ * (`GoTrueClient._signOut` → `admin.signOut(jwt, scope)`). The MFA trust bundle stores a copy of
+ * that refresh token; if it is revoked, `refreshSession` / restore fails on the next sign-in — the
+ * “same issue” loop users saw after “soft” logout.
  *
- * Navigation to `/login` via `location.assign` runs only after a successful client sign-out when
- * `window` is present.
+ * This mirrors the storage half of `GoTrueClient`’s private `_removeSession` (cookie chunks via
+ * `@supabase/ssr`), then navigation reloads the app with an empty session while the bundle’s token
+ * remains valid until natural expiry or {@link practitionerSignOutEverywhere}.
+ *
+ * @param supabase - Browser Supabase client (`createBrowserClient`).
+ */
+async function clearBrowserSessionWithoutServerLogout(
+  supabase: PractitionerBrowserClient,
+): Promise<void> {
+  const auth = supabase.auth as unknown as {
+    storage?: { removeItem: (key: string) => Promise<void> };
+    storageKey: string;
+    userStorage?: { removeItem: (key: string) => Promise<void> };
+  };
+  const { storage, storageKey, userStorage } = auth;
+  if (!storage?.removeItem || !storageKey) {
+    throw new Error('Supabase auth storage API unavailable for soft sign-out');
+  }
+  await storage.removeItem(storageKey);
+  await storage.removeItem(`${storageKey}-code-verifier`);
+  await storage.removeItem(`${storageKey}-user`);
+  if (userStorage?.removeItem) {
+    await userStorage.removeItem(`${storageKey}-user`);
+  }
+}
+
+/**
+ * Signs the user out. If MFA device trust is still valid, clears only **browser** session storage
+ * (no `POST /logout`) so the refresh token kept in the trust bundle stays valid for the next
+ * visit; then navigates to `/login`. Otherwise performs a full Supabase `signOut()` and clears the
+ * bundle. For a **full** server revoke while trust is active, use {@link practitionerSignOutEverywhere}.
+ *
+ * If the soft session clear fails, falls back to {@link practitionerSignOutEverywhere} in the browser.
+ *
+ * Navigation to `/login` via `location.assign` runs after soft clear or full sign-out when `window`
+ * is present.
  *
  * @param supabase - Browser Supabase client.
  */
@@ -486,16 +677,18 @@ export async function practitionerSignOut(
     bundle.trustedUntilMs > Date.now();
 
   if (trustActiveForUser) {
-    const { error: localSignOutError } = await supabase.auth.signOut({
-      scope: 'local',
-    });
-    if (localSignOutError) {
+    try {
+      await clearBrowserSessionWithoutServerLogout(supabase);
+    } catch (err) {
+      console.error(
+        'practitionerSignOut: soft session clear failed; falling back to full logout',
+        err,
+      );
       if (typeof document !== 'undefined') {
         practitionerSignOutEverywhere();
       } else {
         console.error(
-          'practitionerSignOut: local sign-out failed; cannot fall back to server logout without a document.',
-          localSignOutError,
+          'practitionerSignOut: cannot fall back to server logout without a document.',
         );
       }
       return;

--- a/apps/practitioner/src/lib/practitioner-patient-data-access.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-patient-data-access.spec.ts
@@ -1,0 +1,32 @@
+import type { PractitionerAppGate } from '@abstrack/supabase';
+import { getPatientDataMfaBlockReason } from './practitioner-patient-data-access';
+
+describe('getPatientDataMfaBlockReason', () => {
+  const practitioner = (
+    hasMfaAssuranceAal2: boolean,
+  ): Extract<PractitionerAppGate, { kind: 'practitioner' }> => ({
+    kind: 'practitioner',
+    appRole: 'practitioner',
+    hasMfaAssuranceAal2,
+  });
+
+  it('blocks when no verified TOTP even if AAL2 is true', () => {
+    expect(getPatientDataMfaBlockReason(practitioner(true), 0)).toBe(
+      'enrollment',
+    );
+  });
+
+  it('blocks enrollment before AAL2 when counts are inconsistent', () => {
+    expect(getPatientDataMfaBlockReason(practitioner(false), 0)).toBe(
+      'enrollment',
+    );
+  });
+
+  it('blocks AAL2 when enrolled but session is not AAL2', () => {
+    expect(getPatientDataMfaBlockReason(practitioner(false), 1)).toBe('aal2');
+  });
+
+  it('allows when enrolled and AAL2', () => {
+    expect(getPatientDataMfaBlockReason(practitioner(true), 1)).toBe('none');
+  });
+});

--- a/apps/practitioner/src/lib/practitioner-patient-data-access.ts
+++ b/apps/practitioner/src/lib/practitioner-patient-data-access.ts
@@ -1,0 +1,21 @@
+import type { PractitionerAppGate } from '@abstrack/supabase';
+
+/**
+ * Explains why patient-data routes must stay closed for a practitioner session.
+ *
+ * @param gate - Resolved gate when `kind === 'practitioner'`.
+ * @param verifiedTotpCount - Verified TOTP factors from `auth.mfa.listFactors()`.
+ * @returns `none` when both enrollment and AAL2 are satisfied; otherwise the first blocking reason.
+ */
+export function getPatientDataMfaBlockReason(
+  gate: Extract<PractitionerAppGate, { kind: 'practitioner' }>,
+  verifiedTotpCount: number,
+): 'none' | 'enrollment' | 'aal2' {
+  if (verifiedTotpCount < 1) {
+    return 'enrollment';
+  }
+  if (!gate.hasMfaAssuranceAal2) {
+    return 'aal2';
+  }
+  return 'none';
+}

--- a/apps/practitioner/src/lib/same-origin-logout-post.spec.ts
+++ b/apps/practitioner/src/lib/same-origin-logout-post.spec.ts
@@ -1,0 +1,69 @@
+import { getSameOriginLogoutPostFailure } from './same-origin-logout-post';
+
+const BASE = 'https://practitioner.example.com/api/auth/logout';
+
+function req(headers: Record<string, string>) {
+  return {
+    url: BASE,
+    headers: new Headers(headers),
+  };
+}
+
+describe('getSameOriginLogoutPostFailure', () => {
+  it('returns null when Origin matches the request URL origin', () => {
+    expect(
+      getSameOriginLogoutPostFailure(
+        req({ Origin: 'https://practitioner.example.com' }),
+      ),
+    ).toBeNull();
+  });
+
+  it('returns 403 when Origin is a different host', () => {
+    expect(
+      getSameOriginLogoutPostFailure(req({ Origin: 'https://evil.example' })),
+    ).toEqual({ status: 403, error: 'Invalid Origin' });
+  });
+
+  it('returns 403 when Sec-Fetch-Site is cross-site', () => {
+    expect(
+      getSameOriginLogoutPostFailure(req({ 'Sec-Fetch-Site': 'cross-site' })),
+    ).toEqual({ status: 403, error: 'Cross-site request rejected' });
+  });
+
+  it('returns null when Referer matches origin and Origin is absent', () => {
+    expect(
+      getSameOriginLogoutPostFailure(
+        req({
+          Referer: 'https://practitioner.example.com/login',
+          'Sec-Fetch-Site': 'same-origin',
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('returns 403 when Referer origin does not match', () => {
+    expect(
+      getSameOriginLogoutPostFailure(
+        req({
+          Referer: 'https://evil.example/',
+          'Sec-Fetch-Site': 'same-origin',
+        }),
+      ),
+    ).toEqual({ status: 403, error: 'Invalid Referer' });
+  });
+
+  it('returns null when Origin is absent but Sec-Fetch-Site is same-origin', () => {
+    expect(
+      getSameOriginLogoutPostFailure(req({ 'Sec-Fetch-Site': 'same-origin' })),
+    ).toBeNull();
+  });
+
+  it('returns 403 when Origin and Referer are absent and Sec-Fetch-Site is not same-origin/same-site', () => {
+    expect(
+      getSameOriginLogoutPostFailure(req({ 'Sec-Fetch-Site': 'none' })),
+    ).toEqual({
+      status: 403,
+      error: 'Could not validate request origin',
+    });
+  });
+});

--- a/apps/practitioner/src/lib/same-origin-logout-post.spec.ts
+++ b/apps/practitioner/src/lib/same-origin-logout-post.spec.ts
@@ -58,9 +58,18 @@ describe('getSameOriginLogoutPostFailure', () => {
     ).toBeNull();
   });
 
-  it('returns 403 when Origin and Referer are absent and Sec-Fetch-Site is not same-origin/same-site', () => {
+  it('returns 403 when Origin and Referer are absent and Sec-Fetch-Site is none', () => {
     expect(
       getSameOriginLogoutPostFailure(req({ 'Sec-Fetch-Site': 'none' })),
+    ).toEqual({
+      status: 403,
+      error: 'Could not validate request origin',
+    });
+  });
+
+  it('returns 403 when Origin and Referer are absent and Sec-Fetch-Site is same-site (strict same-origin)', () => {
+    expect(
+      getSameOriginLogoutPostFailure(req({ 'Sec-Fetch-Site': 'same-site' })),
     ).toEqual({
       status: 403,
       error: 'Could not validate request origin',

--- a/apps/practitioner/src/lib/same-origin-logout-post.ts
+++ b/apps/practitioner/src/lib/same-origin-logout-post.ts
@@ -8,11 +8,13 @@ export type SameOriginLogoutPostFailure = {
 
 /**
  * Blocks cross-site `POST` requests to the practitioner logout endpoint so a malicious page cannot
- * forge a form that signs users out (CSRF). Same-origin and same-site navigations from this app
- * include headers browsers set for anti-CSRF (`Origin`, `Sec-Fetch-Site`, `Referer`).
+ * forge a form that signs users out (CSRF). Checks enforce **same-origin** (exact URL origin), not
+ * schemeful same-site: prefer a non-empty matching `Origin`, else a matching `Referer` origin; if both
+ * are absent, only `Sec-Fetch-Site: same-origin` is accepted (`same-site` is rejected so the guard
+ * matches its name and stays predictable when browsers omit `Origin` on some `POST`s).
  *
  * This is not a substitute for CSRF tokens when you must support trusted cross-origin clients;
- * practitioner logout is intended to be same-site only.
+ * practitioner logout is intended to be same-origin only.
  *
  * @param request - Minimal request shape (`url` + `headers`), e.g. Next.js `NextRequest`.
  * @returns `null` if the request may proceed, or a failure object the route should turn into a 4xx response.
@@ -47,7 +49,7 @@ export function getSameOriginLogoutPostFailure(
   }
 
   const secFetchSite = request.headers.get('Sec-Fetch-Site');
-  if (secFetchSite === 'same-origin' || secFetchSite === 'same-site') {
+  if (secFetchSite === 'same-origin') {
     return null;
   }
 

--- a/apps/practitioner/src/lib/same-origin-logout-post.ts
+++ b/apps/practitioner/src/lib/same-origin-logout-post.ts
@@ -1,0 +1,55 @@
+/**
+ * Failure payload when a logout `POST` fails same-origin / anti-CSRF checks.
+ */
+export type SameOriginLogoutPostFailure = {
+  status: 400 | 403;
+  error: string;
+};
+
+/**
+ * Blocks cross-site `POST` requests to the practitioner logout endpoint so a malicious page cannot
+ * forge a form that signs users out (CSRF). Same-origin and same-site navigations from this app
+ * include headers browsers set for anti-CSRF (`Origin`, `Sec-Fetch-Site`, `Referer`).
+ *
+ * This is not a substitute for CSRF tokens when you must support trusted cross-origin clients;
+ * practitioner logout is intended to be same-site only.
+ *
+ * @param request - Minimal request shape (`url` + `headers`), e.g. Next.js `NextRequest`.
+ * @returns `null` if the request may proceed, or a failure object the route should turn into a 4xx response.
+ */
+export function getSameOriginLogoutPostFailure(
+  request: Pick<Request, 'url' | 'headers'>,
+): SameOriginLogoutPostFailure | null {
+  const expectedOrigin = new URL(request.url).origin;
+
+  const origin = request.headers.get('Origin');
+  if (origin !== null && origin !== '') {
+    if (origin !== expectedOrigin) {
+      return { status: 403, error: 'Invalid Origin' };
+    }
+    return null;
+  }
+
+  if (request.headers.get('Sec-Fetch-Site') === 'cross-site') {
+    return { status: 403, error: 'Cross-site request rejected' };
+  }
+
+  const referer = request.headers.get('Referer');
+  if (referer) {
+    try {
+      if (new URL(referer).origin !== expectedOrigin) {
+        return { status: 403, error: 'Invalid Referer' };
+      }
+      return null;
+    } catch {
+      return { status: 400, error: 'Invalid Referer' };
+    }
+  }
+
+  const secFetchSite = request.headers.get('Sec-Fetch-Site');
+  if (secFetchSite === 'same-origin' || secFetchSite === 'same-site') {
+    return null;
+  }
+
+  return { status: 403, error: 'Could not validate request origin' };
+}

--- a/apps/practitioner/src/lib/use-practitioner-verified-totp.spec.tsx
+++ b/apps/practitioner/src/lib/use-practitioner-verified-totp.spec.tsx
@@ -1,0 +1,62 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
+import { usePractitionerVerifiedTotpCount } from './use-practitioner-verified-totp';
+
+jest.mock('@abstrack/supabase/browser', () => ({
+  getSupabaseBrowserClient: jest.fn(),
+}));
+
+const mockedGetClient = jest.mocked(getSupabaseBrowserClient);
+
+function listFactorsResult(verifiedCount: number) {
+  const totp = Array.from({ length: verifiedCount }, (_, i) => ({
+    id: `factor-${i}`,
+    status: 'verified' as const,
+  }));
+  return { error: null as const, data: { totp } };
+}
+
+describe('usePractitionerVerifiedTotpCount', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not apply refresh results after enabled becomes false while the request is in flight', async () => {
+    let finishRefresh!: (v: ReturnType<typeof listFactorsResult>) => void;
+    const refreshPromise = new Promise<ReturnType<typeof listFactorsResult>>(
+      (resolve) => {
+        finishRefresh = resolve;
+      },
+    );
+
+    const listFactors = jest
+      .fn()
+      .mockResolvedValueOnce(listFactorsResult(0))
+      .mockImplementationOnce(() => refreshPromise);
+
+    mockedGetClient.mockReturnValue({
+      auth: { mfa: { listFactors } },
+    } as never);
+
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        usePractitionerVerifiedTotpCount(enabled),
+      { initialProps: { enabled: true } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.verifiedTotpCount).toBe(0);
+
+    await act(async () => {
+      const p = result.current.refresh();
+      rerender({ enabled: false });
+      finishRefresh(listFactorsResult(3));
+      await p;
+    });
+
+    expect(result.current.verifiedTotpCount).toBe(0);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/apps/practitioner/src/lib/use-practitioner-verified-totp.ts
+++ b/apps/practitioner/src/lib/use-practitioner-verified-totp.ts
@@ -11,8 +11,13 @@ export type UsePractitionerVerifiedTotpCountResult = {
   refresh: () => Promise<void>;
 };
 
+type FactorsPhase = 'idle' | 'loading' | 'ready';
+
 /**
  * Loads verified TOTP factor count for practitioner MFA gating. No-ops when `enabled` is false.
+ *
+ * When `enabled` flips from false to true, loading is set synchronously (via state adjustment
+ * during render) so consumers do not briefly see a settled count of 0 before the first fetch.
  *
  * @param enabled - When false, clears counts and skips network calls (e.g. non-practitioner gates).
  * @returns Verified factor count, loading and error state, and a manual refresh.
@@ -21,10 +26,26 @@ export function usePractitionerVerifiedTotpCount(
   enabled: boolean,
 ): UsePractitionerVerifiedTotpCountResult {
   const [verifiedTotpCount, setVerifiedTotpCount] = useState(0);
-  const [loading, setLoading] = useState(enabled);
+  const [prevEnabled, setPrevEnabled] = useState(enabled);
+  const [phase, setPhase] = useState<FactorsPhase>(() =>
+    enabled ? 'loading' : 'idle',
+  );
   const [error, setError] = useState<Error | null>(null);
   const isMountedRef = useRef(true);
   const supabase = useMemo(() => getSupabaseBrowserClient(), []);
+
+  if (enabled !== prevEnabled) {
+    setPrevEnabled(enabled);
+    if (!enabled) {
+      setPhase('idle');
+      setVerifiedTotpCount(0);
+      setError(null);
+    } else {
+      setPhase('loading');
+      setVerifiedTotpCount(0);
+      setError(null);
+    }
+  }
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -41,55 +62,33 @@ export function usePractitionerVerifiedTotpCount(
     return result.data.totp.filter((f) => f.status === 'verified').length;
   }, [supabase]);
 
-  const refresh = useCallback(async () => {
+  const refresh = useCallback((): Promise<void> => {
     if (!enabled) {
-      return;
+      return Promise.resolve();
     }
     setError(null);
-    if (isMountedRef.current) {
-      setLoading(true);
-    }
-    try {
-      const n = await loadFactors();
-      if (isMountedRef.current) {
-        setVerifiedTotpCount(n);
-      }
-    } catch (e) {
-      if (isMountedRef.current) {
-        setError(e instanceof Error ? e : new Error(String(e)));
-      }
-    } finally {
-      if (isMountedRef.current) {
-        setLoading(false);
-      }
-    }
-  }, [enabled, loadFactors]);
+    setPhase('loading');
+    return Promise.resolve();
+  }, [enabled]);
 
   useEffect(() => {
-    if (!enabled) {
-      setVerifiedTotpCount(0);
-      setLoading(false);
-      setError(null);
+    if (!enabled || phase !== 'loading') {
       return;
     }
 
     let cancelled = false;
-    setLoading(true);
-    setError(null);
 
     void (async () => {
       try {
         const n = await loadFactors();
-        if (!cancelled) {
+        if (!cancelled && isMountedRef.current) {
           setVerifiedTotpCount(n);
+          setPhase('ready');
         }
       } catch (e) {
-        if (!cancelled) {
+        if (!cancelled && isMountedRef.current) {
           setError(e instanceof Error ? e : new Error(String(e)));
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
+          setPhase('ready');
         }
       }
     })();
@@ -97,7 +96,9 @@ export function usePractitionerVerifiedTotpCount(
     return () => {
       cancelled = true;
     };
-  }, [enabled, loadFactors]);
+  }, [enabled, phase, loadFactors]);
+
+  const loading = enabled && phase === 'loading';
 
   return { verifiedTotpCount, loading, error, refresh };
 }

--- a/apps/practitioner/src/lib/use-practitioner-verified-totp.ts
+++ b/apps/practitioner/src/lib/use-practitioner-verified-totp.ts
@@ -1,23 +1,31 @@
 'use client';
 
 import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 export type UsePractitionerVerifiedTotpCountResult = {
   verifiedTotpCount: number;
   loading: boolean;
   error: Error | null;
-  /** Reloads factor list after enrollment or session changes. */
+  /**
+   * Reloads the verified TOTP factor list. The returned promise settles when that request
+   * finishes (success or failure).
+   */
   refresh: () => Promise<void>;
 };
-
-type FactorsPhase = 'idle' | 'loading' | 'ready';
 
 /**
  * Loads verified TOTP factor count for practitioner MFA gating. No-ops when `enabled` is false.
  *
- * When `enabled` flips from false to true, loading is set synchronously (via state adjustment
- * during render) so consumers do not briefly see a settled count of 0 before the first fetch.
+ * When `enabled` flips from false to true, `useLayoutEffect` sets a pending flag before paint so
+ * consumers do not briefly see a settled count of 0 before the first fetch.
  *
  * @param enabled - When false, clears counts and skips network calls (e.g. non-practitioner gates).
  * @returns Verified factor count, loading and error state, and a manual refresh.
@@ -26,26 +34,31 @@ export function usePractitionerVerifiedTotpCount(
   enabled: boolean,
 ): UsePractitionerVerifiedTotpCountResult {
   const [verifiedTotpCount, setVerifiedTotpCount] = useState(0);
-  const [prevEnabled, setPrevEnabled] = useState(enabled);
-  const [phase, setPhase] = useState<FactorsPhase>(() =>
-    enabled ? 'loading' : 'idle',
-  );
+  /** True while a factor fetch is required or in flight (when `enabled`). */
+  const [pending, setPending] = useState(() => enabled);
   const [error, setError] = useState<Error | null>(null);
+  const prevEnabledRef = useRef(enabled);
+  /** When true, the pending-triggered fetch effect skips once so manual refresh can own the load. */
+  const skipNextEffectFetchRef = useRef(false);
   const isMountedRef = useRef(true);
   const supabase = useMemo(() => getSupabaseBrowserClient(), []);
 
-  if (enabled !== prevEnabled) {
-    setPrevEnabled(enabled);
+  useLayoutEffect(() => {
     if (!enabled) {
-      setPhase('idle');
+      setPending(false);
       setVerifiedTotpCount(0);
       setError(null);
-    } else {
-      setPhase('loading');
+      prevEnabledRef.current = false;
+      return;
+    }
+
+    if (!prevEnabledRef.current) {
+      setPending(true);
       setVerifiedTotpCount(0);
       setError(null);
     }
-  }
+    prevEnabledRef.current = true;
+  }, [enabled]);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -62,17 +75,35 @@ export function usePractitionerVerifiedTotpCount(
     return result.data.totp.filter((f) => f.status === 'verified').length;
   }, [supabase]);
 
-  const refresh = useCallback((): Promise<void> => {
+  const refresh = useCallback(async (): Promise<void> => {
     if (!enabled) {
-      return Promise.resolve();
+      return;
     }
     setError(null);
-    setPhase('loading');
-    return Promise.resolve();
-  }, [enabled]);
+    skipNextEffectFetchRef.current = true;
+    setPending(true);
+    try {
+      const n = await loadFactors();
+      if (isMountedRef.current) {
+        setVerifiedTotpCount(n);
+        setError(null);
+        setPending(false);
+      }
+    } catch (e) {
+      if (isMountedRef.current) {
+        setError(e instanceof Error ? e : new Error(String(e)));
+        setPending(false);
+      }
+    }
+  }, [enabled, loadFactors]);
 
   useEffect(() => {
-    if (!enabled || phase !== 'loading') {
+    if (!enabled || !pending) {
+      return;
+    }
+
+    if (skipNextEffectFetchRef.current) {
+      skipNextEffectFetchRef.current = false;
       return;
     }
 
@@ -83,12 +114,13 @@ export function usePractitionerVerifiedTotpCount(
         const n = await loadFactors();
         if (!cancelled && isMountedRef.current) {
           setVerifiedTotpCount(n);
-          setPhase('ready');
+          setError(null);
+          setPending(false);
         }
       } catch (e) {
         if (!cancelled && isMountedRef.current) {
           setError(e instanceof Error ? e : new Error(String(e)));
-          setPhase('ready');
+          setPending(false);
         }
       }
     })();
@@ -96,9 +128,9 @@ export function usePractitionerVerifiedTotpCount(
     return () => {
       cancelled = true;
     };
-  }, [enabled, phase, loadFactors]);
+  }, [enabled, pending, loadFactors]);
 
-  const loading = enabled && phase === 'loading';
+  const loading = enabled && pending;
 
   return { verifiedTotpCount, loading, error, refresh };
 }

--- a/apps/practitioner/src/lib/use-practitioner-verified-totp.ts
+++ b/apps/practitioner/src/lib/use-practitioner-verified-totp.ts
@@ -38,13 +38,17 @@ export function usePractitionerVerifiedTotpCount(
   const [pending, setPending] = useState(() => enabled);
   const [error, setError] = useState<Error | null>(null);
   const prevEnabledRef = useRef(enabled);
-  /** When true, the pending-triggered fetch effect skips once so manual refresh can own the load. */
+  /**
+   * When true, the next pending-triggered fetch effect skips once so `refresh()` can own the load.
+   * Cleared in `refresh` finally, when `enabled` becomes false, or when the effect consumes it.
+   */
   const skipNextEffectFetchRef = useRef(false);
   const isMountedRef = useRef(true);
   const supabase = useMemo(() => getSupabaseBrowserClient(), []);
 
   useLayoutEffect(() => {
     if (!enabled) {
+      skipNextEffectFetchRef.current = false;
       setPending(false);
       setVerifiedTotpCount(0);
       setError(null);
@@ -94,6 +98,8 @@ export function usePractitionerVerifiedTotpCount(
         setError(e instanceof Error ? e : new Error(String(e)));
         setPending(false);
       }
+    } finally {
+      skipNextEffectFetchRef.current = false;
     }
   }, [enabled, loadFactors]);
 

--- a/apps/practitioner/src/lib/use-practitioner-verified-totp.ts
+++ b/apps/practitioner/src/lib/use-practitioner-verified-totp.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 export type UsePractitionerVerifiedTotpCountResult = {
   verifiedTotpCount: number;
@@ -23,25 +23,47 @@ export function usePractitionerVerifiedTotpCount(
   const [verifiedTotpCount, setVerifiedTotpCount] = useState(0);
   const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState<Error | null>(null);
+  const isMountedRef = useRef(true);
 
-  const loadFactors = useCallback(async () => {
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const loadFactors = useCallback(async (): Promise<number> => {
     const supabase = getSupabaseBrowserClient();
     const result = await supabase.auth.mfa.listFactors();
     if (result.error) {
       throw result.error;
     }
-    const n = result.data.totp.filter((f) => f.status === 'verified').length;
-    setVerifiedTotpCount(n);
+    return result.data.totp.filter((f) => f.status === 'verified').length;
   }, []);
 
   const refresh = useCallback(async () => {
-    setError(null);
-    try {
-      await loadFactors();
-    } catch (e) {
-      setError(e instanceof Error ? e : new Error(String(e)));
+    if (!enabled) {
+      return;
     }
-  }, [loadFactors]);
+    setError(null);
+    if (isMountedRef.current) {
+      setLoading(true);
+    }
+    try {
+      const n = await loadFactors();
+      if (isMountedRef.current) {
+        setVerifiedTotpCount(n);
+      }
+    } catch (e) {
+      if (isMountedRef.current) {
+        setError(e instanceof Error ? e : new Error(String(e)));
+      }
+    } finally {
+      if (isMountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [enabled, loadFactors]);
 
   useEffect(() => {
     if (!enabled) {
@@ -57,7 +79,10 @@ export function usePractitionerVerifiedTotpCount(
 
     void (async () => {
       try {
-        await loadFactors();
+        const n = await loadFactors();
+        if (!cancelled) {
+          setVerifiedTotpCount(n);
+        }
       } catch (e) {
         if (!cancelled) {
           setError(e instanceof Error ? e : new Error(String(e)));

--- a/apps/practitioner/src/lib/use-practitioner-verified-totp.ts
+++ b/apps/practitioner/src/lib/use-practitioner-verified-totp.ts
@@ -1,0 +1,78 @@
+'use client';
+
+import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
+import { useCallback, useEffect, useState } from 'react';
+
+export type UsePractitionerVerifiedTotpCountResult = {
+  verifiedTotpCount: number;
+  loading: boolean;
+  error: Error | null;
+  /** Reloads factor list after enrollment or session changes. */
+  refresh: () => Promise<void>;
+};
+
+/**
+ * Loads verified TOTP factor count for practitioner MFA gating. No-ops when `enabled` is false.
+ *
+ * @param enabled - When false, clears counts and skips network calls (e.g. non-practitioner gates).
+ * @returns Verified factor count, loading and error state, and a manual refresh.
+ */
+export function usePractitionerVerifiedTotpCount(
+  enabled: boolean,
+): UsePractitionerVerifiedTotpCountResult {
+  const [verifiedTotpCount, setVerifiedTotpCount] = useState(0);
+  const [loading, setLoading] = useState(enabled);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadFactors = useCallback(async () => {
+    const supabase = getSupabaseBrowserClient();
+    const result = await supabase.auth.mfa.listFactors();
+    if (result.error) {
+      throw result.error;
+    }
+    const n = result.data.totp.filter((f) => f.status === 'verified').length;
+    setVerifiedTotpCount(n);
+  }, []);
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      await loadFactors();
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error(String(e)));
+    }
+  }, [loadFactors]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setVerifiedTotpCount(0);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    void (async () => {
+      try {
+        await loadFactors();
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e : new Error(String(e)));
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, loadFactors]);
+
+  return { verifiedTotpCount, loading, error, refresh };
+}

--- a/apps/practitioner/src/lib/use-practitioner-verified-totp.ts
+++ b/apps/practitioner/src/lib/use-practitioner-verified-totp.ts
@@ -16,13 +16,17 @@ export type UsePractitionerVerifiedTotpCountResult = {
   error: Error | null;
   /**
    * Reloads the verified TOTP factor list. The returned promise settles when that request
-   * finishes (success or failure).
+   * finishes (success or failure). If `enabled` becomes false while the request is in flight,
+   * results are discarded and state is not updated.
    */
   refresh: () => Promise<void>;
 };
 
 /**
  * Loads verified TOTP factor count for practitioner MFA gating. No-ops when `enabled` is false.
+ *
+ * In-flight `listFactors` calls consult the latest `enabled` after each `await`, so turning
+ * `enabled` off always wins and cannot repopulate counts from a stale request.
  *
  * When `enabled` flips from false to true, `useLayoutEffect` sets a pending flag before paint so
  * consumers do not briefly see a settled count of 0 before the first fetch.
@@ -44,6 +48,9 @@ export function usePractitionerVerifiedTotpCount(
    */
   const skipNextEffectFetchRef = useRef(false);
   const isMountedRef = useRef(true);
+  /** Latest `enabled` for async guards (refresh / effect may finish after `enabled` flips false). */
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
   const supabase = useMemo(() => getSupabaseBrowserClient(), []);
 
   useLayoutEffect(() => {
@@ -88,16 +95,18 @@ export function usePractitionerVerifiedTotpCount(
     setPending(true);
     try {
       const n = await loadFactors();
-      if (isMountedRef.current) {
-        setVerifiedTotpCount(n);
-        setError(null);
-        setPending(false);
+      if (!isMountedRef.current || !enabledRef.current) {
+        return;
       }
+      setVerifiedTotpCount(n);
+      setError(null);
+      setPending(false);
     } catch (e) {
-      if (isMountedRef.current) {
-        setError(e instanceof Error ? e : new Error(String(e)));
-        setPending(false);
+      if (!isMountedRef.current || !enabledRef.current) {
+        return;
       }
+      setError(e instanceof Error ? e : new Error(String(e)));
+      setPending(false);
     } finally {
       skipNextEffectFetchRef.current = false;
     }
@@ -118,13 +127,13 @@ export function usePractitionerVerifiedTotpCount(
     void (async () => {
       try {
         const n = await loadFactors();
-        if (!cancelled && isMountedRef.current) {
+        if (!cancelled && isMountedRef.current && enabledRef.current) {
           setVerifiedTotpCount(n);
           setError(null);
           setPending(false);
         }
       } catch (e) {
-        if (!cancelled && isMountedRef.current) {
+        if (!cancelled && isMountedRef.current && enabledRef.current) {
           setError(e instanceof Error ? e : new Error(String(e)));
           setPending(false);
         }

--- a/apps/practitioner/src/lib/use-practitioner-verified-totp.ts
+++ b/apps/practitioner/src/lib/use-practitioner-verified-totp.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 export type UsePractitionerVerifiedTotpCountResult = {
   verifiedTotpCount: number;
@@ -24,6 +24,7 @@ export function usePractitionerVerifiedTotpCount(
   const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState<Error | null>(null);
   const isMountedRef = useRef(true);
+  const supabase = useMemo(() => getSupabaseBrowserClient(), []);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -33,13 +34,12 @@ export function usePractitionerVerifiedTotpCount(
   }, []);
 
   const loadFactors = useCallback(async (): Promise<number> => {
-    const supabase = getSupabaseBrowserClient();
     const result = await supabase.auth.mfa.listFactors();
     if (result.error) {
       throw result.error;
     }
     return result.data.totp.filter((f) => f.status === 'verified').length;
-  }, []);
+  }, [supabase]);
 
   const refresh = useCallback(async () => {
     if (!enabled) {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -81,7 +81,7 @@
 - [x] TOTP setup flow for practitioners via Supabase Auth MFA API (mandatory for practitioners)
 - [x] Practitioner MFA **fail-closed** per [PRD](PRD.md): RLS and/or **Edge Function** (or equivalent) verifies MFA via Auth APIs before patient-data reads; hooks alone must not be the sole control if they can fail open
 - [x] JWT claims / role metadata for routing; practitioner patient-data access must satisfy MFA rules in policy or server path
-- [ ] Frontend MFA gating in practitioner app (no patient routes until MFA verified)
+- [x] Frontend MFA gating in practitioner app (no patient routes until MFA verified)
 
 **Second half (April 16-19, school finished):**
 

--- a/docs/SECURITY_BASELINE.md
+++ b/docs/SECURITY_BASELINE.md
@@ -110,6 +110,14 @@ This document summarizes the repository security posture, points to implementati
   - [PRD: Practitioner TOTP enforcement (fail-closed)](PRD.md#two-factor-authentication-totp).
 - Status: Week 3 auth baseline implemented; practitioner MFA enforcement and claim contract documented in [AUTH_CLAIM_CONTRACT.md](AUTH_CLAIM_CONTRACT.md).
 
+#### Practitioner “trusted device” (browser storage — documented risk)
+
+- Intent: optional practitioner UX to skip re-entering TOTP on a later email/password sign-in within a time window, after the user opts in post–MFA verification.
+- Implementation: [`apps/practitioner/src/lib/practitioner-device-trust.ts`](../apps/practitioner/src/lib/practitioner-device-trust.ts) stores a bundle that includes Supabase **`refresh_token`** and **`access_token`** in **`localStorage`**. That increases **XSS blast radius**: script running in this origin can read web storage and exfiltrate tokens usable until expiry or revocation—unacceptable to treat as equivalent to HttpOnly cookies.
+- Mitigations (product and engineering): user **opt-in** only; treat **CSP**, XSS-safe rendering (no unsanitized HTML / avoid `dangerouslySetInnerHTML` with untrusted content), and dependency hygiene as part of the control set for this surface. Prefer deploying a **strict Content-Security-Policy** at the edge or host (include `connect-src` / WebSocket hosts required by Supabase Auth and your project URL).
+- Preferred direction: **redesign** to server-managed device trust (opaque HttpOnly cookie + server validation, or short-lived scoped tokens exchanged only server-side)—not implemented in the current client-only bundle.
+- Status: **interim** client implementation; **RLS and MFA rules remain authoritative** for PHI—this path is not an additional server-side authorization layer.
+
 ### 6) Media storage security
 
 - Intent: media confidentiality is provided by private bucket + RLS + TLS + platform encryption at rest, not client-managed DEKs.
@@ -169,6 +177,7 @@ Core implementation artifacts:
 - `apps/mobile/src/app/screens/UpdatePasswordScreen.tsx`
 - `apps/web/src/lib/auth-provider.tsx`
 - `apps/web/src/app/dashboard/page.tsx`
+- `apps/practitioner/src/lib/practitioner-device-trust.ts` (trusted-device UX; see XSS warning in file and subsection above)
 
 Primary design references:
 


### PR DESCRIPTION
Closes #70

## Summary

Adds practitioner-side MFA enforcement so patient-data areas and post–password sign-in require verified TOTP and an AAL2 session, with accessible status messaging and tests.

## What changed

- **Patient routes:** `/patients` (and nested routes) are wrapped in a client gate that blocks rendering until the account is a practitioner with verified TOTP and JWT `aal === 'aal2'`.
- **Login:** Email/password is followed by a TOTP challenge when needed; unenrolled users are directed to security setup on `/`.
- **Device trust (optional):** After successful TOTP verification, users can opt in to a 30-day trust window stored in `localStorage` (session bundle). In-app **Log out** uses trust-aware behavior where applicable; full server sign-out via `/api/auth/logout` still revokes sessions and is documented.
- **Sign out:** Shared `PractitionerSignOutButton` replaces ad hoc logout forms where updated.
- **A11y:** Live announcements and focus-friendly gate copy for blocked states.
- **Tests:** Unit coverage for MFA gate helpers; Playwright coverage extended for unauthenticated patient gate.

## Out of scope

- Supabase MFA enrollment API changes, RLS/Edge policy changes, and episode logging UI (unchanged).

## How to verify

1. Sign in as a practitioner without verified TOTP → expect redirect/setup messaging, no patient UI.
2. Sign in with TOTP enrolled → complete code when prompted → expect access to `/patients` when AAL2 is satisfied.
3. Run `pnpm practitioner:validate` (or project `lint` / `test` / `build` as you usually do for this app).