### PR TITLE
feat(practitioner): add staged CSP (Report-Only default, optional enforce)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,10 @@ NEXT_PUBLIC_APP_NAME=ABStrack
 # Any other non-empty value is treated as disabled (fail-closed).
 # NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST=false
 
+# apps/practitioner: CSP — read at Next config load / build (not exposed to the browser).
+# Default: Content-Security-Policy-Report-Only. Set to true to enforce Content-Security-Policy (Phase B).
+# PRACTITIONER_CSP_ENFORCE=true
+
 # --- Expo (apps/mobile) — inlined at bundle time; same values as Next
 EXPO_PUBLIC_SUPABASE_URL=https://YOUR_PROJECT_REF.supabase.co
 EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_your_key

--- a/apps/practitioner/csp-config.js
+++ b/apps/practitioner/csp-config.js
@@ -4,13 +4,17 @@
  */
 
 /**
- * Normalizes a CSP header string: strip newlines and collapse whitespace (Next.js guidance).
+ * Normalizes a CSP header string for a single-line HTTP header value: CRLF/LF/CR become spaces,
+ * then runs of whitespace collapse to one space, then trim (Next.js CSP examples use this shape).
  *
  * @param {string} raw - Multi-line or padded policy text.
- * @returns {string} Header-safe single-line value.
+ * @returns {string} Header-safe single-line value (no `\r` or `\n`).
  */
 function normalizeCspHeaderValue(raw) {
-  return raw.replace(/\s{2,}/g, ' ').trim();
+  return raw
+    .replace(/\r\n|\r|\n/g, ' ')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
 }
 
 /**

--- a/apps/practitioner/csp-config.js
+++ b/apps/practitioner/csp-config.js
@@ -1,0 +1,119 @@
+/**
+ * Builds a single-line Content-Security-Policy value for the practitioner Next.js app.
+ * Used from `next.config.js` (Node at build time). See `docs/SECURITY_BASELINE.md`.
+ */
+
+/**
+ * Normalizes a CSP header string: strip newlines and collapse whitespace (Next.js guidance).
+ *
+ * @param {string} raw - Multi-line or padded policy text.
+ * @returns {string} Header-safe single-line value.
+ */
+function normalizeCspHeaderValue(raw) {
+  return raw.replace(/\s{2,}/g, ' ').trim();
+}
+
+/**
+ * Adds common local dev origins so Report-Only does not spam the console for Next HMR and
+ * typical Supabase CLI URLs. Does not apply to production builds.
+ *
+ * @param {Set<string>} connectParts - Mutable set of `connect-src` tokens.
+ * @param {boolean} isDev - Whether `NODE_ENV === 'development'`.
+ */
+function addDevLocalConnectSources(connectParts, isDev) {
+  if (!isDev) {
+    return;
+  }
+  const devPorts = ['3000', '3001', '4200'];
+  const hosts = ['localhost', '127.0.0.1'];
+  for (const host of hosts) {
+    connectParts.add(`http://${host}:54321`);
+    connectParts.add(`ws://${host}:54321`);
+    for (const port of devPorts) {
+      connectParts.add(`http://${host}:${port}`);
+      connectParts.add(`ws://${host}:${port}`);
+    }
+  }
+}
+
+/**
+ * Returns HTTP and WebSocket origins for the configured Supabase project URL (Auth, REST,
+ * Realtime, Storage share the same project host).
+ *
+ * @param {string | undefined} supabaseUrl - `NEXT_PUBLIC_SUPABASE_URL` (or equivalent).
+ * @returns {{ httpOrigin: string, wsOrigin: string } | null}
+ */
+function supabaseHttpAndWsOrigins(supabaseUrl) {
+  if (!supabaseUrl) {
+    return null;
+  }
+  try {
+    const u = new URL(supabaseUrl);
+    const httpOrigin = u.origin;
+    const wsProtocol = u.protocol === 'https:' ? 'wss:' : 'ws:';
+    const wsOrigin = `${wsProtocol}//${u.host}`;
+    return { httpOrigin, wsOrigin };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Builds the practitioner CSP directive string (before newline normalization).
+ *
+ * @param {object} opts - Options.
+ * @param {string | undefined} opts.supabaseUrl - `NEXT_PUBLIC_SUPABASE_URL` from the build environment.
+ * @param {boolean} opts.isDev - True when `NODE_ENV === 'development'`.
+ * @param {boolean} opts.isProduction - True when `NODE_ENV === 'production'`.
+ * @returns {string} Semicolon-separated CSP directives.
+ */
+function buildPractitionerCspDirectives(opts) {
+  const { supabaseUrl, isDev, isProduction } = opts;
+
+  const connectParts = new Set(["'self'"]);
+  const origins = supabaseHttpAndWsOrigins(supabaseUrl);
+  if (origins) {
+    connectParts.add(origins.httpOrigin);
+    connectParts.add(origins.wsOrigin);
+  }
+  addDevLocalConnectSources(connectParts, isDev);
+
+  const connectSrc = Array.from(connectParts).join(' ');
+
+  const scriptParts = ["'self'", "'unsafe-inline'"];
+  if (isDev) {
+    scriptParts.push("'unsafe-eval'");
+  }
+
+  /** @type {string[]} */
+  const directives = [
+    "default-src 'self'",
+    `script-src ${scriptParts.join(' ')}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' blob: data:",
+    "font-src 'self'",
+    `connect-src ${connectSrc}`,
+    "worker-src 'self' blob:",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    "frame-src 'none'",
+  ];
+
+  if (
+    isProduction &&
+    supabaseUrl &&
+    supabaseUrl.trim().toLowerCase().startsWith('https://')
+  ) {
+    directives.push('upgrade-insecure-requests');
+  }
+
+  return directives.join('; ');
+}
+
+module.exports = {
+  buildPractitionerCspDirectives,
+  normalizeCspHeaderValue,
+  supabaseHttpAndWsOrigins,
+};

--- a/apps/practitioner/next.config.js
+++ b/apps/practitioner/next.config.js
@@ -1,5 +1,31 @@
 //@ts-check
 const { composePlugins, withNx } = require('@nx/next');
+const {
+  buildPractitionerCspDirectives,
+  normalizeCspHeaderValue,
+} = require('./csp-config.js');
+
+const isDev = process.env.NODE_ENV === 'development';
+const isProduction = process.env.NODE_ENV === 'production';
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const cspEnforce = process.env.PRACTITIONER_CSP_ENFORCE === 'true';
+
+const practitionerCspHeaderValue = normalizeCspHeaderValue(
+  buildPractitionerCspDirectives({
+    supabaseUrl,
+    isDev,
+    isProduction,
+  }),
+);
+
+const practitionerCspHeaders = cspEnforce
+  ? [{ key: 'Content-Security-Policy', value: practitionerCspHeaderValue }]
+  : [
+      {
+        key: 'Content-Security-Policy-Report-Only',
+        value: practitionerCspHeaderValue,
+      },
+    ];
 
 /**
  * @type {import('@nx/next/plugins/with-nx').WithNxOptions}
@@ -8,6 +34,14 @@ const nextConfig = {
   // Use this to set Nx-specific options
   // See: https://nx.dev/recipes/next/next-config-setup
   nx: {},
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: practitionerCspHeaders,
+      },
+    ];
+  },
 };
 
 const plugins = [

--- a/apps/practitioner/src/csp-config.spec.ts
+++ b/apps/practitioner/src/csp-config.spec.ts
@@ -18,6 +18,46 @@ describe('csp-config', () => {
     expect(supabaseHttpAndWsOrigins('not-a-url')).toBeNull();
   });
 
+  describe('normalizeCspHeaderValue', () => {
+    /**
+     * Guards the contract when policy text is built with a multi-line template literal
+     * (one directive per line); the HTTP header value must still be a single line.
+     */
+    it('strips actual newlines and CRLF from raw policy text while preserving token spacing', () => {
+      const rawMultilineTemplate = `default-src 'self';
+script-src 'self' 'unsafe-inline';
+connect-src 'self' https://abc.supabase.co wss://abc.supabase.co`;
+
+      const fromLf = normalizeCspHeaderValue(rawMultilineTemplate);
+
+      expect(fromLf).not.toMatch(/[\r\n]/);
+      expect(fromLf).toBe(
+        "default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self' https://abc.supabase.co wss://abc.supabase.co",
+      );
+
+      const rawCrLf = [
+        "default-src 'self';",
+        "script-src 'self' 'unsafe-inline';",
+        "connect-src 'self' https://abc.supabase.co",
+      ].join('\r\n');
+
+      const fromCrLf = normalizeCspHeaderValue(rawCrLf);
+
+      expect(fromCrLf).not.toMatch(/[\r\n]/);
+      expect(fromCrLf).toBe(
+        "default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self' https://abc.supabase.co",
+      );
+    });
+
+    it('normalizes inline escape sequences and mixed padding', () => {
+      expect(
+        normalizeCspHeaderValue("default-src 'self';\nscript-src 'self'"),
+      ).toBe("default-src 'self'; script-src 'self'");
+      expect(normalizeCspHeaderValue('a\r\nb\rc')).toBe('a b c');
+      expect(normalizeCspHeaderValue('x  \n  y')).toBe('x y');
+    });
+  });
+
   it('emits a single-line policy without accidental newlines', () => {
     const raw = buildPractitionerCspDirectives({
       supabaseUrl: 'https://abc.supabase.co',

--- a/apps/practitioner/src/csp-config.spec.ts
+++ b/apps/practitioner/src/csp-config.spec.ts
@@ -1,0 +1,54 @@
+import {
+  buildPractitionerCspDirectives,
+  normalizeCspHeaderValue,
+  supabaseHttpAndWsOrigins,
+} from '../csp-config.js';
+
+describe('csp-config', () => {
+  it('maps Supabase URL to HTTP and WebSocket origins', () => {
+    expect(supabaseHttpAndWsOrigins('https://abc.supabase.co')).toEqual({
+      httpOrigin: 'https://abc.supabase.co',
+      wsOrigin: 'wss://abc.supabase.co',
+    });
+    expect(supabaseHttpAndWsOrigins('http://127.0.0.1:54321')).toEqual({
+      httpOrigin: 'http://127.0.0.1:54321',
+      wsOrigin: 'ws://127.0.0.1:54321',
+    });
+    expect(supabaseHttpAndWsOrigins(undefined)).toBeNull();
+    expect(supabaseHttpAndWsOrigins('not-a-url')).toBeNull();
+  });
+
+  it('emits a single-line policy without accidental newlines', () => {
+    const raw = buildPractitionerCspDirectives({
+      supabaseUrl: 'https://abc.supabase.co',
+      isDev: false,
+      isProduction: true,
+    });
+    const value = normalizeCspHeaderValue(raw);
+    expect(value).not.toMatch(/\n/);
+    expect(value).toContain('connect-src');
+    expect(value).toContain('https://abc.supabase.co');
+    expect(value).toContain('wss://abc.supabase.co');
+    expect(value).toContain('upgrade-insecure-requests');
+  });
+
+  it("adds 'unsafe-eval' only in development", () => {
+    const prod = normalizeCspHeaderValue(
+      buildPractitionerCspDirectives({
+        supabaseUrl: 'https://abc.supabase.co',
+        isDev: false,
+        isProduction: true,
+      }),
+    );
+    expect(prod).not.toContain("'unsafe-eval'");
+
+    const dev = normalizeCspHeaderValue(
+      buildPractitionerCspDirectives({
+        supabaseUrl: 'https://abc.supabase.co',
+        isDev: true,
+        isProduction: false,
+      }),
+    );
+    expect(dev).toContain("'unsafe-eval'");
+  });
+});

--- a/docs/SECURITY_BASELINE.md
+++ b/docs/SECURITY_BASELINE.md
@@ -127,7 +127,7 @@ This document summarizes the repository security posture, points to implementati
 - **Allowed origins (summary):**
   - **`'self'`** — same-origin navigation, API routes, and Next.js assets.
   - **Supabase project** — `https`/`wss` (or `http`/`ws` for local CLI) origins derived from `NEXT_PUBLIC_SUPABASE_URL` for REST, Auth, Realtime, and Storage.
-  - **Local development** — extra `connect-src` entries for common Next/Nx ports and `localhost`/`127.0.0.1:54321 so Report-Only stays usable during `next dev` (HMR and local Supabase).
+  - **Local development** — extra `connect-src` entries for common Next/Nx ports and `localhost` / `127.0.0.1:54321` so Report-Only stays usable during `next dev` (HMR and local Supabase).
 - **Directives (summary):** `default-src 'self'`; `script-src` includes `'unsafe-inline'` (required for the theme bootstrap inline script and typical Next.js inline handling; **nonces** are the long-term tightening path per [Next.js CSP](https://nextjs.org/docs/app/guides/content-security-policy)); `'unsafe-eval'` is added **in development only** for React/Next tooling; `style-src 'unsafe-inline'` for Tailwind/Next; `img-src` includes `data:`/`blob:` (e.g. TOTP QR); `connect-src` as above; `frame-ancestors 'none'`; `frame-src 'none'`; `upgrade-insecure-requests` in **production** when the Supabase URL is `https://…`.
 - **Reporting:** there is no dedicated violation collector in-repo yet; Phase A still helps via DevTools. A future **`report-to`** / **`Reporting-Endpoints`** endpoint can be added without changing the staged model.
 - Status: **Phase A** deployed by default; **Phase B** is opt-in via env until operators confirm low violation noise.

--- a/docs/SECURITY_BASELINE.md
+++ b/docs/SECURITY_BASELINE.md
@@ -118,6 +118,20 @@ This document summarizes the repository security posture, points to implementati
 - Preferred direction: **redesign** to server-managed device trust (opaque HttpOnly cookie + server validation, or short-lived scoped tokens exchanged only server-side)—not implemented in the current client-only bundle.
 - Status: **interim** client implementation; **RLS and MFA rules remain authoritative** for PHI—this path is not an additional server-side authorization layer.
 
+#### Practitioner Content-Security-Policy (staged)
+
+- Intent: reduce XSS impact on the practitioner surface (including optional trusted-device tokens in `localStorage`) with a **strict, staged** CSP: report violations first, then enforce when noise is acceptable.
+- Implementation: [`apps/practitioner/next.config.js`](../apps/practitioner/next.config.js) sets headers globally (`/:path*`). Policy is built in [`apps/practitioner/csp-config.js`](../apps/practitioner/csp-config.js) from `NEXT_PUBLIC_SUPABASE_URL` at build time (same host as Auth, REST, Realtime, and Storage).
+- **Phase A (default):** `Content-Security-Policy-Report-Only` — violations are logged (browser console / DevTools) but requests are not blocked.
+- **Phase B:** set server-side **`PRACTITIONER_CSP_ENFORCE=true`** (e.g. hosting env at build time) to send **`Content-Security-Policy`** instead of Report-Only. Remove or flip the env after sustained clean reports.
+- **Allowed origins (summary):**
+  - **`'self'`** — same-origin navigation, API routes, and Next.js assets.
+  - **Supabase project** — `https`/`wss` (or `http`/`ws` for local CLI) origins derived from `NEXT_PUBLIC_SUPABASE_URL` for REST, Auth, Realtime, and Storage.
+  - **Local development** — extra `connect-src` entries for common Next/Nx ports and `localhost`/`127.0.0.1:54321 so Report-Only stays usable during `next dev` (HMR and local Supabase).
+- **Directives (summary):** `default-src 'self'`; `script-src` includes `'unsafe-inline'` (required for the theme bootstrap inline script and typical Next.js inline handling; **nonces** are the long-term tightening path per [Next.js CSP](https://nextjs.org/docs/app/guides/content-security-policy)); `'unsafe-eval'` is added **in development only** for React/Next tooling; `style-src 'unsafe-inline'` for Tailwind/Next; `img-src` includes `data:`/`blob:` (e.g. TOTP QR); `connect-src` as above; `frame-ancestors 'none'`; `frame-src 'none'`; `upgrade-insecure-requests` in **production** when the Supabase URL is `https://…`.
+- **Reporting:** there is no dedicated violation collector in-repo yet; Phase A still helps via DevTools. A future **`report-to`** / **`Reporting-Endpoints`** endpoint can be added without changing the staged model.
+- Status: **Phase A** deployed by default; **Phase B** is opt-in via env until operators confirm low violation noise.
+
 ### 6) Media storage security
 
 - Intent: media confidentiality is provided by private bucket + RLS + TLS + platform encryption at rest, not client-managed DEKs.
@@ -178,6 +192,7 @@ Core implementation artifacts:
 - `apps/web/src/lib/auth-provider.tsx`
 - `apps/web/src/app/dashboard/page.tsx`
 - `apps/practitioner/src/lib/practitioner-device-trust.ts` (trusted-device UX; see XSS warning in file and subsection above)
+- `apps/practitioner/next.config.js`, `apps/practitioner/csp-config.js` (practitioner CSP; see “Practitioner Content-Security-Policy” above)
 
 Primary design references:
 


### PR DESCRIPTION
Closes #81

## Summary

Adds a **staged Content-Security-Policy** for the practitioner web app (`apps/practitioner`) to narrow XSS blast radius (especially alongside optional trusted-device tokens in `localStorage`), following a **Report-Only → enforce** rollout.

## What changed

- **`Content-Security-Policy-Report-Only`** on all routes (`/:path*`) by default, with a normalized single-line policy string (Next.js–friendly).
- **Optional enforcement:** set **`PRACTITIONER_CSP_ENFORCE=true`** in the environment that loads `next.config.js` at build to send **`Content-Security-Policy`** instead of Report-Only (no duplicate headers).
- Policy is built in **`apps/practitioner/csp-config.js`** from **`NEXT_PUBLIC_SUPABASE_URL`** (same host for Auth, REST, Realtime, Storage) with matching `https`/`wss` (or `http`/`ws` for local CLI). Dev adds common localhost / port entries to keep Report-Only noise manageable (HMR, local Supabase).
- **`docs/SECURITY_BASELINE.md`:** new subsection documenting directives, origins, phases, and future reporting options.
- **`.env.example`:** documents `PRACTITIONER_CSP_ENFORCE`.
- **Tests:** `apps/practitioner/src/csp-config.spec.ts` for policy helpers.

## How to verify

- Local: `pnpm practitioner` — sign-in, MFA, patient routes; check DevTools / console for CSP violation reports (Phase A does not block).
- Build: `pnpm practitioner:build` with `NEXT_PUBLIC_SUPABASE_URL` / publishable key set as usual.

## Follow-up

- Triage Report-Only violations in real traffic, then enable **`PRACTITIONER_CSP_ENFORCE`** when noise is acceptable.
- Optional later: **`report-to` / Reporting API** collector; nonces for `script-src` / `style-src` per Next.js CSP guide.