### PR TITLE
Episode foundation schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 # Repository instructions for AI coding agents
 
+## Never run Git or Supabase database commands on Sarah’s behalf
+
+**Do not** run **`git commit`**, **`git push`**, **`git merge`**, or any other **Git** command that updates history or remotes. **Do not** run **`pnpm dlx supabase db push`**, **`supabase migration repair`**, or any command that **applies migrations** or **mutates migration history** on her linked/cloud project. **Do not** perform **releases**, **tags**, or **PR merges** for her.
+
+Sarah alone decides when schema hits cloud, when history is rewritten, and when work is published. **Instruct her** to run the exact commands from **[docs/SUPABASE_CLOUD_DEVELOPER.md](docs/SUPABASE_CLOUD_DEVELOPER.md)** (or Git docs) when something must happen in **her** terminal or on **GitHub**—do not execute those steps yourself unless she **explicitly** asks you to run a **specific** command in chat.
+
 ## Supabase: cloud + CLI on Sarah’s machine for migrations
 
 **Sarah uses Supabase Cloud.** **GitHub Actions** runs **`supabase db push`** when code merges to **`main`** (backstop: `main` and cloud stay aligned).
@@ -23,7 +29,7 @@ pnpm exec prettier --write packages/supabase/src/lib/database.types.ts
 
 (`database.types.ts` is the only file overridden in `.prettierrc.cjs` to use `prettier.database-types.json` — `semi: false` and `singleQuote: false` — so Prettier matches what `supabase gen types` emits; the rest of the repo stays single-quoted.)
 
-Then **commit** both the migration file(s) and **`packages/supabase/src/lib/database.types.ts`**.
+Then **Sarah commits** both the migration file(s) and **`packages/supabase/src/lib/database.types.ts`** (the agent does not commit).
 
 **Order matters:** `db push` **before** `gen types --linked` (linked reads **cloud**).
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -85,7 +85,7 @@
 
 **Second half (April 16-19, school finished):**
 
-- [ ] Database: migrations for (1) `episodes.health_marker_preset_id` (nullable FK to `health_marker_presets`, same-owner pattern as `symptom_preset_id`) and (2) **episode preset templates** table (bundle: one symptom preset + one health marker preset per template) + RLS; regenerate `database.types.ts` and clients per [SUPABASE_CLOUD_DEVELOPER.md](SUPABASE_CLOUD_DEVELOPER.md). Template rows must exist **before** the episode-start template picker can list choices ([PRD](PRD.md) §4, [user story](user-stories/episode-and-health-marker-flows.md))
+- [x] Database: migrations for (1) `episodes.health_marker_preset_id` (nullable FK to `health_marker_presets`, same-owner pattern as `symptom_preset_id`) and (2) **episode preset templates** table (bundle: one symptom preset + one health marker preset per template) + RLS; regenerate `database.types.ts` and clients per [SUPABASE_CLOUD_DEVELOPER.md](SUPABASE_CLOUD_DEVELOPER.md). Template rows must exist **before** the episode-start template picker can list choices ([PRD](PRD.md) §4, [user story](user-stories/episode-and-health-marker-flows.md))
 - [ ] **Settings:** UI to create/edit **episode templates** (pair a symptom preset with a health marker preset under one name, e.g. ABS vs CVS)—done when the user is well, so episode start stays one-tap
 - [ ] "I'm having an episode" button on home screen
 - [ ] Episode start: user selects **one episode template** per session; insert episode with both `symptom_preset_id` and `health_marker_preset_id` resolved from that template ([user story](user-stories/episode-and-health-marker-flows.md))

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -85,7 +85,7 @@
 
 **Second half (April 16-19, school finished):**
 
-- [x] Database: migrations for (1) `episodes.health_marker_preset_id` (nullable FK to `health_marker_presets`, same-owner pattern as `symptom_preset_id`) and (2) **episode preset templates** table (bundle: one symptom preset + one health marker preset per template) + RLS; regenerate `database.types.ts` and clients per [SUPABASE_CLOUD_DEVELOPER.md](SUPABASE_CLOUD_DEVELOPER.md). Template rows must exist **before** the episode-start template picker can list choices ([PRD](PRD.md) §4, [user story](user-stories/episode-and-health-marker-flows.md))
+- [x] Database: migrations for (1) `episodes.health_marker_preset_id` (nullable FK to `health_marker_presets`, same-owner pattern as `symptom_preset_id`) and (2) **episode preset templates** table—each template row **requires both** `symptom_preset_id` and `health_marker_preset_id` (NOT NULL; CASCADE if either preset is deleted) + RLS; regenerate `database.types.ts` and clients per [SUPABASE_CLOUD_DEVELOPER.md](SUPABASE_CLOUD_DEVELOPER.md). Template rows must exist **before** the episode-start template picker can list choices ([PRD](PRD.md) §4, [user story](user-stories/episode-and-health-marker-flows.md))
 - [ ] **Settings:** UI to create/edit **episode templates** (pair a symptom preset with a health marker preset under one name, e.g. ABS vs CVS)—done when the user is well, so episode start stays one-tap
 - [ ] "I'm having an episode" button on home screen
 - [ ] Episode start: user selects **one episode template** per session; insert episode with both `symptom_preset_id` and `health_marker_preset_id` resolved from that template ([user story](user-stories/episode-and-health-marker-flows.md))

--- a/packages/supabase/src/lib/database.types.ts
+++ b/packages/supabase/src/lib/database.types.ts
@@ -194,12 +194,58 @@ export type Database = {
           },
         ]
       }
+      episode_templates: {
+        Row: {
+          created_at: string
+          health_marker_preset_id: string | null
+          id: string
+          name: string
+          symptom_preset_id: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          health_marker_preset_id?: string | null
+          id?: string
+          name: string
+          symptom_preset_id?: string | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          health_marker_preset_id?: string | null
+          id?: string
+          name?: string
+          symptom_preset_id?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "episode_templates_health_marker_preset_id_fk"
+            columns: ["health_marker_preset_id"]
+            isOneToOne: false
+            referencedRelation: "health_marker_presets"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "episode_templates_symptom_preset_id_fk"
+            columns: ["symptom_preset_id"]
+            isOneToOne: false
+            referencedRelation: "symptom_presets"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       episodes: {
         Row: {
           created_at: string
           ended_at: string | null
           episode_label: string | null
           episode_type: string
+          health_marker_preset_id: string | null
           id: string
           note: string | null
           started_at: string
@@ -212,6 +258,7 @@ export type Database = {
           ended_at?: string | null
           episode_label?: string | null
           episode_type?: string
+          health_marker_preset_id?: string | null
           id?: string
           note?: string | null
           started_at: string
@@ -224,6 +271,7 @@ export type Database = {
           ended_at?: string | null
           episode_label?: string | null
           episode_type?: string
+          health_marker_preset_id?: string | null
           id?: string
           note?: string | null
           started_at?: string
@@ -232,6 +280,13 @@ export type Database = {
           user_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "episodes_health_marker_preset_id_fk"
+            columns: ["health_marker_preset_id"]
+            isOneToOne: false
+            referencedRelation: "health_marker_presets"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "episodes_symptom_preset_id_fk"
             columns: ["symptom_preset_id"]

--- a/packages/supabase/src/lib/database.types.ts
+++ b/packages/supabase/src/lib/database.types.ts
@@ -197,28 +197,28 @@ export type Database = {
       episode_templates: {
         Row: {
           created_at: string
-          health_marker_preset_id: string | null
+          health_marker_preset_id: string
           id: string
           name: string
-          symptom_preset_id: string | null
+          symptom_preset_id: string
           updated_at: string
           user_id: string
         }
         Insert: {
           created_at?: string
-          health_marker_preset_id?: string | null
+          health_marker_preset_id: string
           id?: string
           name: string
-          symptom_preset_id?: string | null
+          symptom_preset_id: string
           updated_at?: string
           user_id: string
         }
         Update: {
           created_at?: string
-          health_marker_preset_id?: string | null
+          health_marker_preset_id?: string
           id?: string
           name?: string
-          symptom_preset_id?: string | null
+          symptom_preset_id?: string
           updated_at?: string
           user_id?: string
         }

--- a/supabase/migrations/20260417120000_episode_templates_health_marker_preset.sql
+++ b/supabase/migrations/20260417120000_episode_templates_health_marker_preset.sql
@@ -1,5 +1,6 @@
--- Episode rows: optional health-marker preset (same-owner pattern as symptom_preset_id).
--- episode_templates: named pairing of symptom + health-marker presets for template-first episode starts.
+-- episodes: optional per-episode health_marker_preset_id (same-owner pattern as symptom_preset_id).
+-- episode_templates: each row pairs exactly one symptom preset with one health marker preset (both columns NOT NULL; invalid to omit either). ON DELETE CASCADE removes the template if either referenced preset is deleted.
+-- RLS is NOT owner-only: same as symptom_presets / health_marker_presets (caretaker read/write, practitioner read).
 
 -- ---------------------------------------------------------------------------
 -- episodes.health_marker_preset_id
@@ -64,7 +65,7 @@ CREATE TRIGGER episode_preset_owners
   EXECUTE FUNCTION public.enforce_episode_preset_owners ();
 
 -- ---------------------------------------------------------------------------
--- episode_templates — always a usable pair (NOT NULL); CASCADE removes row if either preset is deleted
+-- episode_templates — NOT NULL preset pair; CASCADE on preset delete; RLS mirrors symptom_presets (not owner-only)
 -- ---------------------------------------------------------------------------
 CREATE TABLE public.episode_templates (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
@@ -132,7 +133,8 @@ CREATE TRIGGER set_updated_at
 ALTER TABLE public.episode_templates
   ENABLE ROW LEVEL SECURITY;
 
--- Same pattern as symptom_presets / health_marker_presets (caretaker read/write, practitioner read).
+-- Policies align with public.symptom_presets / public.health_marker_presets in 20260327130000_rls_policies.sql:
+-- SELECT: patient owner OR caretaker OR practitioner (grant); INSERT/UPDATE/DELETE: patient OR caretaker.
 CREATE POLICY episode_templates_select ON public.episode_templates
   FOR SELECT
   TO authenticated

--- a/supabase/migrations/20260417120000_episode_templates_health_marker_preset.sql
+++ b/supabase/migrations/20260417120000_episode_templates_health_marker_preset.sql
@@ -1,6 +1,6 @@
 -- episodes: optional per-episode health_marker_preset_id (same-owner pattern as symptom_preset_id).
 -- episode_templates: each row pairs exactly one symptom preset with one health marker preset (both columns NOT NULL; invalid to omit either). ON DELETE CASCADE removes the template if either referenced preset is deleted.
--- RLS is NOT owner-only: same as symptom_presets / health_marker_presets (caretaker read/write, practitioner read).
+-- RLS (PRD Authorized access): patient CRUD on own user_id; caretaker CRUD when caretaker_access links (same effective access as patient for these rows); practitioner SELECT only when practitioner_access + MFA rules apply—no write policies for practitioners (same policy shape as symptom_presets / health_marker_presets).
 
 -- ---------------------------------------------------------------------------
 -- episodes.health_marker_preset_id
@@ -65,7 +65,7 @@ CREATE TRIGGER episode_preset_owners
   EXECUTE FUNCTION public.enforce_episode_preset_owners ();
 
 -- ---------------------------------------------------------------------------
--- episode_templates — NOT NULL preset pair; CASCADE on preset delete; RLS mirrors symptom_presets (not owner-only)
+-- episode_templates — NOT NULL preset pair; CASCADE on preset delete; RLS mirrors symptom_presets (patient + caretaker write; practitioner read)
 -- ---------------------------------------------------------------------------
 CREATE TABLE public.episode_templates (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
@@ -85,7 +85,7 @@ CREATE TABLE public.episode_templates (
 
 CREATE INDEX episode_templates_user_idx ON public.episode_templates (user_id);
 
-COMMENT ON TABLE public.episode_templates IS 'Named template: required symptom + health-marker preset pair for episode starts (both FKs NOT NULL). Deleting either preset CASCADE-deletes the template. RLS matches symptom_presets / health_marker_presets: patient owner and caretaker may read/write; practitioner may read when granted (user_has_practitioner_access); user_id immutability via phi_user_id_immutable.';
+COMMENT ON TABLE public.episode_templates IS 'Named template: required symptom + health-marker preset pair for episode starts (both FKs NOT NULL). Deleting either preset CASCADE-deletes the template. RLS: patient and linked caretaker read/write; practitioner read-only with grant (PRD); user_id immutability via phi_user_id_immutable.';
 COMMENT ON COLUMN public.episode_templates.symptom_preset_id IS 'Required FK to symptom_presets.id; ON DELETE CASCADE removes this template if the symptom preset is deleted. Same-owner vs user_id is enforced by trigger episode_template_preset_owners.';
 COMMENT ON COLUMN public.episode_templates.health_marker_preset_id IS 'Required FK to health_marker_presets.id; ON DELETE CASCADE removes this template if the health-marker preset is deleted. Same-owner vs user_id is enforced by trigger episode_template_preset_owners.';
 
@@ -133,8 +133,9 @@ CREATE TRIGGER set_updated_at
 ALTER TABLE public.episode_templates
   ENABLE ROW LEVEL SECURITY;
 
--- Policies align with public.symptom_presets / public.health_marker_presets in 20260327130000_rls_policies.sql:
--- SELECT: patient owner OR caretaker OR practitioner (grant); INSERT/UPDATE/DELETE: patient OR caretaker.
+-- Policies align with public.symptom_presets / public.health_marker_presets (20260327130000_rls_policies.sql).
+-- SELECT: patient OR caretaker (grant) OR practitioner (grant + MFA path via user_has_practitioner_access).
+-- INSERT/UPDATE/DELETE: patient OR caretaker only—practitioners have no write policies on this table (PRD: PHI read-only for practitioners).
 CREATE POLICY episode_templates_select ON public.episode_templates
   FOR SELECT
   TO authenticated

--- a/supabase/migrations/20260417120000_episode_templates_health_marker_preset.sql
+++ b/supabase/migrations/20260417120000_episode_templates_health_marker_preset.sql
@@ -1,0 +1,163 @@
+-- Episode rows: optional health-marker preset (same-owner pattern as symptom_preset_id).
+-- episode_templates: named pairing of symptom + health-marker presets for template-first episode starts.
+
+-- ---------------------------------------------------------------------------
+-- episodes.health_marker_preset_id
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.episodes
+  ADD COLUMN health_marker_preset_id uuid;
+
+ALTER TABLE public.episodes
+  ADD CONSTRAINT episodes_health_marker_preset_id_fk FOREIGN KEY (health_marker_preset_id)
+    REFERENCES public.health_marker_presets (id)
+    ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.episodes.health_marker_preset_id IS 'Optional FK to health_marker_presets.id; ON DELETE SET NULL clears only this column. Same-owner vs user_id is enforced by trigger episode_preset_owners.';
+
+COMMENT ON COLUMN public.episodes.symptom_preset_id IS 'Optional FK to symptom_presets.id; ON DELETE SET NULL clears only this column. Same-owner vs user_id is enforced by trigger episode_preset_owners (composite FK SET NULL would null user_id).';
+
+-- ---------------------------------------------------------------------------
+-- Replace symptom-only trigger with combined preset-owner enforcement
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.enforce_episode_preset_owners ()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql
+  AS $$
+BEGIN
+  IF NEW.symptom_preset_id IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT
+        1
+      FROM
+        public.symptom_presets s
+      WHERE
+        s.id = NEW.symptom_preset_id
+        AND s.user_id = NEW.user_id) THEN
+      RAISE EXCEPTION 'episodes.symptom_preset_id must reference a preset owned by user_id';
+    END IF;
+  END IF;
+  IF NEW.health_marker_preset_id IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT
+        1
+      FROM
+        public.health_marker_presets h
+      WHERE
+        h.id = NEW.health_marker_preset_id
+        AND h.user_id = NEW.user_id) THEN
+      RAISE EXCEPTION 'episodes.health_marker_preset_id must reference a preset owned by user_id';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.enforce_episode_preset_owners () IS 'Ensures episode symptom_preset_id and health_marker_preset_id reference presets owned by episodes.user_id.';
+
+DROP TRIGGER episode_symptom_preset_owner ON public.episodes;
+
+DROP FUNCTION public.enforce_episode_symptom_preset_owner ();
+
+CREATE TRIGGER episode_preset_owners
+  BEFORE INSERT OR UPDATE OF symptom_preset_id, health_marker_preset_id, user_id ON public.episodes
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_episode_preset_owners ();
+
+-- ---------------------------------------------------------------------------
+-- episode_templates — owner-only (RLS); preset FKs use same-owner trigger
+-- ---------------------------------------------------------------------------
+CREATE TABLE public.episode_templates (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
+  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  name text NOT NULL,
+  symptom_preset_id uuid,
+  health_marker_preset_id uuid,
+  created_at timestamptz NOT NULL DEFAULT now (),
+  updated_at timestamptz NOT NULL DEFAULT now (),
+  CONSTRAINT episode_templates_symptom_preset_id_fk FOREIGN KEY (symptom_preset_id)
+    REFERENCES public.symptom_presets (id)
+    ON DELETE SET NULL,
+  CONSTRAINT episode_templates_health_marker_preset_id_fk FOREIGN KEY (health_marker_preset_id)
+    REFERENCES public.health_marker_presets (id)
+    ON DELETE SET NULL
+);
+
+CREATE INDEX episode_templates_user_idx ON public.episode_templates (user_id);
+
+COMMENT ON TABLE public.episode_templates IS 'Named template pairing symptom and health-marker presets; RLS restricts CRUD to the owning user (user_id).';
+COMMENT ON COLUMN public.episode_templates.symptom_preset_id IS 'Optional FK to symptom_presets.id; ON DELETE SET NULL. Same-owner vs user_id is enforced by trigger episode_template_preset_owners.';
+COMMENT ON COLUMN public.episode_templates.health_marker_preset_id IS 'Optional FK to health_marker_presets.id; ON DELETE SET NULL. Same-owner vs user_id is enforced by trigger episode_template_preset_owners.';
+
+CREATE OR REPLACE FUNCTION public.enforce_episode_template_preset_owners ()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql
+  AS $$
+BEGIN
+  IF NEW.symptom_preset_id IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT
+        1
+      FROM
+        public.symptom_presets s
+      WHERE
+        s.id = NEW.symptom_preset_id
+        AND s.user_id = NEW.user_id) THEN
+      RAISE EXCEPTION 'episode_templates.symptom_preset_id must reference a preset owned by user_id';
+    END IF;
+  END IF;
+  IF NEW.health_marker_preset_id IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT
+        1
+      FROM
+        public.health_marker_presets h
+      WHERE
+        h.id = NEW.health_marker_preset_id
+        AND h.user_id = NEW.user_id) THEN
+      RAISE EXCEPTION 'episode_templates.health_marker_preset_id must reference a preset owned by user_id';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.enforce_episode_template_preset_owners () IS 'Ensures episode_templates preset FKs reference presets owned by episode_templates.user_id.';
+
+CREATE TRIGGER episode_template_preset_owners
+  BEFORE INSERT OR UPDATE OF symptom_preset_id, health_marker_preset_id, user_id ON public.episode_templates
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_episode_template_preset_owners ();
+
+CREATE TRIGGER set_updated_at
+  BEFORE UPDATE ON public.episode_templates
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_updated_at ();
+
+ALTER TABLE public.episode_templates
+  ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY episode_templates_select ON public.episode_templates
+  FOR SELECT
+  TO authenticated
+  USING (user_id = (SELECT auth.uid()));
+
+CREATE POLICY episode_templates_insert ON public.episode_templates
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (user_id = (SELECT auth.uid()));
+
+CREATE POLICY episode_templates_update ON public.episode_templates
+  FOR UPDATE
+  TO authenticated
+  USING (user_id = (SELECT auth.uid()))
+  WITH CHECK (user_id = (SELECT auth.uid()));
+
+CREATE POLICY episode_templates_delete ON public.episode_templates
+  FOR DELETE
+  TO authenticated
+  USING (user_id = (SELECT auth.uid()));
+
+CREATE TRIGGER phi_user_id_immutable
+  BEFORE UPDATE ON public.episode_templates
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_phi_row_user_id_immutable ();

--- a/supabase/migrations/20260417120000_episode_templates_health_marker_preset.sql
+++ b/supabase/migrations/20260417120000_episode_templates_health_marker_preset.sql
@@ -64,64 +64,60 @@ CREATE TRIGGER episode_preset_owners
   EXECUTE FUNCTION public.enforce_episode_preset_owners ();
 
 -- ---------------------------------------------------------------------------
--- episode_templates — owner-only (RLS); preset FKs use same-owner trigger
+-- episode_templates — always a usable pair (NOT NULL); CASCADE removes row if either preset is deleted
 -- ---------------------------------------------------------------------------
 CREATE TABLE public.episode_templates (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
   user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
   name text NOT NULL,
-  symptom_preset_id uuid,
-  health_marker_preset_id uuid,
+  symptom_preset_id uuid NOT NULL,
+  health_marker_preset_id uuid NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now (),
   updated_at timestamptz NOT NULL DEFAULT now (),
   CONSTRAINT episode_templates_symptom_preset_id_fk FOREIGN KEY (symptom_preset_id)
     REFERENCES public.symptom_presets (id)
-    ON DELETE SET NULL,
+    ON DELETE CASCADE,
   CONSTRAINT episode_templates_health_marker_preset_id_fk FOREIGN KEY (health_marker_preset_id)
     REFERENCES public.health_marker_presets (id)
-    ON DELETE SET NULL
+    ON DELETE CASCADE
 );
 
 CREATE INDEX episode_templates_user_idx ON public.episode_templates (user_id);
 
-COMMENT ON TABLE public.episode_templates IS 'Named template pairing symptom and health-marker presets; RLS restricts CRUD to the owning user (user_id).';
-COMMENT ON COLUMN public.episode_templates.symptom_preset_id IS 'Optional FK to symptom_presets.id; ON DELETE SET NULL. Same-owner vs user_id is enforced by trigger episode_template_preset_owners.';
-COMMENT ON COLUMN public.episode_templates.health_marker_preset_id IS 'Optional FK to health_marker_presets.id; ON DELETE SET NULL. Same-owner vs user_id is enforced by trigger episode_template_preset_owners.';
+COMMENT ON TABLE public.episode_templates IS 'Named template: required symptom + health-marker preset pair for episode starts (both FKs NOT NULL). Deleting either preset CASCADE-deletes the template. RLS matches symptom_presets / health_marker_presets: patient owner and caretaker may read/write; practitioner may read when granted (user_has_practitioner_access); user_id immutability via phi_user_id_immutable.';
+COMMENT ON COLUMN public.episode_templates.symptom_preset_id IS 'Required FK to symptom_presets.id; ON DELETE CASCADE removes this template if the symptom preset is deleted. Same-owner vs user_id is enforced by trigger episode_template_preset_owners.';
+COMMENT ON COLUMN public.episode_templates.health_marker_preset_id IS 'Required FK to health_marker_presets.id; ON DELETE CASCADE removes this template if the health-marker preset is deleted. Same-owner vs user_id is enforced by trigger episode_template_preset_owners.';
 
 CREATE OR REPLACE FUNCTION public.enforce_episode_template_preset_owners ()
   RETURNS TRIGGER
   LANGUAGE plpgsql
   AS $$
 BEGIN
-  IF NEW.symptom_preset_id IS NOT NULL THEN
-    IF NOT EXISTS (
-      SELECT
-        1
-      FROM
-        public.symptom_presets s
-      WHERE
-        s.id = NEW.symptom_preset_id
-        AND s.user_id = NEW.user_id) THEN
-      RAISE EXCEPTION 'episode_templates.symptom_preset_id must reference a preset owned by user_id';
-    END IF;
+  IF NOT EXISTS (
+    SELECT
+      1
+    FROM
+      public.symptom_presets s
+    WHERE
+      s.id = NEW.symptom_preset_id
+      AND s.user_id = NEW.user_id) THEN
+    RAISE EXCEPTION 'episode_templates.symptom_preset_id must reference a preset owned by user_id';
   END IF;
-  IF NEW.health_marker_preset_id IS NOT NULL THEN
-    IF NOT EXISTS (
-      SELECT
-        1
-      FROM
-        public.health_marker_presets h
-      WHERE
-        h.id = NEW.health_marker_preset_id
-        AND h.user_id = NEW.user_id) THEN
-      RAISE EXCEPTION 'episode_templates.health_marker_preset_id must reference a preset owned by user_id';
-    END IF;
+  IF NOT EXISTS (
+    SELECT
+      1
+    FROM
+      public.health_marker_presets h
+    WHERE
+      h.id = NEW.health_marker_preset_id
+      AND h.user_id = NEW.user_id) THEN
+    RAISE EXCEPTION 'episode_templates.health_marker_preset_id must reference a preset owned by user_id';
   END IF;
   RETURN NEW;
 END;
 $$;
 
-COMMENT ON FUNCTION public.enforce_episode_template_preset_owners () IS 'Ensures episode_templates preset FKs reference presets owned by episode_templates.user_id.';
+COMMENT ON FUNCTION public.enforce_episode_template_preset_owners () IS 'Ensures episode_templates preset FKs (both required) reference presets owned by episode_templates.user_id.';
 
 CREATE TRIGGER episode_template_preset_owners
   BEFORE INSERT OR UPDATE OF symptom_preset_id, health_marker_preset_id, user_id ON public.episode_templates
@@ -136,26 +132,33 @@ CREATE TRIGGER set_updated_at
 ALTER TABLE public.episode_templates
   ENABLE ROW LEVEL SECURITY;
 
+-- Same pattern as symptom_presets / health_marker_presets (caretaker read/write, practitioner read).
 CREATE POLICY episode_templates_select ON public.episode_templates
   FOR SELECT
   TO authenticated
-  USING (user_id = (SELECT auth.uid()));
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id)
+    OR public.user_has_practitioner_access (user_id));
 
 CREATE POLICY episode_templates_insert ON public.episode_templates
   FOR INSERT
   TO authenticated
-  WITH CHECK (user_id = (SELECT auth.uid()));
+  WITH CHECK (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id));
 
 CREATE POLICY episode_templates_update ON public.episode_templates
   FOR UPDATE
   TO authenticated
-  USING (user_id = (SELECT auth.uid()))
-  WITH CHECK (user_id = (SELECT auth.uid()));
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id))
+  WITH CHECK (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id));
 
 CREATE POLICY episode_templates_delete ON public.episode_templates
   FOR DELETE
   TO authenticated
-  USING (user_id = (SELECT auth.uid()));
+  USING (user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (user_id));
 
 CREATE TRIGGER phi_user_id_immutable
   BEFORE UPDATE ON public.episode_templates


### PR DESCRIPTION
Closes #71

## Summary

Adds schema for template-first episode flows (dual preset persistence) and documents that AI agents must not run Git or Supabase lifecycle commands on behalf of the maintainer.

## Database

- **`episodes.health_marker_preset_id`**: nullable FK to `health_marker_presets`, `ON DELETE SET NULL`, same-owner enforcement via renamed trigger (`episode_preset_owners` / `enforce_episode_preset_owners`).
- **`episode_templates`**: `user_id`, `name`, **required** `symptom_preset_id` and `health_marker_preset_id` (both `NOT NULL`), `created_at` / `updated_at`. FKs use **`ON DELETE CASCADE`** (deleting either preset removes the template). Preset-owner trigger (`episode_template_preset_owners` / `enforce_episode_template_preset_owners`); `set_updated_at`; `phi_user_id_immutable`.
- **`episode_templates` RLS**: matches **`symptom_presets` / `health_marker_presets`** (see `20260327130000_rls_policies.sql`)—patient owner and caretaker may **read/write**; practitioner may **read** when `user_has_practitioner_access` applies. **Not** owner-only.

## Types

- **`packages/supabase/src/lib/database.types.ts`** updated for the new schema (including required preset IDs on `episode_templates`).

## Agent instructions

- **`AGENTS.md`**: new section forbidding agents from running `git commit` / `git push` / `git merge`, `supabase db push`, `supabase migration repair`, releases/tags/merges, etc.; clarifies that Sarah runs the migration workflow and commits.

## Out of scope (per issue)

- Settings UI CRUD, home CTA, episode runtime screens, prompt rendering UI.

## Before / after merge

- After this lands on **`main`**, CI will run **`db push`** as usual. For local work aligned with **`docs/SUPABASE_CLOUD_DEVELOPER.md`**, use **`pnpm dlx supabase db push`** then **`gen types typescript --linked`** + Prettier if types need to be refreshed against cloud.