### PR TITLE
feat(mobile): episode template CRUD with action-sheet presets and tab/stack unsaved-change guards

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -12,6 +12,7 @@
     "@abstrack/types": "workspace:*",
     "@abstrack/ui": "workspace:*",
     "@expo/metro-config": "*",
+    "@expo/react-native-action-sheet": "^4.1.1",
     "@expo/vector-icons": "*",
     "@react-navigation/bottom-tabs": "*",
     "@react-navigation/native": "*",

--- a/apps/mobile/src/app/App.spec.tsx
+++ b/apps/mobile/src/app/App.spec.tsx
@@ -535,6 +535,9 @@ describe('mobile auth state sync', () => {
 
     fireEvent.press(await findByLabelText('Health marker presets'));
     expect(await findByTestId('health-marker-preset-list-screen')).toBeTruthy();
+
+    fireEvent.press(await findByLabelText('Episode templates'));
+    expect(await findByTestId('episode-template-list-screen')).toBeTruthy();
   });
 
   test('exposes the re-authentication toggle in settings', async () => {

--- a/apps/mobile/src/app/components/AppProviders.tsx
+++ b/apps/mobile/src/app/components/AppProviders.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { AppThemeProvider } from '../theme/AppThemeContext';
 
 /**
- * Global providers: safe area and app theme (NativeWind `colorScheme` + persisted theme preference).
+ * Global providers: safe area, app theme (NativeWind `colorScheme` + persisted theme preference),
+ * and {@link ActionSheetProvider} for native-style option sheets (e.g. episode template preset pickers).
  *
  * @param props - React children.
  * @returns Provider tree.
@@ -11,7 +13,9 @@ import { AppThemeProvider } from '../theme/AppThemeContext';
 export function AppProviders({ children }: { children: React.ReactNode }) {
   return (
     <SafeAreaProvider>
-      <AppThemeProvider>{children}</AppThemeProvider>
+      <AppThemeProvider>
+        <ActionSheetProvider>{children}</ActionSheetProvider>
+      </AppThemeProvider>
     </SafeAreaProvider>
   );
 }

--- a/apps/mobile/src/app/components/episode-templates/PresetOptionSheetField.tsx
+++ b/apps/mobile/src/app/components/episode-templates/PresetOptionSheetField.tsx
@@ -8,6 +8,9 @@ import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
 import { useAppTheme } from '../../theme/AppThemeContext';
 import { nw } from '../../theme/app-nativewind-classes';
 
+const EMPTY_OPTIONS_MESSAGE =
+  'No presets in this list yet. Create one in the Symptoms or Markers tab.';
+
 export type PresetOptionSheetOption = { id: string; name: string };
 
 export type PresetOptionSheetFieldProps = {
@@ -51,9 +54,7 @@ export function PresetOptionSheetField({
       return;
     }
     if (options.length === 0) {
-      announce(
-        'No presets in this list yet. Create one in the Symptoms or Markers tab.',
-      );
+      announce(EMPTY_OPTIONS_MESSAGE);
       return;
     }
 
@@ -95,6 +96,8 @@ export function PresetOptionSheetField({
     showActionSheetWithOptions,
   ]);
 
+  const listEmpty = options.length === 0;
+
   return (
     <View className="gap-2">
       <Text
@@ -107,11 +110,24 @@ export function PresetOptionSheetField({
       <Text className={`text-sm ${nw.textMuted}`} maxFontSizeMultiplier={2}>
         {hint}
       </Text>
+      {listEmpty ? (
+        <Text
+          className={`text-sm ${nw.textMuted}`}
+          maxFontSizeMultiplier={2}
+          accessibilityRole="text"
+        >
+          {EMPTY_OPTIONS_MESSAGE}
+        </Text>
+      ) : null}
       <Pressable
         accessibilityRole="button"
-        accessibilityLabel={`${label}. ${summary}. Opens a list to choose.`}
-        accessibilityState={{ disabled: disabled || options.length === 0 }}
-        disabled={disabled || options.length === 0}
+        accessibilityLabel={`${label}. ${summary}. ${
+          listEmpty
+            ? 'No options yet. Tap to hear this hint again.'
+            : 'Opens a list to choose.'
+        }`}
+        accessibilityState={{ disabled }}
+        disabled={disabled}
         onPress={openSheet}
         className={`flex-row items-center justify-between rounded-[10px] px-3 py-3 active:opacity-90 ${nw.card}`}
         style={{

--- a/apps/mobile/src/app/components/episode-templates/PresetOptionSheetField.tsx
+++ b/apps/mobile/src/app/components/episode-templates/PresetOptionSheetField.tsx
@@ -1,0 +1,142 @@
+import React, { useCallback } from 'react';
+import { Platform, Pressable, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useActionSheet } from '@expo/react-native-action-sheet';
+import { Ionicons } from '@expo/vector-icons';
+import { announce } from '@abstrack/ui/native';
+import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
+import { useAppTheme } from '../../theme/AppThemeContext';
+import { nw } from '../../theme/app-nativewind-classes';
+
+export type PresetOptionSheetOption = { id: string; name: string };
+
+export type PresetOptionSheetFieldProps = {
+  label: string;
+  placeholderLabel: string;
+  options: PresetOptionSheetOption[];
+  value: string | null;
+  onValueChange: (id: string) => void;
+  disabled?: boolean;
+  /** Shown as the action sheet subtitle (iOS) / dialog message where supported. */
+  hint?: string;
+};
+
+/**
+ * Tappable row that opens a native **action sheet** (iOS) or the library’s sheet UI (Android) —
+ * the usual mobile alternative to a web {@code <select>}. Not an inline dropdown or spinner.
+ *
+ * @param props - Label, options, current value, and change handler.
+ * @returns Labeled control that presents options in a bottom/action sheet.
+ */
+export function PresetOptionSheetField({
+  label,
+  placeholderLabel,
+  options,
+  value,
+  onValueChange,
+  disabled = false,
+  hint = 'Tap to see a list of choices.',
+}: PresetOptionSheetFieldProps) {
+  const { colors } = useAppTheme();
+  const insets = useSafeAreaInsets();
+  const { showActionSheetWithOptions } = useActionSheet();
+
+  const selectedName =
+    value != null ? options.find((o) => o.id === value)?.name : undefined;
+  const summary = selectedName ?? placeholderLabel;
+  const mutedSummary = selectedName == null;
+
+  const openSheet = useCallback(() => {
+    if (disabled) {
+      return;
+    }
+    if (options.length === 0) {
+      announce(
+        'No presets in this list yet. Create one in the Symptoms or Markers tab.',
+      );
+      return;
+    }
+
+    const sheetOptions = [...options.map((o) => o.name), 'Cancel'];
+    const cancelButtonIndex = sheetOptions.length - 1;
+
+    // Custom Android sheet is flush to the screen bottom; without insets the Cancel row
+    // can sit in the gesture / 3-button zone and taps go to system UI (recents, etc.).
+    const androidBottomPad =
+      Platform.OS === 'android' ? Math.max(insets.bottom, 24) : 0;
+
+    showActionSheetWithOptions(
+      {
+        title: label,
+        message: hint,
+        options: sheetOptions,
+        cancelButtonIndex,
+        ...(androidBottomPad > 0
+          ? { containerStyle: { paddingBottom: androidBottomPad } }
+          : {}),
+      },
+      (selectedIndex?: number) => {
+        if (selectedIndex == null || selectedIndex === cancelButtonIndex) {
+          return;
+        }
+        const chosen = options[selectedIndex];
+        if (chosen) {
+          onValueChange(chosen.id);
+        }
+      },
+    );
+  }, [
+    disabled,
+    hint,
+    insets.bottom,
+    label,
+    onValueChange,
+    options,
+    showActionSheetWithOptions,
+  ]);
+
+  return (
+    <View className="gap-2">
+      <Text
+        className={`text-base font-semibold ${nw.textInk}`}
+        maxFontSizeMultiplier={2}
+        accessibilityRole="text"
+      >
+        {label}
+      </Text>
+      <Text className={`text-sm ${nw.textMuted}`} maxFontSizeMultiplier={2}>
+        {hint}
+      </Text>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`${label}. ${summary}. Opens a list to choose.`}
+        accessibilityState={{ disabled: disabled || options.length === 0 }}
+        disabled={disabled || options.length === 0}
+        onPress={openSheet}
+        className={`flex-row items-center justify-between rounded-[10px] px-3 py-3 active:opacity-90 ${nw.card}`}
+        style={{
+          minHeight: COMFORTABLE_TOUCH_TARGET_DP,
+          borderWidth: 1,
+          borderColor: colors.border,
+          backgroundColor: colors.surface,
+          opacity: disabled ? 0.55 : 1,
+        }}
+      >
+        <Text
+          className={`min-w-0 flex-1 pr-2 text-[17px] ${mutedSummary ? nw.textMuted : nw.textInk}`}
+          numberOfLines={2}
+          maxFontSizeMultiplier={2}
+        >
+          {summary}
+        </Text>
+        <Ionicons
+          name="chevron-down"
+          size={22}
+          color={colors.muted}
+          accessibilityElementsHidden
+          importantForAccessibility="no"
+        />
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/mobile/src/app/hooks/useUnsavedChangesBeforeRemove.ts
+++ b/apps/mobile/src/app/hooks/useUnsavedChangesBeforeRemove.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { Alert } from 'react-native';
+import type { NavigationProp, ParamListBase } from '@react-navigation/native';
+import { announce } from '@abstrack/ui/native';
+
+const DISCARD_TITLE = 'Discard unsaved changes?';
+const DISCARD_MESSAGE =
+  'You have edits that are not saved yet. If you leave now, those changes will be lost.';
+
+function showDiscardAlert(onDiscard: () => void): void {
+  Alert.alert(DISCARD_TITLE, DISCARD_MESSAGE, [
+    { text: 'Keep editing', style: 'cancel' },
+    {
+      text: 'Discard changes',
+      style: 'destructive',
+      onPress: onDiscard,
+    },
+  ]);
+}
+
+export type UseUnsavedChangesBeforeRemoveOptions = {
+  /** While true, leaving is blocked without a discard prompt (e.g. save in flight). */
+  busy?: boolean;
+  /** Navigate to the episode template list (Cancel button and after confirmed discard). */
+  onNavigateToList: () => void;
+};
+
+/**
+ * Intercepts stack back (header, Android hardware back, gestures) when there are unsaved edits.
+ * Leaving the Templates tab is handled by `EpisodeTemplatesLeavingGuardTabButton` and
+ * `useEpisodeTemplatesDraftRegistration` in the main tab bar (parent `tabPress` listeners are
+ * unreliable with nested stacks and focus timing).
+ */
+export function useUnsavedChangesBeforeRemove(
+  isDirty: boolean,
+  navigation: NavigationProp<ParamListBase>,
+  options: UseUnsavedChangesBeforeRemoveOptions,
+): {
+  prepareLeaveWithoutConfirmation: () => void;
+  requestCancelToList: () => void;
+} {
+  const { busy = false, onNavigateToList } = options;
+  const allowLeaveRef = useRef(false);
+
+  const prepareLeaveWithoutConfirmation = useCallback(() => {
+    allowLeaveRef.current = true;
+  }, []);
+
+  const requestCancelToList = useCallback(() => {
+    if (busy) {
+      announce('Please wait for the current action to finish.');
+      return;
+    }
+    if (!isDirty) {
+      onNavigateToList();
+      return;
+    }
+    showDiscardAlert(() => {
+      allowLeaveRef.current = true;
+      onNavigateToList();
+    });
+  }, [busy, isDirty, onNavigateToList]);
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('beforeRemove', (e) => {
+      if (allowLeaveRef.current) {
+        return;
+      }
+      if (busy) {
+        e.preventDefault();
+        announce('Please wait for the current action to finish.');
+        return;
+      }
+      if (!isDirty) {
+        return;
+      }
+      e.preventDefault();
+      showDiscardAlert(() => {
+        allowLeaveRef.current = true;
+        navigation.dispatch(e.data.action);
+      });
+    });
+    return unsubscribe;
+  }, [busy, isDirty, navigation]);
+
+  return { prepareLeaveWithoutConfirmation, requestCancelToList };
+}

--- a/apps/mobile/src/app/navigation/EpisodeTemplatesDraftContext.tsx
+++ b/apps/mobile/src/app/navigation/EpisodeTemplatesDraftContext.tsx
@@ -1,0 +1,71 @@
+import React, { createContext, useContext, useEffect, useRef } from 'react';
+
+export type EpisodeTemplatesDraftSnapshot = {
+  isDirty: boolean;
+  busy: boolean;
+  navigateToList: () => void;
+};
+
+const EpisodeTemplatesDraftRefContext =
+  createContext<React.MutableRefObject<EpisodeTemplatesDraftSnapshot | null> | null>(
+    null,
+  );
+
+/**
+ * Wraps the main tab navigator; create/edit screens register draft state so the tab bar can
+ * intercept leaving the Templates tab.
+ */
+export function EpisodeTemplatesDraftProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const draftRef = useRef<EpisodeTemplatesDraftSnapshot | null>(null);
+  return (
+    <EpisodeTemplatesDraftRefContext.Provider value={draftRef}>
+      {children}
+    </EpisodeTemplatesDraftRefContext.Provider>
+  );
+}
+
+/**
+ * Registers unsaved-episode-template draft state while create or edit is active.
+ *
+ * @param active - When false, unregisters (e.g. editor still loading).
+ * @param isDirty - Whether the form has unsaved edits.
+ * @param busy - Save/delete in flight; blocks leaving.
+ * @param navigateToList - Pushes nested stack to `EpisodeTemplateList`.
+ */
+export function useEpisodeTemplatesDraftRegistration(
+  active: boolean,
+  isDirty: boolean,
+  busy: boolean,
+  navigateToList: () => void,
+): void {
+  const ref = useContext(EpisodeTemplatesDraftRefContext);
+  if (!ref) {
+    throw new Error(
+      'useEpisodeTemplatesDraftRegistration must be used under EpisodeTemplatesDraftProvider.',
+    );
+  }
+  useEffect(() => {
+    if (!active) {
+      ref.current = null;
+      return undefined;
+    }
+    ref.current = { isDirty, busy, navigateToList };
+    return () => {
+      ref.current = null;
+    };
+  }, [active, ref, isDirty, busy, navigateToList]);
+}
+
+export function useEpisodeTemplatesDraftRef(): React.MutableRefObject<EpisodeTemplatesDraftSnapshot | null> {
+  const ref = useContext(EpisodeTemplatesDraftRefContext);
+  if (!ref) {
+    throw new Error(
+      'useEpisodeTemplatesDraftRef must be used under EpisodeTemplatesDraftProvider.',
+    );
+  }
+  return ref;
+}

--- a/apps/mobile/src/app/navigation/EpisodeTemplatesLeavingGuardTabButton.spec.tsx
+++ b/apps/mobile/src/app/navigation/EpisodeTemplatesLeavingGuardTabButton.spec.tsx
@@ -1,0 +1,192 @@
+import * as React from 'react';
+import { Alert } from 'react-native';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import { useNavigationState } from '@react-navigation/native';
+
+import {
+  EpisodeTemplatesDraftProvider,
+  useEpisodeTemplatesDraftRegistration,
+} from './EpisodeTemplatesDraftContext';
+import { EpisodeTemplatesLeavingGuardTabButton } from './EpisodeTemplatesLeavingGuardTabButton';
+import type { MainTabParamList } from './types';
+
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigationState: jest.fn(),
+  };
+});
+
+jest.mock('@abstrack/ui/native', () => {
+  const actual = jest.requireActual('@abstrack/ui/native');
+  return {
+    ...actual,
+    announce: jest.fn(),
+  };
+});
+
+function makeEpisodeTemplatesNavState(
+  nested: 'EpisodeTemplateCreate' | 'EpisodeTemplateEdit',
+) {
+  return {
+    routes: [
+      {
+        name: 'EpisodeTemplates',
+        state: {
+          routes: [
+            nested === 'EpisodeTemplateEdit'
+              ? { name: 'EpisodeTemplateEdit', params: { templateId: 't1' } }
+              : { name: 'EpisodeTemplateCreate' },
+          ],
+          index: 0,
+        },
+      },
+    ],
+    index: 0,
+  };
+}
+
+function TabButtonWithDraft(props: {
+  isDirty: boolean;
+  busy: boolean;
+  targetRoute: keyof MainTabParamList;
+  onTabPress: () => void;
+  navigateToList: () => void;
+}) {
+  useEpisodeTemplatesDraftRegistration(
+    true,
+    props.isDirty,
+    props.busy,
+    props.navigateToList,
+  );
+  return (
+    <EpisodeTemplatesLeavingGuardTabButton
+      targetRoute={props.targetRoute}
+      onPress={props.onTabPress}
+      testID="leaving-guard-tab"
+    />
+  );
+}
+
+describe('EpisodeTemplatesLeavingGuardTabButton', () => {
+  const navigateToList = jest.fn();
+  const onTabPress = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest
+      .mocked(useNavigationState)
+      .mockImplementation((selector) =>
+        selector(makeEpisodeTemplatesNavState('EpisodeTemplateCreate')),
+      );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('when draft is dirty and user switches to another tab, shows discard alert; navigateToList and tab onPress run only after confirm', async () => {
+    const alertSpy = jest
+      .spyOn(Alert, 'alert')
+      .mockImplementation(() => undefined);
+
+    const screen = render(
+      <EpisodeTemplatesDraftProvider>
+        <TabButtonWithDraft
+          isDirty
+          busy={false}
+          targetRoute="Home"
+          onTabPress={onTabPress}
+          navigateToList={navigateToList}
+        />
+      </EpisodeTemplatesDraftProvider>,
+    );
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('leaving-guard-tab'));
+    });
+
+    expect(navigateToList).not.toHaveBeenCalled();
+    expect(onTabPress).not.toHaveBeenCalled();
+
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+    const [title, message, buttons] = alertSpy.mock.calls[0];
+    expect(title).toBe('Discard unsaved changes?');
+    expect(message).toContain('not saved');
+
+    const discard = buttons?.find((b) => b.text === 'Discard changes');
+    expect(discard?.onPress).toEqual(expect.any(Function));
+
+    await act(async () => {
+      discard?.onPress?.();
+    });
+
+    expect(navigateToList).toHaveBeenCalledTimes(1);
+    expect(onTabPress).toHaveBeenCalledTimes(1);
+  });
+
+  test('same behavior when nested route is EpisodeTemplateEdit', async () => {
+    jest
+      .mocked(useNavigationState)
+      .mockImplementation((selector) =>
+        selector(makeEpisodeTemplatesNavState('EpisodeTemplateEdit')),
+      );
+
+    const alertSpy = jest
+      .spyOn(Alert, 'alert')
+      .mockImplementation(() => undefined);
+
+    const screen = render(
+      <EpisodeTemplatesDraftProvider>
+        <TabButtonWithDraft
+          isDirty
+          busy={false}
+          targetRoute="SymptomPresets"
+          onTabPress={onTabPress}
+          navigateToList={navigateToList}
+        />
+      </EpisodeTemplatesDraftProvider>,
+    );
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('leaving-guard-tab'));
+    });
+
+    expect(navigateToList).not.toHaveBeenCalled();
+    expect(onTabPress).not.toHaveBeenCalled();
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+
+    const [, , buttons] = alertSpy.mock.calls[0];
+    await act(async () => {
+      buttons?.find((b) => b.text === 'Discard changes')?.onPress?.();
+    });
+
+    expect(navigateToList).toHaveBeenCalledTimes(1);
+    expect(onTabPress).toHaveBeenCalledTimes(1);
+  });
+
+  test('when draft is not dirty, switches tab without alert and resets stack via navigateToList', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert');
+
+    const screen = render(
+      <EpisodeTemplatesDraftProvider>
+        <TabButtonWithDraft
+          isDirty={false}
+          busy={false}
+          targetRoute="Home"
+          onTabPress={onTabPress}
+          navigateToList={navigateToList}
+        />
+      </EpisodeTemplatesDraftProvider>,
+    );
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('leaving-guard-tab'));
+    });
+
+    expect(alertSpy).not.toHaveBeenCalled();
+    expect(navigateToList).toHaveBeenCalledTimes(1);
+    expect(onTabPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/app/navigation/EpisodeTemplatesLeavingGuardTabButton.spec.tsx
+++ b/apps/mobile/src/app/navigation/EpisodeTemplatesLeavingGuardTabButton.spec.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import { Alert } from 'react-native';
 import { act, fireEvent, render } from '@testing-library/react-native';
-import { useNavigationState } from '@react-navigation/native';
+import {
+  useNavigationState,
+  type NavigationState,
+} from '@react-navigation/native';
 
 import {
   EpisodeTemplatesDraftProvider,
@@ -28,22 +31,41 @@ jest.mock('@abstrack/ui/native', () => {
 
 function makeEpisodeTemplatesNavState(
   nested: 'EpisodeTemplateCreate' | 'EpisodeTemplateEdit',
-) {
+): NavigationState {
+  const nestedScreen =
+    nested === 'EpisodeTemplateEdit'
+      ? ({
+          key: 'EpisodeTemplateEdit',
+          name: 'EpisodeTemplateEdit' as const,
+          params: { templateId: 't1' },
+        } as const)
+      : ({
+          key: 'EpisodeTemplateCreate',
+          name: 'EpisodeTemplateCreate' as const,
+        } as const);
+
+  const nestedStack: NavigationState = {
+    key: 'episode-templates-stack',
+    index: 0,
+    routeNames: [nestedScreen.name],
+    type: 'stack',
+    stale: false,
+    routes: [nestedScreen],
+  };
+
   return {
+    key: 'main-tabs',
+    index: 0,
+    routeNames: ['EpisodeTemplates'],
+    type: 'tab',
+    stale: false,
     routes: [
       {
+        key: 'EpisodeTemplates',
         name: 'EpisodeTemplates',
-        state: {
-          routes: [
-            nested === 'EpisodeTemplateEdit'
-              ? { name: 'EpisodeTemplateEdit', params: { templateId: 't1' } }
-              : { name: 'EpisodeTemplateCreate' },
-          ],
-          index: 0,
-        },
+        state: nestedStack,
       },
     ],
-    index: 0,
   };
 }
 
@@ -65,7 +87,9 @@ function TabButtonWithDraft(props: {
       targetRoute={props.targetRoute}
       onPress={props.onTabPress}
       testID="leaving-guard-tab"
-    />
+    >
+      {null}
+    </EpisodeTemplatesLeavingGuardTabButton>
   );
 }
 

--- a/apps/mobile/src/app/navigation/EpisodeTemplatesLeavingGuardTabButton.tsx
+++ b/apps/mobile/src/app/navigation/EpisodeTemplatesLeavingGuardTabButton.tsx
@@ -1,0 +1,106 @@
+import React, { useCallback } from 'react';
+import { Alert, GestureResponderEvent, Pressable } from 'react-native';
+import type { BottomTabBarButtonProps } from '@react-navigation/bottom-tabs';
+import { useNavigationState } from '@react-navigation/native';
+import { announce } from '@abstrack/ui/native';
+import type { MainTabParamList } from './types';
+import { useEpisodeTemplatesDraftRef } from './EpisodeTemplatesDraftContext';
+
+const DISCARD_TITLE = 'Discard unsaved changes?';
+const DISCARD_MESSAGE =
+  'You have edits that are not saved yet. If you leave now, those changes will be lost.';
+
+type Props = BottomTabBarButtonProps & {
+  /** Tab this button switches to (from the enclosing screen’s route). */
+  targetRoute: keyof MainTabParamList;
+};
+
+/**
+ * Wraps the default tab bar button so leaving the Templates tab from create/edit can prompt or
+ * reset the nested stack — implemented here instead of `navigation.addListener('tabPress')`,
+ * which is easy to get wrong with focus timing and mounted-but-hidden screens.
+ */
+export function EpisodeTemplatesLeavingGuardTabButton({
+  targetRoute,
+  onPress,
+  ...rest
+}: Props) {
+  const draftRef = useEpisodeTemplatesDraftRef();
+
+  const tabSituation = useNavigationState((state) => {
+    if (!state?.routes || typeof state.index !== 'number') {
+      return {
+        currentTab: undefined as keyof MainTabParamList | undefined,
+        nested: undefined as string | undefined,
+      };
+    }
+    const current = state.routes[state.index] as {
+      name: string;
+      state?: { routes: { name: string }[]; index: number };
+    };
+    const currentTab = current?.name as keyof MainTabParamList;
+    let nested: string | undefined;
+    if (current?.name === 'EpisodeTemplates' && current.state?.routes?.length) {
+      const st = current.state;
+      nested = st.routes[st.index]?.name;
+    }
+    return { currentTab, nested };
+  });
+
+  const handlePress = useCallback(
+    (e: GestureResponderEvent) => {
+      const { currentTab, nested } = tabSituation;
+
+      if (
+        currentTab !== 'EpisodeTemplates' ||
+        (nested !== 'EpisodeTemplateCreate' && nested !== 'EpisodeTemplateEdit')
+      ) {
+        onPress?.(e);
+        return;
+      }
+
+      if (targetRoute === 'EpisodeTemplates') {
+        onPress?.(e);
+        return;
+      }
+
+      const draft = draftRef.current;
+      if (!draft) {
+        onPress?.(e);
+        return;
+      }
+
+      if (draft.busy) {
+        announce('Please wait for the current action to finish.');
+        return;
+      }
+
+      const go = () => {
+        draft.navigateToList();
+        onPress?.(e);
+      };
+
+      if (!draft.isDirty) {
+        go();
+        return;
+      }
+
+      Alert.alert(DISCARD_TITLE, DISCARD_MESSAGE, [
+        { text: 'Keep editing', style: 'cancel' },
+        {
+          text: 'Discard changes',
+          style: 'destructive',
+          onPress: go,
+        },
+      ]);
+    },
+    [draftRef, onPress, tabSituation, targetRoute],
+  );
+
+  return (
+    <Pressable
+      {...(rest as React.ComponentPropsWithoutRef<typeof Pressable>)}
+      onPress={handlePress}
+    />
+  );
+}

--- a/apps/mobile/src/app/navigation/EpisodeTemplatesNavigator.tsx
+++ b/apps/mobile/src/app/navigation/EpisodeTemplatesNavigator.tsx
@@ -1,0 +1,48 @@
+import React, { useMemo } from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { EpisodeTemplateCreateScreen } from '../screens/EpisodeTemplateCreateScreen';
+import { EpisodeTemplateEditorScreen } from '../screens/EpisodeTemplateEditorScreen';
+import { EpisodeTemplateListScreen } from '../screens/EpisodeTemplateListScreen';
+import { useAppTheme } from '../theme/AppThemeContext';
+import type { EpisodeTemplatesStackParamList } from './types';
+
+const Stack = createNativeStackNavigator<EpisodeTemplatesStackParamList>();
+
+/**
+ * Nested stack for episode template list, creation, and editing (symptom + marker pairing).
+ *
+ * @returns Native stack navigator for the Episode templates tab.
+ */
+export function EpisodeTemplatesNavigator() {
+  const { colors } = useAppTheme();
+
+  const screenOptions = useMemo(
+    () => ({
+      headerStyle: { backgroundColor: colors.surface },
+      headerTintColor: colors.primary,
+      headerTitleStyle: { color: colors.ink, fontWeight: '600' as const },
+      contentStyle: { backgroundColor: colors.bg },
+    }),
+    [colors],
+  );
+
+  return (
+    <Stack.Navigator screenOptions={screenOptions}>
+      <Stack.Screen
+        name="EpisodeTemplateList"
+        component={EpisodeTemplateListScreen}
+        options={{ title: 'Episode templates' }}
+      />
+      <Stack.Screen
+        name="EpisodeTemplateCreate"
+        component={EpisodeTemplateCreateScreen}
+        options={{ title: 'New template' }}
+      />
+      <Stack.Screen
+        name="EpisodeTemplateEdit"
+        component={EpisodeTemplateEditorScreen}
+        options={{ title: 'Edit template' }}
+      />
+    </Stack.Navigator>
+  );
+}

--- a/apps/mobile/src/app/navigation/MainTabNavigator.tsx
+++ b/apps/mobile/src/app/navigation/MainTabNavigator.tsx
@@ -6,9 +6,12 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
 import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
 import { HomeScreen } from '../screens/HomeScreen';
+import { EpisodeTemplatesNavigator } from './EpisodeTemplatesNavigator';
 import { HealthMarkerPresetsNavigator } from './HealthMarkerPresetsNavigator';
 import { SymptomPresetsNavigator } from './SymptomPresetsNavigator';
 import { useAppTheme } from '../theme/AppThemeContext';
+import { EpisodeTemplatesDraftProvider } from './EpisodeTemplatesDraftContext';
+import { EpisodeTemplatesLeavingGuardTabButton } from './EpisodeTemplatesLeavingGuardTabButton';
 import type { MainStackParamList, MainTabParamList } from './types';
 
 const Tab = createBottomTabNavigator<MainTabParamList>();
@@ -54,60 +57,77 @@ export function MainTabNavigator() {
   const { colors } = useAppTheme();
 
   return (
-    <Tab.Navigator
-      screenOptions={{
-        headerShown: false,
-        tabBarActiveTintColor: colors.primary,
-        tabBarInactiveTintColor: colors.muted,
-        tabBarLabelPosition: 'below-icon',
-        tabBarShowLabel: true,
-        tabBarStyle: {
-          paddingTop: 4,
-          paddingBottom: 6,
-          minHeight: COMFORTABLE_TOUCH_TARGET_DP + 28,
-          backgroundColor: colors.surface,
-          borderTopColor: colors.border,
-          borderTopWidth: StyleSheet.hairlineWidth,
-        },
-        tabBarItemStyle: {
-          paddingVertical: 4,
-        },
-      }}
-    >
-      <Tab.Screen
-        name="Home"
-        options={{
-          tabBarLabel: 'Home',
-          tabBarAccessibilityLabel: 'Home',
-          tabBarIcon: tabBarIonIcon('home-outline'),
-        }}
+    <EpisodeTemplatesDraftProvider>
+      <Tab.Navigator
+        screenOptions={({ route }) => ({
+          headerShown: false,
+          tabBarActiveTintColor: colors.primary,
+          tabBarInactiveTintColor: colors.muted,
+          tabBarLabelPosition: 'below-icon',
+          tabBarShowLabel: true,
+          tabBarStyle: {
+            paddingTop: 4,
+            paddingBottom: 6,
+            minHeight: COMFORTABLE_TOUCH_TARGET_DP + 28,
+            backgroundColor: colors.surface,
+            borderTopColor: colors.border,
+            borderTopWidth: StyleSheet.hairlineWidth,
+          },
+          tabBarItemStyle: {
+            paddingVertical: 4,
+          },
+          tabBarButton: (props) => (
+            <EpisodeTemplatesLeavingGuardTabButton
+              {...props}
+              targetRoute={route.name as keyof MainTabParamList}
+            />
+          ),
+        })}
       >
-        {({ navigation }) => (
-          <HomeScreen
-            onGoToSettings={() => {
-              navigateFromHomeTabToSettings(navigation);
-            }}
-          />
-        )}
-      </Tab.Screen>
-      <Tab.Screen
-        name="SymptomPresets"
-        component={SymptomPresetsNavigator}
-        options={{
-          tabBarLabel: 'Symptoms',
-          tabBarAccessibilityLabel: 'Symptom presets',
-          tabBarIcon: tabBarIonIcon('medkit-outline'),
-        }}
-      />
-      <Tab.Screen
-        name="HealthMarkerPresets"
-        component={HealthMarkerPresetsNavigator}
-        options={{
-          tabBarLabel: 'Markers',
-          tabBarAccessibilityLabel: 'Health marker presets',
-          tabBarIcon: tabBarIonIcon('pulse-outline'),
-        }}
-      />
-    </Tab.Navigator>
+        <Tab.Screen
+          name="Home"
+          options={{
+            tabBarLabel: 'Home',
+            tabBarAccessibilityLabel: 'Home',
+            tabBarIcon: tabBarIonIcon('home-outline'),
+          }}
+        >
+          {({ navigation }) => (
+            <HomeScreen
+              onGoToSettings={() => {
+                navigateFromHomeTabToSettings(navigation);
+              }}
+            />
+          )}
+        </Tab.Screen>
+        <Tab.Screen
+          name="SymptomPresets"
+          component={SymptomPresetsNavigator}
+          options={{
+            tabBarLabel: 'Symptoms',
+            tabBarAccessibilityLabel: 'Symptom presets',
+            tabBarIcon: tabBarIonIcon('medkit-outline'),
+          }}
+        />
+        <Tab.Screen
+          name="HealthMarkerPresets"
+          component={HealthMarkerPresetsNavigator}
+          options={{
+            tabBarLabel: 'Markers',
+            tabBarAccessibilityLabel: 'Health marker presets',
+            tabBarIcon: tabBarIonIcon('pulse-outline'),
+          }}
+        />
+        <Tab.Screen
+          name="EpisodeTemplates"
+          component={EpisodeTemplatesNavigator}
+          options={{
+            tabBarLabel: 'Templates',
+            tabBarAccessibilityLabel: 'Episode templates',
+            tabBarIcon: tabBarIonIcon('layers-outline'),
+          }}
+        />
+      </Tab.Navigator>
+    </EpisodeTemplatesDraftProvider>
   );
 }

--- a/apps/mobile/src/app/navigation/types.ts
+++ b/apps/mobile/src/app/navigation/types.ts
@@ -16,10 +16,18 @@ export type HealthMarkerPresetsStackParamList = {
   HealthMarkerPresetEdit: { presetId: string };
 };
 
+/** Stack inside the Episode templates tab: list, create, edit. */
+export type EpisodeTemplatesStackParamList = {
+  EpisodeTemplateList: undefined;
+  EpisodeTemplateCreate: undefined;
+  EpisodeTemplateEdit: { templateId: string };
+};
+
 export type MainTabParamList = {
   Home: undefined;
   SymptomPresets: undefined;
   HealthMarkerPresets: undefined;
+  EpisodeTemplates: undefined;
 };
 
 export type MainStackParamList = {

--- a/apps/mobile/src/app/screens/EpisodeTemplateCreateScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeTemplateCreateScreen.tsx
@@ -1,0 +1,336 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Pressable, ScrollView, Text, TextInput, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { announce } from '@abstrack/ui/native';
+import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
+import {
+  validateEpisodeTemplateName,
+  validateEpisodeTemplatePresetPair,
+} from '@abstrack/types';
+import {
+  getCurrentUserId,
+  saveNewEpisodeTemplate,
+} from '../../lib/episode-templates/episode-template-service';
+import { fetchHealthMarkerPresets } from '../../lib/health-marker-presets/health-marker-preset-service';
+import { fetchSymptomPresets } from '../../lib/symptom-presets/symptom-preset-service';
+import { PresetOptionSheetField } from '../components/episode-templates/PresetOptionSheetField';
+import { useUnsavedChangesBeforeRemove } from '../hooks/useUnsavedChangesBeforeRemove';
+import { useEpisodeTemplatesDraftRegistration } from '../navigation/EpisodeTemplatesDraftContext';
+import type { EpisodeTemplatesStackParamList } from '../navigation/types';
+import { useAppTheme } from '../theme/AppThemeContext';
+import { nw } from '../theme/app-nativewind-classes';
+
+type CreateNav = NativeStackNavigationProp<
+  EpisodeTemplatesStackParamList,
+  'EpisodeTemplateCreate'
+>;
+
+type PresetOption = { id: string; name: string };
+
+/**
+ * Create screen: template name plus symptom and health marker presets (picker opens an action sheet).
+ * Header back, Cancel, and Android system back prompt before discarding unsaved input (like web).
+ *
+ * @returns Create episode template screen.
+ */
+export function EpisodeTemplateCreateScreen() {
+  const navigation = useNavigation<CreateNav>();
+  const { colors } = useAppTheme();
+  const [name, setName] = useState('');
+  const [symptomId, setSymptomId] = useState<string | null>(null);
+  const [markerId, setMarkerId] = useState<string | null>(null);
+  const [symptoms, setSymptoms] = useState<PresetOption[]>([]);
+  const [markers, setMarkers] = useState<PresetOption[]>([]);
+  const [listsLoading, setListsLoading] = useState(true);
+  const [listsError, setListsError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [formBaseline, setFormBaseline] = useState<{
+    name: string;
+    symptomId: string | null;
+    markerId: string | null;
+  } | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      setListsLoading(true);
+      setListsError(null);
+      const [sRes, mRes] = await Promise.all([
+        fetchSymptomPresets(),
+        fetchHealthMarkerPresets(),
+      ]);
+      if (cancelled) {
+        return;
+      }
+      if (!sRes.ok) {
+        setListsError(sRes.error.message);
+        setListsLoading(false);
+        return;
+      }
+      if (!mRes.ok) {
+        setListsError(mRes.error.message);
+        setListsLoading(false);
+        return;
+      }
+      const sList = sRes.data.map((r) => ({ id: r.id, name: r.name }));
+      const mList = mRes.data.map((r) => ({ id: r.id, name: r.name }));
+      const initSymptom = sList.length === 1 ? sList[0].id : null;
+      const initMarker = mList.length === 1 ? mList[0].id : null;
+      setSymptoms(sList);
+      setMarkers(mList);
+      setSymptomId(initSymptom);
+      setMarkerId(initMarker);
+      setFormBaseline({
+        name: '',
+        symptomId: initSymptom,
+        markerId: initMarker,
+      });
+      setListsLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const nameOk = useMemo(() => validateEpisodeTemplateName(name).ok, [name]);
+
+  const isDirty = useMemo(() => {
+    if (!formBaseline) {
+      return false;
+    }
+    return (
+      name.trim() !== formBaseline.name.trim() ||
+      symptomId !== formBaseline.symptomId ||
+      markerId !== formBaseline.markerId
+    );
+  }, [formBaseline, name, symptomId, markerId]);
+
+  const goToTemplateList = useCallback(() => {
+    navigation.navigate('EpisodeTemplateList');
+  }, [navigation]);
+
+  const { prepareLeaveWithoutConfirmation, requestCancelToList } =
+    useUnsavedChangesBeforeRemove(isDirty, navigation, {
+      busy,
+      onNavigateToList: goToTemplateList,
+    });
+
+  useEpisodeTemplatesDraftRegistration(true, isDirty, busy, goToTemplateList);
+
+  const canSave = useMemo(() => {
+    if (listsLoading || listsError || busy) {
+      return false;
+    }
+    if (!symptomId || !markerId) {
+      return false;
+    }
+    return nameOk;
+  }, [busy, listsError, listsLoading, markerId, nameOk, symptomId]);
+
+  const onSave = async () => {
+    const nameCheck = validateEpisodeTemplateName(name);
+    if (!nameCheck.ok) {
+      announce(nameCheck.message);
+      return;
+    }
+    const pair = validateEpisodeTemplatePresetPair(
+      symptomId ?? '',
+      markerId ?? '',
+    );
+    if (!pair.ok) {
+      announce(pair.message);
+      return;
+    }
+    const sid = symptomId as string;
+    const hid = markerId as string;
+    setBusy(true);
+    try {
+      const authResult = await getCurrentUserId();
+      if (!authResult.ok) {
+        announce(authResult.error.message);
+        return;
+      }
+      if (authResult.data === null) {
+        announce('You need to be signed in to create a template.');
+        return;
+      }
+      const result = await saveNewEpisodeTemplate({
+        user_id: authResult.data,
+        name: nameCheck.name,
+        symptom_preset_id: sid,
+        health_marker_preset_id: hid,
+      });
+      if (!result.ok) {
+        announce(result.error.message);
+        return;
+      }
+      announce('Episode template saved.');
+      prepareLeaveWithoutConfirmation();
+      navigation.replace('EpisodeTemplateList');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const needsPresetSelection =
+    !listsLoading &&
+    !listsError &&
+    (symptomId == null || markerId == null) &&
+    symptoms.length > 0 &&
+    markers.length > 0;
+
+  return (
+    <ScrollView
+      className="flex-1"
+      contentContainerStyle={{
+        flexGrow: 1,
+        padding: 16,
+        paddingBottom: 24,
+      }}
+      keyboardShouldPersistTaps="handled"
+    >
+      <Text className={`text-base ${nw.textMuted}`} maxFontSizeMultiplier={2}>
+        Choose a name you will recognize when impaired, then tap each row below
+        to pick from a list (action sheet). Similar preset names do not link
+        automatically — this template row stores the pairing.
+      </Text>
+
+      {listsLoading ? (
+        <Text className={`mt-4 text-base ${nw.textMuted}`}>
+          Loading your presets…
+        </Text>
+      ) : null}
+      {listsError ? (
+        <Text
+          className={`mt-4 text-base ${nw.textError}`}
+          accessibilityRole="alert"
+          maxFontSizeMultiplier={2}
+        >
+          {listsError}
+        </Text>
+      ) : null}
+
+      <View className="mt-6 gap-2">
+        <Text
+          accessibilityRole="text"
+          className={`text-base font-semibold ${nw.textInk}`}
+          maxFontSizeMultiplier={2}
+        >
+          Template name
+        </Text>
+        <TextInput
+          value={name}
+          onChangeText={setName}
+          editable={!busy}
+          placeholder='e.g. "ABS Episode"'
+          placeholderTextColor={colors.inputPlaceholder}
+          className={`rounded-[10px] px-3 py-3 text-[17px] ${nw.input}`}
+          style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+          autoCapitalize="sentences"
+          autoCorrect
+          maxFontSizeMultiplier={2}
+          accessibilityLabel="Episode template name"
+        />
+      </View>
+
+      <View className="mt-8">
+        <PresetOptionSheetField
+          label="Symptom preset"
+          placeholderLabel="Tap to choose a symptom preset…"
+          options={symptoms}
+          value={symptomId}
+          onValueChange={setSymptomId}
+          disabled={busy || listsLoading}
+          hint="Opens a list from the bottom of the screen."
+        />
+      </View>
+
+      <View className="mt-6">
+        <PresetOptionSheetField
+          label="Health marker preset"
+          placeholderLabel="Tap to choose a health marker preset…"
+          options={markers}
+          value={markerId}
+          onValueChange={setMarkerId}
+          disabled={busy || listsLoading}
+          hint="Pick which marker preset pairs with this template."
+        />
+      </View>
+
+      {needsPresetSelection ? (
+        <Text
+          className={`mt-4 text-sm ${nw.textMuted}`}
+          accessibilityRole="text"
+          maxFontSizeMultiplier={2}
+        >
+          Select both a symptom preset and a health marker preset above, then
+          save.
+        </Text>
+      ) : null}
+
+      {!listsLoading && !listsError && symptomId && markerId && !name.trim() ? (
+        <Text
+          className={`mt-4 text-sm ${nw.textMuted}`}
+          accessibilityRole="text"
+          maxFontSizeMultiplier={2}
+        >
+          Enter a template name to enable save.
+        </Text>
+      ) : null}
+
+      {!nameOk && name.trim().length > 0 ? (
+        <Text
+          className={`mt-2 text-sm ${nw.textError}`}
+          accessibilityRole="alert"
+          maxFontSizeMultiplier={2}
+        >
+          Fix the template name (cannot be empty; check length limits).
+        </Text>
+      ) : null}
+
+      <View className="mt-8 gap-3">
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Save episode template"
+          accessibilityState={{ disabled: !canSave }}
+          disabled={!canSave}
+          onPress={() => void onSave()}
+          className={`items-center justify-center rounded-[12px] px-4 active:opacity-90 ${nw.btnPrimary}`}
+          style={{
+            minHeight: COMFORTABLE_TOUCH_TARGET_DP,
+            opacity: canSave ? 1 : 0.45,
+          }}
+        >
+          <Text
+            className={`text-[17px] font-semibold ${nw.textOnPrimary}`}
+            maxFontSizeMultiplier={2}
+          >
+            {busy ? 'Saving…' : 'Save template'}
+          </Text>
+        </Pressable>
+
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Cancel without saving, return to episode templates"
+          accessibilityHint="If you have unsaved changes, you will be asked to confirm."
+          accessibilityState={{ disabled: busy }}
+          disabled={busy}
+          onPress={requestCancelToList}
+          className={`items-center justify-center rounded-[12px] border px-4 active:opacity-90 ${nw.btnSecondary}`}
+          style={{
+            minHeight: COMFORTABLE_TOUCH_TARGET_DP,
+            opacity: busy ? 0.45 : 1,
+          }}
+        >
+          <Text
+            className={`text-[17px] font-semibold ${nw.textInk}`}
+            maxFontSizeMultiplier={2}
+          >
+            Cancel
+          </Text>
+        </Pressable>
+      </View>
+    </ScrollView>
+  );
+}

--- a/apps/mobile/src/app/screens/EpisodeTemplateCreateScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeTemplateCreateScreen.tsx
@@ -45,11 +45,16 @@ export function EpisodeTemplateCreateScreen() {
   const [listsLoading, setListsLoading] = useState(true);
   const [listsError, setListsError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  /** Matches initial field values so dirty detection works while preset lists are still loading. */
   const [formBaseline, setFormBaseline] = useState<{
     name: string;
     symptomId: string | null;
     markerId: string | null;
-  } | null>(null);
+  }>({
+    name: '',
+    symptomId: null,
+    markerId: null,
+  });
 
   useEffect(() => {
     let cancelled = false;
@@ -95,16 +100,13 @@ export function EpisodeTemplateCreateScreen() {
 
   const nameOk = useMemo(() => validateEpisodeTemplateName(name).ok, [name]);
 
-  const isDirty = useMemo(() => {
-    if (!formBaseline) {
-      return false;
-    }
-    return (
+  const isDirty = useMemo(
+    () =>
       name.trim() !== formBaseline.name.trim() ||
       symptomId !== formBaseline.symptomId ||
-      markerId !== formBaseline.markerId
-    );
-  }, [formBaseline, name, symptomId, markerId]);
+      markerId !== formBaseline.markerId,
+    [formBaseline, name, symptomId, markerId],
+  );
 
   const goToTemplateList = useCallback(() => {
     navigation.navigate('EpisodeTemplateList');

--- a/apps/mobile/src/app/screens/EpisodeTemplateEditorScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeTemplateEditorScreen.tsx
@@ -133,12 +133,7 @@ export function EpisodeTemplateEditorScreen() {
       onNavigateToList: goToTemplateList,
     });
 
-  useEpisodeTemplatesDraftRegistration(
-    status === 'ready',
-    isDirty,
-    busy,
-    goToTemplateList,
-  );
+  useEpisodeTemplatesDraftRegistration(true, isDirty, busy, goToTemplateList);
 
   const nameValidation = useMemo(
     () => validateEpisodeTemplateName(name),

--- a/apps/mobile/src/app/screens/EpisodeTemplateEditorScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeTemplateEditorScreen.tsx
@@ -14,6 +14,7 @@ import { announce } from '@abstrack/ui/native';
 import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
 import type { EpisodeTemplateWithPresetsRow } from '@abstrack/types';
 import {
+  normalizeEpisodeTemplateName,
   validateEpisodeTemplateName,
   validateEpisodeTemplatePresetPair,
 } from '@abstrack/types';
@@ -101,7 +102,7 @@ export function EpisodeTemplateEditorScreen() {
     }
     const t = tRes.data;
     setRow(t);
-    setName(t.name);
+    setName(normalizeEpisodeTemplateName(t.name));
     setSymptomId(t.symptom_preset_id);
     setMarkerId(t.health_marker_preset_id);
     setStatus('ready');
@@ -115,9 +116,10 @@ export function EpisodeTemplateEditorScreen() {
     if (!row) {
       return false;
     }
-    const nameTrimmed = name.trim();
+    const draftName = normalizeEpisodeTemplateName(name);
+    const storedName = normalizeEpisodeTemplateName(row.name);
     return (
-      nameTrimmed !== row.name ||
+      draftName !== storedName ||
       symptomId !== row.symptom_preset_id ||
       markerId !== row.health_marker_preset_id
     );
@@ -176,7 +178,7 @@ export function EpisodeTemplateEditorScreen() {
     const sid = symptomId as string;
     const hid = markerId as string;
     const unchanged =
-      nameCheck.name === row.name &&
+      nameCheck.name === normalizeEpisodeTemplateName(row.name) &&
       sid === row.symptom_preset_id &&
       hid === row.health_marker_preset_id;
     if (unchanged) {

--- a/apps/mobile/src/app/screens/EpisodeTemplateEditorScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeTemplateEditorScreen.tsx
@@ -1,0 +1,397 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { RouteProp } from '@react-navigation/native';
+import { announce } from '@abstrack/ui/native';
+import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
+import type { EpisodeTemplateWithPresetsRow } from '@abstrack/types';
+import {
+  validateEpisodeTemplateName,
+  validateEpisodeTemplatePresetPair,
+} from '@abstrack/types';
+import {
+  fetchEpisodeTemplateById,
+  removeEpisodeTemplate,
+  saveEpisodeTemplate,
+} from '../../lib/episode-templates/episode-template-service';
+import { fetchHealthMarkerPresets } from '../../lib/health-marker-presets/health-marker-preset-service';
+import { fetchSymptomPresets } from '../../lib/symptom-presets/symptom-preset-service';
+import { PresetOptionSheetField } from '../components/episode-templates/PresetOptionSheetField';
+import { AsyncScreenContainer } from '../components/AsyncScreenContainer';
+import { useUnsavedChangesBeforeRemove } from '../hooks/useUnsavedChangesBeforeRemove';
+import { useEpisodeTemplatesDraftRegistration } from '../navigation/EpisodeTemplatesDraftContext';
+import type { EpisodeTemplatesStackParamList } from '../navigation/types';
+import { useAppTheme } from '../theme/AppThemeContext';
+import { nw } from '../theme/app-nativewind-classes';
+
+type EditorNav = NativeStackNavigationProp<
+  EpisodeTemplatesStackParamList,
+  'EpisodeTemplateEdit'
+>;
+
+type EditorRoute = RouteProp<
+  EpisodeTemplatesStackParamList,
+  'EpisodeTemplateEdit'
+>;
+
+type PresetOption = { id: string; name: string };
+
+/**
+ * Edit an episode template: name and/or linked presets. Back, Cancel, and Android back prompt
+ * before discarding unsaved edits.
+ *
+ * @returns Edit screen bound to route `templateId`.
+ */
+export function EpisodeTemplateEditorScreen() {
+  const route = useRoute<EditorRoute>();
+  const { templateId } = route.params;
+  const navigation = useNavigation<EditorNav>();
+  const { colors } = useAppTheme();
+
+  const [status, setStatus] = useState<'loading' | 'error' | 'ready'>(
+    'loading',
+  );
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [row, setRow] = useState<EpisodeTemplateWithPresetsRow | null>(null);
+  const [name, setName] = useState('');
+  const [symptomId, setSymptomId] = useState<string | null>(null);
+  const [markerId, setMarkerId] = useState<string | null>(null);
+  const [symptoms, setSymptoms] = useState<PresetOption[]>([]);
+  const [markers, setMarkers] = useState<PresetOption[]>([]);
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    setStatus('loading');
+    setErrorMessage(null);
+    const [tRes, sRes, mRes] = await Promise.all([
+      fetchEpisodeTemplateById(templateId),
+      fetchSymptomPresets(),
+      fetchHealthMarkerPresets(),
+    ]);
+    if (!sRes.ok) {
+      setErrorMessage(sRes.error.message);
+      setStatus('error');
+      return;
+    }
+    if (!mRes.ok) {
+      setErrorMessage(mRes.error.message);
+      setStatus('error');
+      return;
+    }
+    setSymptoms(sRes.data.map((r) => ({ id: r.id, name: r.name })));
+    setMarkers(mRes.data.map((r) => ({ id: r.id, name: r.name })));
+
+    if (!tRes.ok) {
+      setErrorMessage(tRes.error.message);
+      setStatus('error');
+      return;
+    }
+    if (!tRes.data) {
+      setErrorMessage('We could not find that episode template.');
+      setStatus('error');
+      return;
+    }
+    const t = tRes.data;
+    setRow(t);
+    setName(t.name);
+    setSymptomId(t.symptom_preset_id);
+    setMarkerId(t.health_marker_preset_id);
+    setStatus('ready');
+  }, [templateId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const isDirty = useMemo(() => {
+    if (!row) {
+      return false;
+    }
+    const nameTrimmed = name.trim();
+    return (
+      nameTrimmed !== row.name ||
+      symptomId !== row.symptom_preset_id ||
+      markerId !== row.health_marker_preset_id
+    );
+  }, [row, name, symptomId, markerId]);
+
+  const goToTemplateList = useCallback(() => {
+    navigation.navigate('EpisodeTemplateList');
+  }, [navigation]);
+
+  const { prepareLeaveWithoutConfirmation, requestCancelToList } =
+    useUnsavedChangesBeforeRemove(isDirty && status === 'ready', navigation, {
+      busy,
+      onNavigateToList: goToTemplateList,
+    });
+
+  useEpisodeTemplatesDraftRegistration(
+    status === 'ready',
+    isDirty,
+    busy,
+    goToTemplateList,
+  );
+
+  const nameValidation = useMemo(
+    () => validateEpisodeTemplateName(name),
+    [name],
+  );
+
+  const canSave = useMemo(() => {
+    if (status !== 'ready' || !row || busy) {
+      return false;
+    }
+    if (!isDirty) {
+      return false;
+    }
+    if (!nameValidation.ok) {
+      return false;
+    }
+    if (symptomId == null || markerId == null) {
+      return false;
+    }
+    return true;
+  }, [busy, isDirty, markerId, nameValidation.ok, row, status, symptomId]);
+
+  const onSave = async () => {
+    if (!row) {
+      return;
+    }
+    const nameCheck = validateEpisodeTemplateName(name);
+    if (!nameCheck.ok) {
+      announce(nameCheck.message);
+      return;
+    }
+    const pair = validateEpisodeTemplatePresetPair(
+      symptomId ?? '',
+      markerId ?? '',
+    );
+    if (!pair.ok) {
+      announce(pair.message);
+      return;
+    }
+    const sid = symptomId as string;
+    const hid = markerId as string;
+    const unchanged =
+      nameCheck.name === row.name &&
+      sid === row.symptom_preset_id &&
+      hid === row.health_marker_preset_id;
+    if (unchanged) {
+      announce('No changes to save.');
+      return;
+    }
+    setBusy(true);
+    try {
+      const result = await saveEpisodeTemplate(row.id, {
+        name: nameCheck.name,
+        symptom_preset_id: sid,
+        health_marker_preset_id: hid,
+      });
+      if (!result.ok) {
+        announce(result.error.message);
+        return;
+      }
+      announce('Episode template saved.');
+      prepareLeaveWithoutConfirmation();
+      navigation.navigate('EpisodeTemplateList');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const confirmDelete = () => {
+    if (!row) {
+      return;
+    }
+    Alert.alert(
+      'Delete this episode template?',
+      `“${row.name}” will be removed. This cannot be undone.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: () => {
+            void (async () => {
+              setBusy(true);
+              try {
+                const result = await removeEpisodeTemplate(row.id);
+                if (!result.ok) {
+                  announce(result.error.message);
+                  return;
+                }
+                announce('Episode template deleted.');
+                prepareLeaveWithoutConfirmation();
+                navigation.navigate('EpisodeTemplateList');
+              } finally {
+                setBusy(false);
+              }
+            })();
+          },
+        },
+      ],
+    );
+  };
+
+  return (
+    <AsyncScreenContainer
+      status={status}
+      errorMessage={errorMessage ?? undefined}
+      onRetry={() => {
+        void load();
+      }}
+    >
+      {row ? (
+        <ScrollView
+          className="flex-1"
+          contentContainerStyle={{
+            flexGrow: 1,
+            padding: 16,
+            paddingBottom: 24,
+          }}
+          keyboardShouldPersistTaps="handled"
+        >
+          <Text
+            className={`text-base ${nw.textMuted}`}
+            maxFontSizeMultiplier={2}
+          >
+            Update the name or tap a preset row to pick from a list. Save when
+            you are done — you will return to the list after a successful save.
+          </Text>
+
+          <View className="mt-6 gap-2">
+            <Text
+              className={`text-base font-semibold ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            >
+              Template name
+            </Text>
+            <TextInput
+              value={name}
+              onChangeText={setName}
+              editable={!busy}
+              placeholderTextColor={colors.inputPlaceholder}
+              className={`rounded-[10px] px-3 py-3 text-[17px] ${nw.input}`}
+              style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+              autoCapitalize="sentences"
+              maxFontSizeMultiplier={2}
+              accessibilityLabel="Episode template name"
+            />
+          </View>
+
+          <View className="mt-8">
+            <PresetOptionSheetField
+              label="Symptom preset"
+              placeholderLabel="Tap to choose a symptom preset…"
+              options={symptoms}
+              value={symptomId}
+              onValueChange={setSymptomId}
+              disabled={busy}
+              hint="Opens a list from the bottom of the screen."
+            />
+          </View>
+
+          <View className="mt-6">
+            <PresetOptionSheetField
+              label="Health marker preset"
+              placeholderLabel="Tap to choose a health marker preset…"
+              options={markers}
+              value={markerId}
+              onValueChange={setMarkerId}
+              disabled={busy}
+              hint="Pick which marker preset pairs with this template."
+            />
+          </View>
+
+          {!isDirty ? (
+            <Text
+              className={`mt-4 text-sm ${nw.textMuted}`}
+              accessibilityRole="text"
+              maxFontSizeMultiplier={2}
+            >
+              Change something above to enable save, use Cancel to go back, or
+              use Delete to remove this template.
+            </Text>
+          ) : null}
+
+          {!nameValidation.ok && name.trim().length > 0 ? (
+            <Text
+              className={`mt-2 text-sm ${nw.textError}`}
+              accessibilityRole="alert"
+              maxFontSizeMultiplier={2}
+            >
+              {nameValidation.message}
+            </Text>
+          ) : null}
+
+          <View className="mt-8 gap-3">
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Save changes"
+              accessibilityState={{ disabled: !canSave }}
+              disabled={!canSave}
+              onPress={() => void onSave()}
+              className={`items-center justify-center rounded-[12px] px-4 active:opacity-90 ${nw.btnPrimary}`}
+              style={{
+                minHeight: COMFORTABLE_TOUCH_TARGET_DP,
+                opacity: canSave ? 1 : 0.45,
+              }}
+            >
+              <Text
+                className={`text-[17px] font-semibold ${nw.textOnPrimary}`}
+                maxFontSizeMultiplier={2}
+              >
+                {busy ? 'Saving…' : 'Save changes'}
+              </Text>
+            </Pressable>
+
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Cancel without saving, return to episode templates"
+              accessibilityHint="If you have unsaved changes, you will be asked to confirm."
+              accessibilityState={{ disabled: busy }}
+              disabled={busy}
+              onPress={requestCancelToList}
+              className={`items-center justify-center rounded-[12px] border px-4 active:opacity-90 ${nw.btnSecondary}`}
+              style={{
+                minHeight: COMFORTABLE_TOUCH_TARGET_DP,
+                opacity: busy ? 0.45 : 1,
+              }}
+            >
+              <Text
+                className={`text-[17px] font-semibold ${nw.textInk}`}
+                maxFontSizeMultiplier={2}
+              >
+                Cancel
+              </Text>
+            </Pressable>
+          </View>
+
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Delete episode template"
+            disabled={busy}
+            onPress={confirmDelete}
+            className="mt-4 items-center justify-center rounded-[12px] border border-red-300 bg-red-50 px-4 py-3 dark:border-red-800 dark:bg-red-950/40"
+            style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+          >
+            <Text
+              className="text-[17px] font-semibold text-red-800 dark:text-red-200"
+              maxFontSizeMultiplier={2}
+            >
+              Delete template
+            </Text>
+          </Pressable>
+        </ScrollView>
+      ) : null}
+    </AsyncScreenContainer>
+  );
+}

--- a/apps/mobile/src/app/screens/EpisodeTemplateListScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/EpisodeTemplateListScreen.spec.tsx
@@ -1,0 +1,211 @@
+import * as React from 'react';
+import { Alert } from 'react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { DefaultTheme } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
+import { PresetDataError } from '@abstrack/supabase';
+import type { EpisodeTemplateWithPresetsRow } from '@abstrack/types';
+
+import {
+  fetchEpisodeTemplates,
+  getCurrentUserId,
+  removeEpisodeTemplate,
+} from '../../lib/episode-templates/episode-template-service';
+import { useAppTheme } from '../theme/AppThemeContext';
+import { lightAppColors } from '../theme/app-colors';
+import { EpisodeTemplateListScreen } from './EpisodeTemplateListScreen';
+
+jest.mock('@react-navigation/native', () => {
+  const React = require('react');
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: jest.fn(),
+    useFocusEffect: (fn: () => void) => {
+      React.useEffect(() => {
+        fn();
+      }, [fn]);
+    },
+  };
+});
+
+jest.mock('../theme/AppThemeContext', () => ({
+  useAppTheme: jest.fn(),
+}));
+
+jest.mock('@abstrack/ui/native', () => {
+  const actual = jest.requireActual('@abstrack/ui/native');
+  return {
+    ...actual,
+    announce: jest.fn(),
+  };
+});
+
+jest.mock('../../lib/episode-templates/episode-template-service', () => ({
+  getCurrentUserId: jest.fn(),
+  fetchEpisodeTemplates: jest.fn(),
+  removeEpisodeTemplate: jest.fn(),
+}));
+
+const templateRow: EpisodeTemplateWithPresetsRow = {
+  id: 'et-1',
+  user_id: 'user-1',
+  name: 'ABS Episode',
+  symptom_preset_id: 'sp-1',
+  health_marker_preset_id: 'hm-1',
+  created_at: '2020-01-01T00:00:00Z',
+  updated_at: '2020-01-01T00:00:00Z',
+  symptom_preset: { id: 'sp-1', name: 'My symptoms' },
+  health_marker_preset: { id: 'hm-1', name: 'My markers' },
+};
+
+describe('EpisodeTemplateListScreen', () => {
+  const mockNavigate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.mocked(useNavigation).mockReturnValue({
+      navigate: mockNavigate,
+    } as never);
+
+    jest.mocked(useAppTheme).mockReturnValue({
+      colorScheme: 'light',
+      colors: lightAppColors,
+      themePreference: 'system',
+      setThemePreference: jest.fn(() => Promise.resolve()),
+      navigationTheme: DefaultTheme,
+      statusBarStyle: 'dark',
+    });
+
+    jest
+      .mocked(getCurrentUserId)
+      .mockResolvedValue({ ok: true, data: 'user-1' });
+    jest
+      .mocked(fetchEpisodeTemplates)
+      .mockResolvedValue({ ok: true, data: [] });
+    jest
+      .mocked(removeEpisodeTemplate)
+      .mockResolvedValue({ ok: true, data: undefined });
+
+    mockNavigate.mockReset();
+  });
+
+  test('renders empty state when signed in and there are no templates', async () => {
+    const screen = render(<EpisodeTemplateListScreen />);
+
+    expect(
+      await screen.findByTestId('episode-template-list-screen'),
+    ).toBeTruthy();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /Episode templates pair one symptom preset with one health marker preset/,
+        ),
+      ).toBeTruthy();
+    });
+
+    expect(getCurrentUserId).toHaveBeenCalled();
+    expect(fetchEpisodeTemplates).toHaveBeenCalled();
+  });
+
+  test('shows signed-out message when getCurrentUserId returns no user', async () => {
+    jest.mocked(getCurrentUserId).mockResolvedValue({ ok: true, data: null });
+
+    const screen = render(<EpisodeTemplateListScreen />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'You need to be signed in to manage episode templates.',
+        ),
+      ).toBeTruthy();
+    });
+
+    expect(fetchEpisodeTemplates).not.toHaveBeenCalled();
+  });
+
+  test('shows auth error message when getCurrentUserId fails', async () => {
+    jest.mocked(getCurrentUserId).mockResolvedValue({
+      ok: false,
+      error: new PresetDataError(
+        'network_error',
+        'Could not reach the server. Check your connection and try again.',
+      ),
+    });
+
+    const screen = render(<EpisodeTemplateListScreen />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Could not reach the server. Check your connection and try again.',
+        ),
+      ).toBeTruthy();
+    });
+
+    expect(fetchEpisodeTemplates).not.toHaveBeenCalled();
+  });
+
+  test('renders template rows when data is returned', async () => {
+    jest
+      .mocked(fetchEpisodeTemplates)
+      .mockResolvedValue({ ok: true, data: [templateRow] });
+
+    const screen = render(<EpisodeTemplateListScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('ABS Episode')).toBeTruthy();
+    });
+
+    expect(
+      screen.getByLabelText(
+        'Edit template ABS Episode. Symptoms My symptoms, markers My markers',
+      ),
+    ).toBeTruthy();
+  });
+
+  test('pressing delete opens confirmation and removeEpisodeTemplate runs on confirm, then reloads', async () => {
+    jest
+      .mocked(fetchEpisodeTemplates)
+      .mockResolvedValue({ ok: true, data: [templateRow] });
+
+    const alertSpy = jest.spyOn(Alert, 'alert');
+
+    const screen = render(<EpisodeTemplateListScreen />);
+
+    await screen.findByText('ABS Episode');
+
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText('Delete template ABS Episode'));
+    });
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Delete this episode template?',
+      expect.stringContaining('ABS Episode'),
+      expect.any(Array),
+    );
+
+    const buttons = alertSpy.mock.calls[0][2] as {
+      text?: string;
+      onPress?: () => void;
+    }[];
+    const deleteAction = buttons.find((b) => b.text === 'Delete');
+    expect(deleteAction?.onPress).toBeDefined();
+
+    await act(async () => {
+      deleteAction?.onPress?.();
+    });
+
+    await waitFor(() => {
+      expect(removeEpisodeTemplate).toHaveBeenCalledWith('et-1');
+    });
+
+    await waitFor(() => {
+      expect(fetchEpisodeTemplates).toHaveBeenCalledTimes(2);
+    });
+
+    alertSpy.mockRestore();
+  });
+});

--- a/apps/mobile/src/app/screens/EpisodeTemplateListScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeTemplateListScreen.tsx
@@ -1,0 +1,221 @@
+import React, { useCallback, useState } from 'react';
+import { Alert, Pressable, ScrollView, Text, View } from 'react-native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { Ionicons } from '@expo/vector-icons';
+import type { EpisodeTemplateWithPresetsRow } from '@abstrack/types';
+import { announce } from '@abstrack/ui/native';
+import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
+import {
+  fetchEpisodeTemplates,
+  getCurrentUserId,
+  removeEpisodeTemplate,
+} from '../../lib/episode-templates/episode-template-service';
+import { AsyncScreenContainer } from '../components/AsyncScreenContainer';
+import type { EpisodeTemplatesStackParamList } from '../navigation/types';
+import { useAppTheme } from '../theme/AppThemeContext';
+import { nw } from '../theme/app-nativewind-classes';
+
+/** Token for focus-scoped list loads. */
+type FocusLoadCancel = { cancelled: boolean };
+
+type ListNav = NativeStackNavigationProp<
+  EpisodeTemplatesStackParamList,
+  'EpisodeTemplateList'
+>;
+
+/**
+ * Lists episode templates (named symptom + health marker pairings).
+ *
+ * @returns List screen for the Episode templates tab stack.
+ */
+export function EpisodeTemplateListScreen() {
+  const navigation = useNavigation<ListNav>();
+  const { colors } = useAppTheme();
+  const [status, setStatus] = useState<'loading' | 'error' | 'ready'>(
+    'loading',
+  );
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [rows, setRows] = useState<EpisodeTemplateWithPresetsRow[]>([]);
+
+  const load = useCallback(async (focusCancel?: FocusLoadCancel) => {
+    const stale = () => focusCancel?.cancelled === true;
+
+    setStatus('loading');
+    setErrorMessage(null);
+    const authResult = await getCurrentUserId();
+    if (stale()) {
+      return;
+    }
+    if (!authResult.ok) {
+      setErrorMessage(authResult.error.message);
+      setStatus('error');
+      return;
+    }
+    if (authResult.data === null) {
+      setErrorMessage('You need to be signed in to manage episode templates.');
+      setStatus('error');
+      return;
+    }
+    const result = await fetchEpisodeTemplates();
+    if (stale()) {
+      return;
+    }
+    if (!result.ok) {
+      setErrorMessage(result.error.message);
+      setStatus('error');
+      return;
+    }
+    setRows(result.data);
+    setStatus('ready');
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      const focusCancel: FocusLoadCancel = { cancelled: false };
+      void load(focusCancel);
+      return () => {
+        focusCancel.cancelled = true;
+      };
+    }, [load]),
+  );
+
+  const confirmDelete = (template: EpisodeTemplateWithPresetsRow) => {
+    Alert.alert(
+      'Delete this episode template?',
+      `“${template.name}” will be removed. This cannot be undone.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: () => {
+            void (async () => {
+              const result = await removeEpisodeTemplate(template.id);
+              if (!result.ok) {
+                announce(result.error.message);
+                return;
+              }
+              announce('Episode template deleted.');
+              await load();
+            })();
+          },
+        },
+      ],
+    );
+  };
+
+  return (
+    <AsyncScreenContainer
+      status={status}
+      errorMessage={errorMessage ?? undefined}
+      onRetry={() => {
+        void load();
+      }}
+    >
+      <ScrollView
+        testID="episode-template-list-screen"
+        className="flex-1"
+        contentContainerStyle={{
+          flexGrow: 1,
+          padding: 16,
+          paddingBottom: 24,
+        }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Add episode template"
+          onPress={() => {
+            navigation.navigate('EpisodeTemplateCreate');
+          }}
+          className={`mb-4 items-center justify-center rounded-[12px] px-4 active:opacity-90 ${nw.btnPrimary}`}
+          style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+        >
+          <Text
+            className={`text-[17px] font-semibold ${nw.textOnPrimary}`}
+            maxFontSizeMultiplier={2}
+          >
+            Add template
+          </Text>
+        </Pressable>
+
+        {rows.length === 0 ? (
+          <View
+            className={`rounded-xl p-4 ${nw.card}`}
+            accessibilityRole="text"
+          >
+            <Text
+              className={`text-base leading-6 ${nw.textMuted}`}
+              maxFontSizeMultiplier={2}
+            >
+              Episode templates pair one symptom preset with one health marker
+              preset under a name you will recognize when impaired (for example
+              “ABS Episode”). Create symptom and marker presets first, then add
+              a template here.
+            </Text>
+          </View>
+        ) : (
+          <View className="gap-3" accessibilityRole="list">
+            {rows.map((template) => (
+              <View
+                key={template.id}
+                className={`flex-row items-stretch overflow-hidden rounded-xl ${nw.card}`}
+                accessibilityRole="none"
+              >
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={`Edit template ${template.name}. Symptoms ${template.symptom_preset.name}, markers ${template.health_marker_preset.name}`}
+                  onPress={() => {
+                    navigation.navigate('EpisodeTemplateEdit', {
+                      templateId: template.id,
+                    });
+                  }}
+                  className="min-w-0 flex-1 px-4 py-3 active:opacity-90"
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                >
+                  <Text
+                    className={`text-[17px] font-semibold ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                    numberOfLines={2}
+                  >
+                    {template.name}
+                  </Text>
+                  <Text
+                    className={`mt-1 text-sm ${nw.textMuted}`}
+                    maxFontSizeMultiplier={2}
+                    numberOfLines={3}
+                  >
+                    Symptoms: {template.symptom_preset.name} · Markers:{' '}
+                    {template.health_marker_preset.name}
+                  </Text>
+                </Pressable>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={`Delete template ${template.name}`}
+                  onPress={() => {
+                    confirmDelete(template);
+                  }}
+                  className="items-center justify-center px-4 active:opacity-80"
+                  style={{
+                    minWidth: COMFORTABLE_TOUCH_TARGET_DP,
+                    minHeight: COMFORTABLE_TOUCH_TARGET_DP,
+                  }}
+                  hitSlop={{ top: 8, bottom: 8, left: 4, right: 8 }}
+                >
+                  <Ionicons
+                    name="trash-outline"
+                    size={24}
+                    color={colors.muted}
+                    accessibilityElementsHidden
+                    importantForAccessibility="no"
+                  />
+                </Pressable>
+              </View>
+            ))}
+          </View>
+        )}
+      </ScrollView>
+    </AsyncScreenContainer>
+  );
+}

--- a/apps/mobile/src/lib/episode-templates/episode-template-service.ts
+++ b/apps/mobile/src/lib/episode-templates/episode-template-service.ts
@@ -1,0 +1,65 @@
+/**
+ * Mobile episode template operations: persistence only through `@abstrack/supabase` helpers.
+ */
+import type {
+  EpisodeTemplateInsert,
+  EpisodeTemplateUpdate,
+} from '@abstrack/types';
+import type { PresetDataResult } from '@abstrack/supabase';
+import {
+  createEpisodeTemplate,
+  deleteEpisodeTemplate,
+  getEpisodeTemplateById,
+  getAuthUser,
+  listEpisodeTemplates,
+  toPresetDataError,
+  updateEpisodeTemplate,
+} from '@abstrack/supabase';
+import { getMobileSupabaseClient } from '../supabase-wiring';
+
+/**
+ * Resolves the signed-in user id for template saves (same pattern as symptom preset service).
+ *
+ * @returns User id, null when signed out, or an error when the auth lookup fails.
+ */
+export async function getCurrentUserId(): Promise<
+  PresetDataResult<string | null>
+> {
+  try {
+    const {
+      data: { user },
+      error,
+    } = await getAuthUser(getMobileSupabaseClient());
+    if (error) {
+      return { ok: false, error: toPresetDataError(error) };
+    }
+    return { ok: true, data: user?.id ?? null };
+  } catch (caught) {
+    return { ok: false, error: toPresetDataError(caught) };
+  }
+}
+
+/** Lists episode templates with nested preset names. */
+export function fetchEpisodeTemplates() {
+  return listEpisodeTemplates(getMobileSupabaseClient());
+}
+
+/** Fetches one template by id with nested names. */
+export function fetchEpisodeTemplateById(id: string) {
+  return getEpisodeTemplateById(getMobileSupabaseClient(), id);
+}
+
+/** Creates a template row. */
+export function saveNewEpisodeTemplate(row: EpisodeTemplateInsert) {
+  return createEpisodeTemplate(getMobileSupabaseClient(), row);
+}
+
+/** Updates a template. */
+export function saveEpisodeTemplate(id: string, patch: EpisodeTemplateUpdate) {
+  return updateEpisodeTemplate(getMobileSupabaseClient(), id, patch);
+}
+
+/** Deletes a template. */
+export function removeEpisodeTemplate(id: string) {
+  return deleteEpisodeTemplate(getMobileSupabaseClient(), id);
+}

--- a/apps/web/src/app/(app)/presets/episode-templates/[id]/page.tsx
+++ b/apps/web/src/app/(app)/presets/episode-templates/[id]/page.tsx
@@ -1,0 +1,17 @@
+import { EpisodeTemplateEditorPage } from '@/components/episode-templates/EpisodeTemplateEditorPage';
+
+type PageProps = {
+  /** Next.js 16 passes dynamic route params as a Promise (await before use). */
+  params: Promise<{ id: string }>;
+};
+
+/**
+ * Edit one episode template.
+ *
+ * @param props - Next.js route params.
+ * @returns Editor route content.
+ */
+export default async function EpisodeTemplateDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  return <EpisodeTemplateEditorPage templateId={id} />;
+}

--- a/apps/web/src/app/(app)/presets/episode-templates/error.tsx
+++ b/apps/web/src/app/(app)/presets/episode-templates/error.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useEffect } from 'react';
+import { PageError } from '@/components/page-states/PageError';
+import { getPublicErrorBoundaryMessage } from '@/lib/public-error-message';
+
+/**
+ * Segment error boundary for episode templates routes.
+ *
+ * @param props - Next.js `error` boundary props.
+ * @returns Recoverable error UI.
+ */
+export default function EpisodeTemplatesError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <PageError
+      title="Could not load episode templates"
+      message={getPublicErrorBoundaryMessage(error)}
+      onRetry={reset}
+    />
+  );
+}

--- a/apps/web/src/app/(app)/presets/episode-templates/loading.tsx
+++ b/apps/web/src/app/(app)/presets/episode-templates/loading.tsx
@@ -1,0 +1,10 @@
+import { PageLoading } from '@/components/page-states/PageLoading';
+
+/**
+ * Route-level loading UI for episode templates.
+ *
+ * @returns Loading fallback.
+ */
+export default function EpisodeTemplatesLoading() {
+  return <PageLoading title="Episode templates" />;
+}

--- a/apps/web/src/app/(app)/presets/episode-templates/new/page.tsx
+++ b/apps/web/src/app/(app)/presets/episode-templates/new/page.tsx
@@ -1,0 +1,10 @@
+import { EpisodeTemplateCreateForm } from '@/components/episode-templates/EpisodeTemplateCreateForm';
+
+/**
+ * Create a new episode template (symptom preset + health marker preset + display name).
+ *
+ * @returns Create route content.
+ */
+export default function NewEpisodeTemplatePage() {
+  return <EpisodeTemplateCreateForm />;
+}

--- a/apps/web/src/app/(app)/presets/episode-templates/page.tsx
+++ b/apps/web/src/app/(app)/presets/episode-templates/page.tsx
@@ -1,0 +1,10 @@
+import { EpisodeTemplatesListPage } from '@/components/episode-templates/EpisodeTemplatesListPage';
+
+/**
+ * Episode templates settings: list named pairings of symptom + health marker presets.
+ *
+ * @returns List route content.
+ */
+export default function EpisodeTemplatesPage() {
+  return <EpisodeTemplatesListPage />;
+}

--- a/apps/web/src/app/(public)/page.tsx
+++ b/apps/web/src/app/(public)/page.tsx
@@ -51,6 +51,12 @@ export default function Index() {
             >
               Health marker presets
             </Link>
+            <Link
+              href="/presets/episode-templates"
+              className="block w-full rounded-full border border-app-border bg-app-surface py-3 text-center text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+            >
+              Episode templates
+            </Link>
             <form action="/api/auth/logout" method="POST">
               <button
                 type="submit"

--- a/apps/web/src/components/app-shell/AuthenticatedShell.tsx
+++ b/apps/web/src/components/app-shell/AuthenticatedShell.tsx
@@ -28,6 +28,13 @@ const NAV_ITEMS: {
       path === '/presets/health-markers' ||
       path.startsWith('/presets/health-markers/'),
   },
+  {
+    href: '/presets/episode-templates',
+    label: 'Episode templates',
+    match: (path) =>
+      path === '/presets/episode-templates' ||
+      path.startsWith('/presets/episode-templates/'),
+  },
 ];
 
 function isNavActive(pathname: string, match: (path: string) => boolean) {

--- a/apps/web/src/components/episode-templates/EpisodeTemplateCreateForm.tsx
+++ b/apps/web/src/components/episode-templates/EpisodeTemplateCreateForm.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import {
+  validateEpisodeTemplateName,
+  validateEpisodeTemplatePresetPair,
+} from '@abstrack/types';
+import {
+  createEpisodeTemplate,
+  listHealthMarkerPresets,
+  listSymptomPresets,
+} from '@abstrack/supabase';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import { createBrowserClient } from '@/lib/supabase/browser-client';
+import { useAuth } from '@/lib/auth-provider';
+
+/**
+ * Form to create an episode template: display name plus paired symptom and health marker presets.
+ *
+ * @returns Create episode template page content.
+ */
+export function EpisodeTemplateCreateForm() {
+  const router = useRouter();
+  const { session, loading: authLoading } = useAuth();
+  const { announce } = useAnnounce();
+  const [name, setName] = useState('');
+  const [symptomPresetId, setSymptomPresetId] = useState('');
+  const [healthMarkerPresetId, setHealthMarkerPresetId] = useState('');
+  const [symptomOptions, setSymptomOptions] = useState<
+    { id: string; name: string }[]
+  >([]);
+  const [markerOptions, setMarkerOptions] = useState<
+    { id: string; name: string }[]
+  >([]);
+  const [listsLoading, setListsLoading] = useState(true);
+  const [listsError, setListsError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (authLoading || !session?.user.id) {
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      setListsLoading(true);
+      setListsError(null);
+      const supabase = createBrowserClient();
+      const [symRes, hmRes] = await Promise.all([
+        listSymptomPresets(supabase),
+        listHealthMarkerPresets(supabase),
+      ]);
+      if (cancelled) {
+        return;
+      }
+      if (!symRes.ok) {
+        setListsError(symRes.error.message);
+        setListsLoading(false);
+        return;
+      }
+      if (!hmRes.ok) {
+        setListsError(hmRes.error.message);
+        setListsLoading(false);
+        return;
+      }
+      setSymptomOptions(symRes.data.map((r) => ({ id: r.id, name: r.name })));
+      setMarkerOptions(hmRes.data.map((r) => ({ id: r.id, name: r.name })));
+      setListsLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [authLoading, session?.user.id]);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!session?.user.id) {
+      setError('You must be signed in to create a template.');
+      return;
+    }
+    const nameCheck = validateEpisodeTemplateName(name);
+    if (!nameCheck.ok) {
+      setError(nameCheck.message);
+      announce(nameCheck.message, { politeness: 'assertive' });
+      return;
+    }
+    const pair = validateEpisodeTemplatePresetPair(
+      symptomPresetId,
+      healthMarkerPresetId,
+    );
+    if (!pair.ok) {
+      setError(pair.message);
+      announce(pair.message, { politeness: 'assertive' });
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    const supabase = createBrowserClient();
+    const result = await createEpisodeTemplate(supabase, {
+      user_id: session.user.id,
+      name: nameCheck.name,
+      symptom_preset_id: symptomPresetId,
+      health_marker_preset_id: healthMarkerPresetId,
+    });
+    setSaving(false);
+    if (!result.ok) {
+      setError(result.error.message);
+      announce(result.error.message, { politeness: 'assertive' });
+      return;
+    }
+    announce('Episode template saved.', { politeness: 'polite' });
+    router.push('/presets/episode-templates');
+  };
+
+  if (authLoading) {
+    return (
+      <div className="w-full space-y-4">
+        <p className="text-sm text-app-muted">Loading…</p>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div role="alert" className="text-sm text-red-700 dark:text-red-300">
+        You must be signed in to create a template.
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full space-y-8">
+      <div>
+        <Link
+          href="/presets/episode-templates"
+          className="text-sm font-medium text-app-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+        >
+          ← Back to episode templates
+        </Link>
+        <h1 className="mt-4 text-2xl font-bold tracking-tight text-app-ink">
+          New episode template
+        </h1>
+        <p className="mt-1 text-sm text-app-muted">
+          Choose a clear name and which symptom list and marker list belong
+          together. This pairing is saved explicitly — similar preset names do
+          not link automatically.
+        </p>
+      </div>
+
+      {listsLoading ? (
+        <p className="text-sm text-app-muted">Loading your presets…</p>
+      ) : null}
+      {listsError ? (
+        <div
+          role="alert"
+          className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-800/60 dark:bg-red-950/35 dark:text-red-200"
+        >
+          {listsError}
+        </div>
+      ) : null}
+
+      <form
+        onSubmit={(e) => {
+          void onSubmit(e);
+        }}
+        className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
+        noValidate
+      >
+        <div className="space-y-6">
+          <div className="space-y-2">
+            <label
+              htmlFor="episode-template-name"
+              className="text-sm font-medium text-app-ink"
+            >
+              Template name
+            </label>
+            <input
+              id="episode-template-name"
+              name="episodeTemplateName"
+              type="text"
+              autoComplete="off"
+              required
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+              }}
+              className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-bg px-3 text-app-ink shadow-inner outline-none transition placeholder:text-app-muted focus-visible:ring-2 focus-visible:ring-app-ring"
+              placeholder='e.g. "ABS Episode"'
+              aria-describedby="episode-template-name-hint"
+            />
+            <p
+              id="episode-template-name-hint"
+              className="text-sm text-app-muted"
+            >
+              This is the label you will tap when starting an episode — keep it
+              short and familiar.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <label
+              htmlFor="episode-template-symptom-preset"
+              className="text-sm font-medium text-app-ink"
+            >
+              Symptom preset
+            </label>
+            <select
+              id="episode-template-symptom-preset"
+              name="symptomPresetId"
+              value={symptomPresetId}
+              onChange={(e) => {
+                setSymptomPresetId(e.target.value);
+              }}
+              required
+              className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-bg px-3 text-app-ink shadow-inner outline-none transition focus-visible:ring-2 focus-visible:ring-app-ring"
+            >
+              <option value="">Select a symptom preset…</option>
+              {symptomOptions.map((o) => (
+                <option key={o.id} value={o.id}>
+                  {o.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-2">
+            <label
+              htmlFor="episode-template-marker-preset"
+              className="text-sm font-medium text-app-ink"
+            >
+              Health marker preset
+            </label>
+            <select
+              id="episode-template-marker-preset"
+              name="healthMarkerPresetId"
+              value={healthMarkerPresetId}
+              onChange={(e) => {
+                setHealthMarkerPresetId(e.target.value);
+              }}
+              required
+              className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-bg px-3 text-app-ink shadow-inner outline-none transition focus-visible:ring-2 focus-visible:ring-app-ring"
+            >
+              <option value="">Select a health marker preset…</option>
+              {markerOptions.map((o) => (
+                <option key={o.id} value={o.id}>
+                  {o.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {error ? (
+          <div
+            role="alert"
+            className="mt-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-800/60 dark:bg-red-950/35 dark:text-red-200"
+          >
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-8 flex flex-wrap gap-3">
+          <button
+            type="submit"
+            disabled={saving || listsLoading || !!listsError}
+            className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-app-primary px-5 text-sm font-semibold text-white shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60"
+          >
+            {saving ? 'Saving…' : 'Save template'}
+          </button>
+          <Link
+            href="/presets/episode-templates"
+            className="inline-flex min-h-[44px] items-center justify-center rounded-full border border-app-border bg-app-bg px-5 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          >
+            Cancel
+          </Link>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/components/episode-templates/EpisodeTemplateCreateForm.tsx
+++ b/apps/web/src/components/episode-templates/EpisodeTemplateCreateForm.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   validateEpisodeTemplateName,
   validateEpisodeTemplatePresetPair,
@@ -15,6 +14,11 @@ import {
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { useAuth } from '@/lib/auth-provider';
+import {
+  useUnsavedChangesLeaveGuard,
+  type PendingLeaveAction,
+} from '@/lib/use-unsaved-changes-leave-guard';
+import { ConfirmDialog } from '../symptom-presets/ConfirmDialog';
 
 /**
  * Form to create an episode template: display name plus paired symptom and health marker presets.
@@ -38,6 +42,73 @@ export function EpisodeTemplateCreateForm() {
   const [listsError, setListsError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [discardDialogOpen, setDiscardDialogOpen] = useState(false);
+  const pendingLeaveRef = useRef<PendingLeaveAction | null>(null);
+
+  const isDirty = useMemo(() => {
+    const nameTrimmed = name.trim();
+    return (
+      nameTrimmed !== '' ||
+      symptomPresetId !== '' ||
+      healthMarkerPresetId !== ''
+    );
+  }, [name, symptomPresetId, healthMarkerPresetId]);
+
+  const onRequestDiscardDialog = useCallback(() => {
+    setDiscardDialogOpen(true);
+  }, []);
+
+  useUnsavedChangesLeaveGuard({
+    active: isDirty && !!session,
+    blockIntercepts: saving,
+    dialogOpen: discardDialogOpen,
+    pendingLeaveRef,
+    onRequestDiscard: onRequestDiscardDialog,
+    exemptFormId: 'episode-template-create-form',
+  });
+
+  const navigateToTemplatesList = useCallback(() => {
+    router.push('/presets/episode-templates');
+  }, [router]);
+
+  const handleDiscardConfirm = useCallback(() => {
+    const action = pendingLeaveRef.current;
+    pendingLeaveRef.current = null;
+
+    if (!action) {
+      router.push('/presets/episode-templates');
+      return;
+    }
+    if (action.kind === 'form') {
+      action.form.submit();
+      return;
+    }
+    const { href } = action;
+    let url: URL;
+    try {
+      url = new URL(href, window.location.origin);
+    } catch {
+      router.push('/presets/episode-templates');
+      return;
+    }
+    if (url.origin !== window.location.origin) {
+      window.location.assign(href);
+      return;
+    }
+    router.push(`${url.pathname}${url.search}${url.hash}`);
+  }, [router]);
+
+  const requestLeaveCreate = useCallback(() => {
+    if (!isDirty) {
+      navigateToTemplatesList();
+      return;
+    }
+    pendingLeaveRef.current = {
+      kind: 'href',
+      href: '/presets/episode-templates',
+    };
+    setDiscardDialogOpen(true);
+  }, [isDirty, navigateToTemplatesList]);
 
   useEffect(() => {
     if (authLoading || !session?.user.id) {
@@ -133,12 +204,16 @@ export function EpisodeTemplateCreateForm() {
   return (
     <div className="w-full space-y-8">
       <div>
-        <Link
-          href="/presets/episode-templates"
-          className="text-sm font-medium text-app-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+        <button
+          type="button"
+          disabled={saving}
+          onClick={() => {
+            requestLeaveCreate();
+          }}
+          className="text-left text-sm font-medium text-app-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
         >
           ← Back to episode templates
-        </Link>
+        </button>
         <h1 className="mt-4 text-2xl font-bold tracking-tight text-app-ink">
           New episode template
         </h1>
@@ -162,6 +237,7 @@ export function EpisodeTemplateCreateForm() {
       ) : null}
 
       <form
+        id="episode-template-create-form"
         onSubmit={(e) => {
           void onSubmit(e);
         }}
@@ -269,14 +345,33 @@ export function EpisodeTemplateCreateForm() {
           >
             {saving ? 'Saving…' : 'Save template'}
           </button>
-          <Link
-            href="/presets/episode-templates"
-            className="inline-flex min-h-[44px] items-center justify-center rounded-full border border-app-border bg-app-bg px-5 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          <button
+            type="button"
+            disabled={saving}
+            className="inline-flex min-h-[44px] items-center justify-center rounded-full border border-app-border bg-app-bg px-5 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60"
+            onClick={() => {
+              requestLeaveCreate();
+            }}
           >
             Cancel
-          </Link>
+          </button>
         </div>
       </form>
+
+      <ConfirmDialog
+        open={discardDialogOpen}
+        title="Discard unsaved changes?"
+        description="You have edits that are not saved yet. If you leave now, those changes will be lost."
+        confirmLabel="Discard changes"
+        cancelLabel="Keep editing"
+        onConfirm={() => {
+          handleDiscardConfirm();
+        }}
+        onClose={() => {
+          pendingLeaveRef.current = null;
+          setDiscardDialogOpen(false);
+        }}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/episode-templates/EpisodeTemplateEditorPage.tsx
+++ b/apps/web/src/components/episode-templates/EpisodeTemplateEditorPage.tsx
@@ -109,6 +109,12 @@ export function EpisodeTemplateEditorPage({
     void refresh();
   }, [authLoading, session, refresh]);
 
+  useEffect(() => {
+    if (saving && deleteOpen) {
+      setDeleteOpen(false);
+    }
+  }, [saving, deleteOpen]);
+
   const isDirty = useMemo(() => {
     if (!row) {
       return false;
@@ -419,8 +425,8 @@ export function EpisodeTemplateEditorPage({
           </button>
           <button
             type="button"
-            className="inline-flex min-h-[44px] items-center justify-center rounded-full border border-red-200 bg-red-50 px-5 text-sm font-semibold text-red-800 shadow-sm transition hover:bg-red-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-200 dark:hover:bg-red-950/60"
-            disabled={deleting}
+            className="inline-flex min-h-[44px] items-center justify-center rounded-full border border-red-200 bg-red-50 px-5 text-sm font-semibold text-red-800 shadow-sm transition hover:bg-red-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-200 dark:hover:bg-red-950/60"
+            disabled={saving || deleting}
             onClick={() => {
               setDeleteOpen(true);
             }}

--- a/apps/web/src/components/episode-templates/EpisodeTemplateEditorPage.tsx
+++ b/apps/web/src/components/episode-templates/EpisodeTemplateEditorPage.tsx
@@ -1,0 +1,459 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { EpisodeTemplateWithPresetsRow } from '@abstrack/types';
+import {
+  validateEpisodeTemplateName,
+  validateEpisodeTemplatePresetPair,
+} from '@abstrack/types';
+import {
+  deleteEpisodeTemplate,
+  getEpisodeTemplateById,
+  listHealthMarkerPresets,
+  listSymptomPresets,
+  updateEpisodeTemplate,
+} from '@abstrack/supabase';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import { createBrowserClient } from '@/lib/supabase/browser-client';
+import { useAuth } from '@/lib/auth-provider';
+import {
+  useUnsavedChangesLeaveGuard,
+  type PendingLeaveAction,
+} from '@/lib/use-unsaved-changes-leave-guard';
+import { ConfirmDialog } from '../symptom-presets/ConfirmDialog';
+
+export type EpisodeTemplateEditorPageProps = {
+  /** `episode_templates.id` from the route. */
+  templateId: string;
+};
+
+/**
+ * Edit an episode template: rename and/or change which symptom and health marker presets are paired.
+ *
+ * @param props - Route param wiring.
+ * @returns Editor UI.
+ */
+export function EpisodeTemplateEditorPage({
+  templateId,
+}: EpisodeTemplateEditorPageProps) {
+  const router = useRouter();
+  const { session, loading: authLoading } = useAuth();
+  const { announce } = useAnnounce();
+
+  const [row, setRow] = useState<EpisodeTemplateWithPresetsRow | null>(null);
+  const [nameDraft, setNameDraft] = useState('');
+  const [symptomPresetId, setSymptomPresetId] = useState('');
+  const [healthMarkerPresetId, setHealthMarkerPresetId] = useState('');
+  const [symptomOptions, setSymptomOptions] = useState<
+    { id: string; name: string }[]
+  >([]);
+  const [markerOptions, setMarkerOptions] = useState<
+    { id: string; name: string }[]
+  >([]);
+  const [pageStatus, setPageStatus] = useState<
+    'loading' | 'ready' | 'not_found' | 'error'
+  >('loading');
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [discardDialogOpen, setDiscardDialogOpen] = useState(false);
+  const pendingLeaveRef = useRef<PendingLeaveAction | null>(null);
+
+  const refresh = useCallback(async () => {
+    const supabase = createBrowserClient();
+    setPageStatus('loading');
+    setLoadError(null);
+    const [templateResult, symRes, hmRes] = await Promise.all([
+      getEpisodeTemplateById(supabase, templateId),
+      listSymptomPresets(supabase),
+      listHealthMarkerPresets(supabase),
+    ]);
+    if (!symRes.ok) {
+      setPageStatus('error');
+      setLoadError(symRes.error.message);
+      return;
+    }
+    if (!hmRes.ok) {
+      setPageStatus('error');
+      setLoadError(hmRes.error.message);
+      return;
+    }
+    setSymptomOptions(symRes.data.map((r) => ({ id: r.id, name: r.name })));
+    setMarkerOptions(hmRes.data.map((r) => ({ id: r.id, name: r.name })));
+
+    if (!templateResult.ok) {
+      setPageStatus('error');
+      setLoadError(templateResult.error.message);
+      return;
+    }
+    if (!templateResult.data) {
+      setPageStatus('not_found');
+      return;
+    }
+    const t = templateResult.data;
+    setRow(t);
+    setNameDraft(t.name);
+    setSymptomPresetId(t.symptom_preset_id);
+    setHealthMarkerPresetId(t.health_marker_preset_id);
+    setPageStatus('ready');
+  }, [templateId]);
+
+  useEffect(() => {
+    if (authLoading || !session) {
+      return;
+    }
+    void refresh();
+  }, [authLoading, session, refresh]);
+
+  const isDirty = useMemo(() => {
+    if (!row) {
+      return false;
+    }
+    const nameTrimmed = nameDraft.trim();
+    return (
+      nameTrimmed !== row.name ||
+      symptomPresetId !== row.symptom_preset_id ||
+      healthMarkerPresetId !== row.health_marker_preset_id
+    );
+  }, [row, nameDraft, symptomPresetId, healthMarkerPresetId]);
+
+  const onRequestDiscardDialog = useCallback(() => {
+    setDiscardDialogOpen(true);
+  }, []);
+
+  useUnsavedChangesLeaveGuard({
+    active: isDirty && pageStatus === 'ready' && !!row,
+    blockIntercepts: saving,
+    dialogOpen: discardDialogOpen,
+    pendingLeaveRef,
+    onRequestDiscard: onRequestDiscardDialog,
+    exemptFormId: 'episode-template-edit-form',
+  });
+
+  const navigateToTemplatesList = useCallback(() => {
+    router.push('/presets/episode-templates');
+  }, [router]);
+
+  const handleDiscardConfirm = useCallback(() => {
+    const action = pendingLeaveRef.current;
+    pendingLeaveRef.current = null;
+
+    if (!action) {
+      router.push('/presets/episode-templates');
+      return;
+    }
+    if (action.kind === 'form') {
+      action.form.submit();
+      return;
+    }
+    const { href } = action;
+    let url: URL;
+    try {
+      url = new URL(href, window.location.origin);
+    } catch {
+      router.push('/presets/episode-templates');
+      return;
+    }
+    if (url.origin !== window.location.origin) {
+      window.location.assign(href);
+      return;
+    }
+    router.push(`${url.pathname}${url.search}${url.hash}`);
+  }, [router]);
+
+  const requestLeaveEditor = useCallback(() => {
+    if (!isDirty) {
+      navigateToTemplatesList();
+      return;
+    }
+    pendingLeaveRef.current = {
+      kind: 'href',
+      href: '/presets/episode-templates',
+    };
+    setDiscardDialogOpen(true);
+  }, [isDirty, navigateToTemplatesList]);
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!row) {
+      return;
+    }
+    const nameCheck = validateEpisodeTemplateName(nameDraft);
+    if (!nameCheck.ok) {
+      announce(nameCheck.message, { politeness: 'assertive' });
+      return;
+    }
+    const pair = validateEpisodeTemplatePresetPair(
+      symptomPresetId,
+      healthMarkerPresetId,
+    );
+    if (!pair.ok) {
+      announce(pair.message, { politeness: 'assertive' });
+      return;
+    }
+    const unchanged =
+      nameCheck.name === row.name &&
+      symptomPresetId === row.symptom_preset_id &&
+      healthMarkerPresetId === row.health_marker_preset_id;
+    if (unchanged) {
+      announce('No changes to save.', { politeness: 'polite' });
+      return;
+    }
+    setSaving(true);
+    const supabase = createBrowserClient();
+    const result = await updateEpisodeTemplate(supabase, row.id, {
+      name: nameCheck.name,
+      symptom_preset_id: symptomPresetId,
+      health_marker_preset_id: healthMarkerPresetId,
+    });
+    setSaving(false);
+    if (!result.ok) {
+      announce(result.error.message, { politeness: 'assertive' });
+      return;
+    }
+    announce('Episode template saved.', { politeness: 'polite' });
+    navigateToTemplatesList();
+  };
+
+  const handleDeleteConfirm = async (): Promise<void | false> => {
+    if (!row) {
+      return false;
+    }
+    setDeleting(true);
+    try {
+      const supabase = createBrowserClient();
+      const result = await deleteEpisodeTemplate(supabase, row.id);
+      if (!result.ok) {
+        announce(result.error.message, { politeness: 'assertive' });
+        return false;
+      }
+      announce('Episode template deleted.', { politeness: 'polite' });
+      router.push('/presets/episode-templates');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  if (authLoading) {
+    return (
+      <div className="w-full space-y-4">
+        <p className="text-sm text-app-muted">Loading…</p>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div role="alert" className="text-sm text-red-700 dark:text-red-300">
+        You must be signed in to edit templates.
+      </div>
+    );
+  }
+
+  if (pageStatus === 'loading' && !row) {
+    return (
+      <div className="w-full space-y-4">
+        <p className="text-sm text-app-muted">Loading template…</p>
+      </div>
+    );
+  }
+
+  if (pageStatus === 'error' && loadError) {
+    return (
+      <div className="w-full space-y-4">
+        <div
+          role="alert"
+          className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-800/60 dark:bg-red-950/35 dark:text-red-200"
+        >
+          {loadError}
+        </div>
+        <button
+          type="button"
+          className="min-h-[44px] rounded-full border border-app-border bg-app-surface px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          onClick={() => {
+            void refresh();
+          }}
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  if (pageStatus === 'not_found' || !row) {
+    return (
+      <div className="w-full space-y-4">
+        <p className="text-app-ink">We could not find that episode template.</p>
+        <Link
+          href="/presets/episode-templates"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-app-primary px-5 text-sm font-semibold text-white shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+        >
+          Back to episode templates
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full space-y-8">
+      <div>
+        <button
+          type="button"
+          disabled={saving}
+          onClick={() => {
+            requestLeaveEditor();
+          }}
+          className="text-left text-sm font-medium text-app-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          ← Back to episode templates
+        </button>
+        <h1 className="mt-4 text-2xl font-bold tracking-tight text-app-ink">
+          Edit episode template
+        </h1>
+        <p className="mt-1 text-sm text-app-muted">
+          Update the name or the paired presets. Changes apply only to this
+          template row.
+        </p>
+      </div>
+
+      <form
+        id="episode-template-edit-form"
+        onSubmit={(e) => {
+          void handleSave(e);
+        }}
+        className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
+        noValidate
+      >
+        <div className="space-y-6">
+          <div className="space-y-2">
+            <label
+              htmlFor="edit-episode-template-name"
+              className="text-sm font-medium text-app-ink"
+            >
+              Template name
+            </label>
+            <input
+              id="edit-episode-template-name"
+              name="episodeTemplateName"
+              type="text"
+              autoComplete="off"
+              value={nameDraft}
+              onChange={(e) => {
+                setNameDraft(e.target.value);
+              }}
+              className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-bg px-3 text-app-ink shadow-inner outline-none transition placeholder:text-app-muted focus-visible:ring-2 focus-visible:ring-app-ring"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label
+              htmlFor="edit-episode-template-symptom"
+              className="text-sm font-medium text-app-ink"
+            >
+              Symptom preset
+            </label>
+            <select
+              id="edit-episode-template-symptom"
+              name="symptomPresetId"
+              value={symptomPresetId}
+              onChange={(e) => {
+                setSymptomPresetId(e.target.value);
+              }}
+              className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-bg px-3 text-app-ink shadow-inner outline-none transition focus-visible:ring-2 focus-visible:ring-app-ring"
+            >
+              {symptomOptions.map((o) => (
+                <option key={o.id} value={o.id}>
+                  {o.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-2">
+            <label
+              htmlFor="edit-episode-template-marker"
+              className="text-sm font-medium text-app-ink"
+            >
+              Health marker preset
+            </label>
+            <select
+              id="edit-episode-template-marker"
+              name="healthMarkerPresetId"
+              value={healthMarkerPresetId}
+              onChange={(e) => {
+                setHealthMarkerPresetId(e.target.value);
+              }}
+              className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-bg px-3 text-app-ink shadow-inner outline-none transition focus-visible:ring-2 focus-visible:ring-app-ring"
+            >
+              {markerOptions.map((o) => (
+                <option key={o.id} value={o.id}>
+                  {o.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="mt-8 flex flex-wrap gap-3">
+          <button
+            type="submit"
+            disabled={saving}
+            className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-app-primary px-5 text-sm font-semibold text-white shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60"
+          >
+            {saving ? 'Saving…' : 'Save changes'}
+          </button>
+          <button
+            type="button"
+            disabled={saving}
+            className="inline-flex min-h-[44px] items-center justify-center rounded-full border border-app-border bg-app-bg px-5 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60"
+            onClick={() => {
+              requestLeaveEditor();
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="inline-flex min-h-[44px] items-center justify-center rounded-full border border-red-200 bg-red-50 px-5 text-sm font-semibold text-red-800 shadow-sm transition hover:bg-red-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-200 dark:hover:bg-red-950/60"
+            disabled={deleting}
+            onClick={() => {
+              setDeleteOpen(true);
+            }}
+          >
+            Delete template
+          </button>
+        </div>
+      </form>
+
+      <ConfirmDialog
+        open={discardDialogOpen}
+        title="Discard unsaved changes?"
+        description="You have edits that are not saved yet. If you leave now, those changes will be lost."
+        confirmLabel="Discard changes"
+        cancelLabel="Keep editing"
+        onConfirm={() => {
+          handleDiscardConfirm();
+        }}
+        onClose={() => {
+          pendingLeaveRef.current = null;
+          setDiscardDialogOpen(false);
+        }}
+      />
+
+      <ConfirmDialog
+        open={deleteOpen}
+        title="Delete this episode template?"
+        description={`“${row.name}” will be removed. This cannot be undone.`}
+        confirmLabel="Delete template"
+        cancelLabel="Keep template"
+        onConfirm={() => handleDeleteConfirm()}
+        onClose={() => {
+          setDeleteOpen(false);
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/episode-templates/EpisodeTemplateEditorPage.tsx
+++ b/apps/web/src/components/episode-templates/EpisodeTemplateEditorPage.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { EpisodeTemplateWithPresetsRow } from '@abstrack/types';
 import {
+  normalizeEpisodeTemplateName,
   validateEpisodeTemplateName,
   validateEpisodeTemplatePresetPair,
 } from '@abstrack/types';
@@ -95,7 +96,7 @@ export function EpisodeTemplateEditorPage({
     }
     const t = templateResult.data;
     setRow(t);
-    setNameDraft(t.name);
+    setNameDraft(normalizeEpisodeTemplateName(t.name));
     setSymptomPresetId(t.symptom_preset_id);
     setHealthMarkerPresetId(t.health_marker_preset_id);
     setPageStatus('ready');
@@ -112,9 +113,10 @@ export function EpisodeTemplateEditorPage({
     if (!row) {
       return false;
     }
-    const nameTrimmed = nameDraft.trim();
+    const draftName = normalizeEpisodeTemplateName(nameDraft);
+    const storedName = normalizeEpisodeTemplateName(row.name);
     return (
-      nameTrimmed !== row.name ||
+      draftName !== storedName ||
       symptomPresetId !== row.symptom_preset_id ||
       healthMarkerPresetId !== row.health_marker_preset_id
     );
@@ -195,7 +197,7 @@ export function EpisodeTemplateEditorPage({
       return;
     }
     const unchanged =
-      nameCheck.name === row.name &&
+      nameCheck.name === normalizeEpisodeTemplateName(row.name) &&
       symptomPresetId === row.symptom_preset_id &&
       healthMarkerPresetId === row.health_marker_preset_id;
     if (unchanged) {

--- a/apps/web/src/components/episode-templates/EpisodeTemplatesListPage.tsx
+++ b/apps/web/src/components/episode-templates/EpisodeTemplatesListPage.tsx
@@ -1,0 +1,250 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useState } from 'react';
+import type { EpisodeTemplateWithPresetsRow } from '@abstrack/types';
+import {
+  deleteEpisodeTemplate,
+  listEpisodeTemplates,
+} from '@abstrack/supabase';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import { createBrowserClient } from '@/lib/supabase/browser-client';
+import { useAuth } from '@/lib/auth-provider';
+import { ConfirmDialog } from '../symptom-presets/ConfirmDialog';
+
+/**
+ * Lists episode templates: each row pairs one symptom preset with one health marker preset under a
+ * name the user will recognize when impaired at episode start (PRD).
+ *
+ * @returns Episode templates settings landing content.
+ */
+export function EpisodeTemplatesListPage() {
+  const { session, loading: authLoading } = useAuth();
+  const { announce } = useAnnounce();
+  const [rows, setRows] = useState<EpisodeTemplateWithPresetsRow[]>([]);
+  const [loadState, setLoadState] = useState<'idle' | 'loading' | 'error'>(
+    'loading',
+  );
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const refresh = useCallback(async () => {
+    const supabase = createBrowserClient();
+    setLoadState('loading');
+    setLoadError(null);
+    const result = await listEpisodeTemplates(supabase);
+    if (!result.ok) {
+      setLoadState('error');
+      setLoadError(result.error.message);
+      return;
+    }
+    setRows(result.data);
+    setLoadState('idle');
+  }, []);
+
+  useEffect(() => {
+    if (authLoading || !session) {
+      return;
+    }
+    void refresh();
+  }, [authLoading, session, refresh]);
+
+  const handleDeleteConfirm = async (): Promise<void | false> => {
+    if (!deleteTarget) {
+      return false;
+    }
+    setDeleting(true);
+    try {
+      const supabase = createBrowserClient();
+      const result = await deleteEpisodeTemplate(supabase, deleteTarget.id);
+      if (!result.ok) {
+        announce(result.error.message, { politeness: 'assertive' });
+        return false;
+      }
+      announce('Episode template deleted.', { politeness: 'polite' });
+      await refresh();
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  if (authLoading) {
+    return (
+      <div className="w-full space-y-4">
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Episode templates
+        </h1>
+        <p className="text-sm text-app-muted">Loading…</p>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="w-full space-y-4">
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Episode templates
+        </h1>
+        <p className="text-sm text-app-muted" role="status">
+          You need to be signed in to view and manage episode templates.
+        </p>
+        <Link
+          href="/login"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-app-primary px-5 text-sm font-semibold text-white shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+        >
+          Sign in
+        </Link>
+      </div>
+    );
+  }
+
+  if (loadState === 'loading' && rows.length === 0) {
+    return (
+      <div className="w-full space-y-4">
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Episode templates
+        </h1>
+        <p className="text-sm text-app-muted">Loading templates…</p>
+      </div>
+    );
+  }
+
+  if (loadState === 'error' && loadError) {
+    return (
+      <div className="w-full space-y-4">
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Episode templates
+        </h1>
+        <div
+          role="alert"
+          className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-800/60 dark:bg-red-950/35 dark:text-red-200"
+        >
+          {loadError}
+        </div>
+        <button
+          type="button"
+          className="min-h-[44px] rounded-full border border-app-border bg-app-surface px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          onClick={() => {
+            void refresh();
+          }}
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full space-y-8">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+            Episode templates
+          </h1>
+          <p className="mt-1 text-sm text-app-muted">
+            Name each template and pair one symptom preset with one health
+            marker preset. When you start an episode later, you will pick a
+            single template — not separate preset lists — so set these up while
+            you are well.
+          </p>
+        </div>
+        <Link
+          href="/presets/episode-templates/new"
+          className="inline-flex min-h-[44px] shrink-0 items-center justify-center rounded-full bg-app-primary px-5 text-sm font-semibold text-white shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+        >
+          Create template
+        </Link>
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="rounded-2xl border border-app-border/90 bg-app-surface p-8 text-center shadow-soft ring-1 ring-[color:var(--app-ring-slate)]">
+          <p className="text-app-ink">
+            You have not created any episode templates yet.
+          </p>
+          <p className="mt-2 text-sm text-app-muted">
+            Create at least one symptom preset and one health marker preset
+            first, then add a template that pairs them under a name you will
+            recognize when impaired (for example &quot;ABS Episode&quot; or
+            &quot;CVS Episode&quot;).
+          </p>
+          <Link
+            href="/presets/episode-templates/new"
+            className="mt-6 inline-flex min-h-[44px] items-center justify-center rounded-full bg-app-primary px-5 text-sm font-semibold text-white shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          >
+            Create your first template
+          </Link>
+        </div>
+      ) : (
+        <ul
+          className="divide-y divide-app-border/80 rounded-2xl border border-app-border/90 bg-app-surface shadow-soft ring-1 ring-[color:var(--app-ring-slate)]"
+          aria-label="Your episode templates"
+        >
+          {rows.map((row) => (
+            <li
+              key={row.id}
+              className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div className="min-w-0 space-y-1">
+                <Link
+                  href={`/presets/episode-templates/${row.id}`}
+                  className="block rounded-md text-base font-semibold text-app-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                >
+                  {row.name}
+                </Link>
+                <p className="text-sm text-app-muted">
+                  Symptoms:{' '}
+                  <span className="text-app-ink">
+                    {row.symptom_preset.name}
+                  </span>
+                  {' · '}
+                  Markers:{' '}
+                  <span className="text-app-ink">
+                    {row.health_marker_preset.name}
+                  </span>
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Link
+                  href={`/presets/episode-templates/${row.id}`}
+                  className="inline-flex min-h-[44px] items-center justify-center rounded-full border border-app-border bg-app-bg px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                >
+                  Edit
+                </Link>
+                <button
+                  type="button"
+                  className="inline-flex min-h-[44px] items-center justify-center rounded-full border border-red-200 bg-red-50 px-4 text-sm font-semibold text-red-800 shadow-sm transition hover:bg-red-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-200 dark:hover:bg-red-950/60"
+                  disabled={deleting}
+                  onClick={() => {
+                    setDeleteTarget({ id: row.id, name: row.name });
+                  }}
+                >
+                  Delete
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title="Delete this episode template?"
+        description={
+          deleteTarget
+            ? `“${deleteTarget.name}” will be removed. This cannot be undone.`
+            : undefined
+        }
+        confirmLabel="Delete template"
+        cancelLabel="Keep template"
+        onConfirm={() => handleDeleteConfirm()}
+        onClose={() => {
+          setDeleteTarget(null);
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/lib/use-unsaved-changes-leave-guard.ts
+++ b/apps/web/src/lib/use-unsaved-changes-leave-guard.ts
@@ -1,0 +1,165 @@
+'use client';
+
+import { useEffect, useRef, type MutableRefObject } from 'react';
+
+export type PendingLeaveAction =
+  | { kind: 'href'; href: string }
+  | { kind: 'form'; form: HTMLFormElement };
+
+export type UseUnsavedChangesLeaveGuardParams = {
+  /** When true, leaving the page may discard edits (listeners active). */
+  active: boolean;
+  /** While true, do not start new intercepts (e.g. save in flight). */
+  blockIntercepts?: boolean;
+  /** Set when the discard-confirmation dialog is open (skip nested intercepts). */
+  dialogOpen: boolean;
+  /** Latest pending navigation / form submit if the user confirms discard. */
+  pendingLeaveRef: MutableRefObject<PendingLeaveAction | null>;
+  /** Called after {@link pendingLeaveRef} is set (caller opens the discard dialog). */
+  onRequestDiscard: () => void;
+  /**
+   * When set, {@link HTMLFormElement} with this `id` is not intercepted (e.g. the save form).
+   * If omitted, submit interception is disabled so normal forms are not blocked by mistake.
+   */
+  exemptFormId?: string;
+};
+
+/**
+ * Warns before losing in-progress edits: browser tab close/refresh ({@link BeforeUnloadEvent}),
+ * same-origin navigations via {@link HTMLAnchorElement}, and {@link HTMLFormElement} submit
+ * (e.g. sign-out). Does not intercept {@link KeyboardEvent} modified link opens or programmatic
+ * {@link useRouter} calls from non-anchor sources.
+ *
+ * @param params - Guard configuration and refs shared with the confirmation dialog.
+ */
+export function useUnsavedChangesLeaveGuard({
+  active,
+  blockIntercepts = false,
+  dialogOpen,
+  pendingLeaveRef,
+  onRequestDiscard,
+  exemptFormId,
+}: UseUnsavedChangesLeaveGuardParams): void {
+  const dialogOpenRef = useRef(dialogOpen);
+  dialogOpenRef.current = dialogOpen;
+
+  useEffect(() => {
+    if (!active) {
+      return undefined;
+    }
+
+    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', onBeforeUnload);
+    };
+  }, [active]);
+
+  useEffect(() => {
+    if (!active || blockIntercepts) {
+      return undefined;
+    }
+
+    const onClickCapture = (event: MouseEvent) => {
+      if (dialogOpenRef.current) {
+        return;
+      }
+      if (event.defaultPrevented) {
+        return;
+      }
+      if (event.ctrlKey || event.metaKey || event.shiftKey || event.altKey) {
+        return;
+      }
+
+      const target = event.target;
+      if (!(target instanceof Element)) {
+        return;
+      }
+
+      const anchor = target.closest('a[href]');
+      if (!(anchor instanceof HTMLAnchorElement)) {
+        return;
+      }
+
+      const rawHref = anchor.getAttribute('href');
+      if (rawHref == null || rawHref === '' || rawHref.startsWith('#')) {
+        return;
+      }
+      if (anchor.target === '_blank' || anchor.hasAttribute('download')) {
+        return;
+      }
+
+      let url: URL;
+      try {
+        url = new URL(anchor.href, window.location.href);
+      } catch {
+        return;
+      }
+
+      const next =
+        url.origin === window.location.origin
+          ? `${url.pathname}${url.search}${url.hash}`
+          : url.href;
+
+      const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+
+      if (url.origin === window.location.origin && next === current) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      pendingLeaveRef.current =
+        url.origin === window.location.origin
+          ? { kind: 'href', href: next }
+          : { kind: 'href', href: url.href };
+      onRequestDiscard();
+    };
+
+    document.addEventListener('click', onClickCapture, true);
+    return () => {
+      document.removeEventListener('click', onClickCapture, true);
+    };
+  }, [active, blockIntercepts, onRequestDiscard, pendingLeaveRef]);
+
+  useEffect(() => {
+    if (!active || blockIntercepts || !exemptFormId) {
+      return undefined;
+    }
+
+    const onSubmitCapture = (event: SubmitEvent) => {
+      if (dialogOpenRef.current) {
+        return;
+      }
+      if (!(event.target instanceof HTMLFormElement)) {
+        return;
+      }
+      const form = event.target;
+      if (form.id === exemptFormId) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      pendingLeaveRef.current = { kind: 'form', form };
+      onRequestDiscard();
+    };
+
+    document.addEventListener('submit', onSubmitCapture, true);
+    return () => {
+      document.removeEventListener('submit', onSubmitCapture, true);
+    };
+  }, [
+    active,
+    blockIntercepts,
+    exemptFormId,
+    onRequestDiscard,
+    pendingLeaveRef,
+  ]);
+}

--- a/apps/web/src/lib/use-unsaved-changes-leave-guard.ts
+++ b/apps/web/src/lib/use-unsaved-changes-leave-guard.ts
@@ -74,6 +74,10 @@ export function useUnsavedChangesLeaveGuard({
       if (event.ctrlKey || event.metaKey || event.shiftKey || event.altKey) {
         return;
       }
+      // Only intercept primary-button navigations; aux clicks (e.g. middle = open in new tab) must pass through.
+      if (event.button !== 0) {
+        return;
+      }
 
       const target = event.target;
       if (!(target instanceof Element)) {

--- a/nx.json
+++ b/nx.json
@@ -98,6 +98,9 @@
         { "env": "EXPO_PUBLIC_SUPABASE_ANON_KEY" },
         { "env": "SUPABASE_URL" }
       ]
+    },
+    "typecheck": {
+      "inputs": ["default", { "dependentTasksOutputFiles": "**/*.d.ts" }]
     }
   },
   "generators": {

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -68,3 +68,10 @@ export {
   updateSymptomPreset,
   validateReorderLineIds,
 } from './lib/preset-data.js';
+export {
+  createEpisodeTemplate,
+  deleteEpisodeTemplate,
+  getEpisodeTemplateById,
+  listEpisodeTemplates,
+  updateEpisodeTemplate,
+} from './lib/episode-template-data.js';

--- a/packages/supabase/src/lib/episode-template-data.ts
+++ b/packages/supabase/src/lib/episode-template-data.ts
@@ -1,0 +1,142 @@
+import type {
+  EpisodeTemplateInsert,
+  EpisodeTemplateRow,
+  EpisodeTemplateUpdate,
+  EpisodeTemplateWithPresetsRow,
+} from '@abstrack/types';
+import { toPresetDataError } from './preset-data-error.js';
+import type { PresetDataResult } from './preset-data.js';
+import { wrap, wrapDeleteExpectOne } from './preset-data.js';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+
+/**
+ * Lists the signed-in user’s episode templates with nested symptom and health marker preset names.
+ *
+ * @param client - Browser, native, or server Supabase client (RLS applies).
+ */
+export async function listEpisodeTemplates(
+  client: AbstrackSupabaseClient,
+): Promise<PresetDataResult<EpisodeTemplateWithPresetsRow[]>> {
+  return wrap(async () => {
+    const result = await client
+      .from('episode_templates')
+      .select(
+        `
+        *,
+        symptom_preset:symptom_presets!episode_templates_symptom_preset_id_fk ( id, name ),
+        health_marker_preset:health_marker_presets!episode_templates_health_marker_preset_id_fk ( id, name )
+      `,
+      )
+      .order('created_at', { ascending: true })
+      .order('id', { ascending: true });
+    const rows = result.data as EpisodeTemplateWithPresetsRow[] | null;
+    return {
+      data: rows ?? [],
+      error: result.error,
+    };
+  });
+}
+
+/**
+ * Fetches one episode template by id with nested preset names when RLS allows.
+ *
+ * @param client - Supabase client.
+ * @param id - `episode_templates.id`.
+ */
+export async function getEpisodeTemplateById(
+  client: AbstrackSupabaseClient,
+  id: string,
+): Promise<PresetDataResult<EpisodeTemplateWithPresetsRow | null>> {
+  try {
+    const { data, error } = await client
+      .from('episode_templates')
+      .select(
+        `
+        *,
+        symptom_preset:symptom_presets!episode_templates_symptom_preset_id_fk ( id, name ),
+        health_marker_preset:health_marker_presets!episode_templates_health_marker_preset_id_fk ( id, name )
+      `,
+      )
+      .eq('id', id)
+      .maybeSingle();
+    if (error) {
+      return { ok: false, error: toPresetDataError(error) };
+    }
+    return {
+      ok: true,
+      data: data as EpisodeTemplateWithPresetsRow | null,
+    };
+  } catch (caught) {
+    return { ok: false, error: toPresetDataError(caught) };
+  }
+}
+
+/**
+ * Creates an episode template (one symptom preset + one health marker preset under a display name).
+ *
+ * @param client - Supabase client.
+ * @param row - Insert payload (`user_id` must match the signed-in user under RLS).
+ */
+export async function createEpisodeTemplate(
+  client: AbstrackSupabaseClient,
+  row: EpisodeTemplateInsert,
+): Promise<PresetDataResult<EpisodeTemplateRow>> {
+  return wrap(async () => {
+    const r = await client
+      .from('episode_templates')
+      .insert(row)
+      .select('*')
+      .single();
+    return {
+      data: r.data as EpisodeTemplateRow | null,
+      error: r.error,
+    };
+  });
+}
+
+/**
+ * Updates an episode template (name and/or linked presets).
+ *
+ * @param client - Supabase client.
+ * @param id - `episode_templates.id`.
+ * @param patch - Fields to change.
+ */
+export async function updateEpisodeTemplate(
+  client: AbstrackSupabaseClient,
+  id: string,
+  patch: EpisodeTemplateUpdate,
+): Promise<PresetDataResult<EpisodeTemplateRow>> {
+  return wrap(async () => {
+    const r = await client
+      .from('episode_templates')
+      .update(patch)
+      .eq('id', id)
+      .select('*')
+      .single();
+    return {
+      data: r.data as EpisodeTemplateRow | null,
+      error: r.error,
+    };
+  });
+}
+
+/**
+ * Deletes an episode template. If no row matched (or RLS hides it), returns an error — not silent success.
+ *
+ * @param client - Supabase client.
+ * @param id - `episode_templates.id`.
+ */
+export async function deleteEpisodeTemplate(
+  client: AbstrackSupabaseClient,
+  id: string,
+): Promise<PresetDataResult<void>> {
+  return wrapDeleteExpectOne(async () => {
+    const r = await client
+      .from('episode_templates')
+      .delete()
+      .eq('id', id)
+      .select('id')
+      .single();
+    return { data: r.data, error: r.error };
+  });
+}

--- a/packages/supabase/src/lib/preset-data.ts
+++ b/packages/supabase/src/lib/preset-data.ts
@@ -22,7 +22,8 @@ export type PresetDataResult<T> =
   | { ok: true; data: T }
   | { ok: false; error: PresetDataError };
 
-async function wrap<T>(
+/** @internal Shared by preset and episode-template data modules. */
+export async function wrap<T>(
   run: () => Promise<{ data: T | null; error: unknown }>,
 ): Promise<PresetDataResult<NonNullable<T>>> {
   try {
@@ -61,8 +62,10 @@ async function wrapVoid(
 
 /**
  * DELETE with a returning row so 0-row deletes surface as PostgREST errors (e.g. PGRST116) instead of silent success.
+ *
+ * @internal Shared by preset and episode-template data modules.
  */
-async function wrapDeleteExpectOne(
+export async function wrapDeleteExpectOne(
   run: () => Promise<{ data: unknown; error: unknown }>,
 ): Promise<PresetDataResult<void>> {
   try {

--- a/packages/supabase/src/preset-flows.integration.spec.ts
+++ b/packages/supabase/src/preset-flows.integration.spec.ts
@@ -533,9 +533,9 @@ describe.skipIf(!presetIntegrationReady)(
     });
 
     describe.sequential('episode templates — CRUD and cross-user', () => {
-      let etSymptomId: string;
-      let etHmId: string;
-      let etTemplateId: string;
+      let etSymptomId: string | undefined;
+      let etHmId: string | undefined;
+      let etTemplateId: string | undefined;
 
       beforeAll(async () => {
         const sp = await createSymptomPreset(clientA, {
@@ -561,8 +561,8 @@ describe.skipIf(!presetIntegrationReady)(
         const created = await createEpisodeTemplate(clientA, {
           user_id: userAId,
           name: `ABS Episode ${suffix}`,
-          symptom_preset_id: etSymptomId,
-          health_marker_preset_id: etHmId,
+          symptom_preset_id: etSymptomId!,
+          health_marker_preset_id: etHmId!,
         });
         expect(created.ok).toBe(true);
         if (!created.ok) {
@@ -577,14 +577,14 @@ describe.skipIf(!presetIntegrationReady)(
         if (!list.ok) {
           return;
         }
-        const found = list.data.find((r) => r.id === etTemplateId);
+        const found = list.data.find((r) => r.id === etTemplateId!);
         expect(found).toBeDefined();
         expect(found?.symptom_preset.name).toContain(`ET sym ${suffix}`);
         expect(found?.health_marker_preset.name).toContain(`ET hm ${suffix}`);
       });
 
       it('updates episode template', async () => {
-        const up = await updateEpisodeTemplate(clientA, etTemplateId, {
+        const up = await updateEpisodeTemplate(clientA, etTemplateId!, {
           name: `Renamed ${suffix}`,
         });
         expect(up.ok).toBe(true);
@@ -595,7 +595,7 @@ describe.skipIf(!presetIntegrationReady)(
       });
 
       it('hides other user template from get by id', async () => {
-        const got = await getEpisodeTemplateById(clientB, etTemplateId);
+        const got = await getEpisodeTemplateById(clientB, etTemplateId!);
         expect(got.ok).toBe(true);
         if (!got.ok) {
           return;
@@ -604,13 +604,17 @@ describe.skipIf(!presetIntegrationReady)(
       });
 
       it('deletes episode template', async () => {
-        const del = await deleteEpisodeTemplate(clientA, etTemplateId);
+        const del = await deleteEpisodeTemplate(clientA, etTemplateId!);
         expect(del.ok).toBe(true);
       });
 
       afterAll(async () => {
-        await deleteSymptomPreset(clientA, etSymptomId);
-        await deleteHealthMarkerPreset(clientA, etHmId);
+        if (etSymptomId !== undefined) {
+          await deleteSymptomPreset(clientA, etSymptomId);
+        }
+        if (etHmId !== undefined) {
+          await deleteHealthMarkerPreset(clientA, etHmId);
+        }
       });
     });
   },

--- a/packages/supabase/src/preset-flows.integration.spec.ts
+++ b/packages/supabase/src/preset-flows.integration.spec.ts
@@ -557,9 +557,7 @@ describe.skipIf(!presetIntegrationReady)(
           throw new Error(hm.error.message);
         }
         etHmId = hm.data.id;
-      });
 
-      it('creates and lists episode template with nested preset names', async () => {
         const created = await createEpisodeTemplate(clientA, {
           user_id: userAId,
           name: `ABS Episode ${suffix}`,
@@ -568,10 +566,12 @@ describe.skipIf(!presetIntegrationReady)(
         });
         expect(created.ok).toBe(true);
         if (!created.ok) {
-          return;
+          throw new Error(created.error.message);
         }
         etTemplateId = created.data.id;
+      });
 
+      it('lists episode template with nested preset names', async () => {
         const list = await listEpisodeTemplates(clientA);
         expect(list.ok).toBe(true);
         if (!list.ok) {

--- a/packages/supabase/src/preset-flows.integration.spec.ts
+++ b/packages/supabase/src/preset-flows.integration.spec.ts
@@ -18,6 +18,13 @@ import { getSupabasePublishableKey, getSupabaseUrl } from './lib/env-public.js';
 import type { AbstrackSupabaseClient } from './lib/supabase-client-type.js';
 import { getSupabaseAdminClient } from './admin.js';
 import {
+  createEpisodeTemplate,
+  deleteEpisodeTemplate,
+  getEpisodeTemplateById,
+  listEpisodeTemplates,
+  updateEpisodeTemplate,
+} from './lib/episode-template-data.js';
+import {
   createHealthMarkerPreset,
   createPresetHealthMarker,
   createPresetSymptom,
@@ -522,6 +529,88 @@ describe.skipIf(!presetIntegrationReady)(
 
       afterAll(async () => {
         await deleteHealthMarkerPreset(clientA, victimHId);
+      });
+    });
+
+    describe.sequential('episode templates — CRUD and cross-user', () => {
+      let etSymptomId: string;
+      let etHmId: string;
+      let etTemplateId: string;
+
+      beforeAll(async () => {
+        const sp = await createSymptomPreset(clientA, {
+          user_id: userAId,
+          name: `ET sym ${suffix}`,
+        });
+        expect(sp.ok).toBe(true);
+        if (!sp.ok) {
+          throw new Error(sp.error.message);
+        }
+        etSymptomId = sp.data.id;
+
+        const hm = await createHealthMarkerPreset(clientA, {
+          user_id: userAId,
+          name: `ET hm ${suffix}`,
+        });
+        expect(hm.ok).toBe(true);
+        if (!hm.ok) {
+          throw new Error(hm.error.message);
+        }
+        etHmId = hm.data.id;
+      });
+
+      it('creates and lists episode template with nested preset names', async () => {
+        const created = await createEpisodeTemplate(clientA, {
+          user_id: userAId,
+          name: `ABS Episode ${suffix}`,
+          symptom_preset_id: etSymptomId,
+          health_marker_preset_id: etHmId,
+        });
+        expect(created.ok).toBe(true);
+        if (!created.ok) {
+          return;
+        }
+        etTemplateId = created.data.id;
+
+        const list = await listEpisodeTemplates(clientA);
+        expect(list.ok).toBe(true);
+        if (!list.ok) {
+          return;
+        }
+        const found = list.data.find((r) => r.id === etTemplateId);
+        expect(found).toBeDefined();
+        expect(found?.symptom_preset.name).toContain(`ET sym ${suffix}`);
+        expect(found?.health_marker_preset.name).toContain(`ET hm ${suffix}`);
+      });
+
+      it('updates episode template', async () => {
+        const up = await updateEpisodeTemplate(clientA, etTemplateId, {
+          name: `Renamed ${suffix}`,
+        });
+        expect(up.ok).toBe(true);
+        if (!up.ok) {
+          return;
+        }
+        expect(up.data.name).toBe(`Renamed ${suffix}`);
+      });
+
+      it('hides other user template from get by id', async () => {
+        const got = await getEpisodeTemplateById(clientB, etTemplateId);
+        expect(got.ok).toBe(true);
+        if (!got.ok) {
+          return;
+        }
+        expect(got.data).toBeNull();
+      });
+
+      it('deletes episode template', async () => {
+        const del = await deleteEpisodeTemplate(clientA, etTemplateId);
+        expect(del.ok).toBe(true);
+      });
+
+      afterAll(async () => {
+        await deleteSymptomPreset(clientA, etSymptomId);
+        await deleteHealthMarkerPreset(clientA, etHmId);
       });
     });
   },

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/abs-symptom-suggestions.js';
+export * from './lib/episode-template.js';
 export * from './lib/types.js';

--- a/packages/types/src/lib/episode-template.spec.ts
+++ b/packages/types/src/lib/episode-template.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EPISODE_TEMPLATE_NAME_MAX_LENGTH,
+  normalizeEpisodeTemplateName,
+  validateEpisodeTemplateName,
+} from './episode-template.js';
+
+describe('episode template name helpers', () => {
+  it('normalizes whitespace', () => {
+    expect(normalizeEpisodeTemplateName('  ABS Episode  ')).toBe('ABS Episode');
+  });
+
+  it('rejects empty names', () => {
+    const r = validateEpisodeTemplateName('   ');
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.message).toContain('Enter a name');
+    }
+  });
+
+  it('accepts valid names', () => {
+    const r = validateEpisodeTemplateName('ABS Episode');
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.name).toBe('ABS Episode');
+    }
+  });
+
+  it('rejects names over max length', () => {
+    const long = 'x'.repeat(EPISODE_TEMPLATE_NAME_MAX_LENGTH + 1);
+    const r = validateEpisodeTemplateName(long);
+    expect(r.ok).toBe(false);
+  });
+});

--- a/packages/types/src/lib/episode-template.spec.ts
+++ b/packages/types/src/lib/episode-template.spec.ts
@@ -3,6 +3,7 @@ import {
   EPISODE_TEMPLATE_NAME_MAX_LENGTH,
   normalizeEpisodeTemplateName,
   validateEpisodeTemplateName,
+  validateEpisodeTemplatePresetPair,
 } from './episode-template.js';
 
 describe('episode template name helpers', () => {
@@ -30,5 +31,42 @@ describe('episode template name helpers', () => {
     const long = 'x'.repeat(EPISODE_TEMPLATE_NAME_MAX_LENGTH + 1);
     const r = validateEpisodeTemplateName(long);
     expect(r.ok).toBe(false);
+  });
+});
+
+describe('validateEpisodeTemplatePresetPair', () => {
+  const symptomId = '11111111-1111-1111-1111-111111111111';
+  const markerId = '22222222-2222-2222-2222-222222222222';
+
+  it('rejects missing symptom preset id (null / undefined / empty)', () => {
+    for (const symptom of [null, undefined, '', '   '] as const) {
+      const r = validateEpisodeTemplatePresetPair(symptom, markerId);
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.message).toBe('Choose a symptom preset.');
+      }
+    }
+  });
+
+  it('rejects missing health marker preset id when symptom is set', () => {
+    for (const marker of [null, undefined, '', '   '] as const) {
+      const r = validateEpisodeTemplatePresetPair(symptomId, marker);
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.message).toBe('Choose a health marker preset.');
+      }
+    }
+  });
+
+  it('accepts when both ids are non-empty (trims whitespace)', () => {
+    const r = validateEpisodeTemplatePresetPair(
+      `  ${symptomId}  `,
+      `  ${markerId}  `,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('accepts minimal non-whitespace ids', () => {
+    expect(validateEpisodeTemplatePresetPair('a', 'b').ok).toBe(true);
   });
 });

--- a/packages/types/src/lib/episode-template.ts
+++ b/packages/types/src/lib/episode-template.ts
@@ -65,7 +65,7 @@ export type EpisodeTemplateInsert = Pick<
   EpisodeTemplateRow,
   'user_id' | 'name' | 'symptom_preset_id' | 'health_marker_preset_id'
 > & {
-  id?: string;
+  id?: Uuid;
 };
 
 export type EpisodeTemplateUpdate = Partial<

--- a/packages/types/src/lib/episode-template.ts
+++ b/packages/types/src/lib/episode-template.ts
@@ -1,0 +1,110 @@
+import type {
+  HealthMarkerPresetRow,
+  IsoTimestamptz,
+  SymptomPresetRow,
+  Uuid,
+} from './types.js';
+
+/**
+ * Maximum length for {@link EpisodeTemplateRow.name} in the UI and shared validation.
+ * Database column is unbounded `text`; this keeps payloads reasonable and matches product expectations.
+ */
+export const EPISODE_TEMPLATE_NAME_MAX_LENGTH = 200;
+
+/**
+ * Trims whitespace for episode template display names.
+ *
+ * @param raw - User input.
+ * @returns Trimmed string (may be empty).
+ */
+export function normalizeEpisodeTemplateName(raw: string): string {
+  return raw.trim();
+}
+
+export type EpisodeTemplateNameValidation =
+  | { ok: true; name: string }
+  | { ok: false; message: string };
+
+/**
+ * Validates a template name after {@link normalizeEpisodeTemplateName}.
+ * Use the returned `name` on success for persistence.
+ *
+ * @param raw - User input (trimmed inside this function).
+ * @returns Success with normalized name or a user-facing error message.
+ */
+export function validateEpisodeTemplateName(
+  raw: string,
+): EpisodeTemplateNameValidation {
+  const name = normalizeEpisodeTemplateName(raw);
+  if (!name) {
+    return { ok: false, message: 'Enter a name for this episode template.' };
+  }
+  if (name.length > EPISODE_TEMPLATE_NAME_MAX_LENGTH) {
+    return {
+      ok: false,
+      message: `Use at most ${EPISODE_TEMPLATE_NAME_MAX_LENGTH} characters for the template name.`,
+    };
+  }
+  return { ok: true, name };
+}
+
+/**
+ * Row from `episode_templates`: one named pairing of symptom + health marker presets (PRD).
+ */
+export interface EpisodeTemplateRow {
+  id: Uuid;
+  user_id: Uuid;
+  name: string;
+  symptom_preset_id: Uuid;
+  health_marker_preset_id: Uuid;
+  created_at: IsoTimestamptz;
+  updated_at: IsoTimestamptz;
+}
+
+export type EpisodeTemplateInsert = Pick<
+  EpisodeTemplateRow,
+  'user_id' | 'name' | 'symptom_preset_id' | 'health_marker_preset_id'
+> & {
+  id?: string;
+};
+
+export type EpisodeTemplateUpdate = Partial<
+  Pick<
+    EpisodeTemplateRow,
+    'name' | 'symptom_preset_id' | 'health_marker_preset_id'
+  >
+>;
+
+/**
+ * Episode template with embedded preset names for list/detail UIs (from Supabase select with joins).
+ */
+export interface EpisodeTemplateWithPresetsRow extends EpisodeTemplateRow {
+  symptom_preset: Pick<SymptomPresetRow, 'id' | 'name'>;
+  health_marker_preset: Pick<HealthMarkerPresetRow, 'id' | 'name'>;
+}
+
+export type EpisodeTemplatePairValidation =
+  | { ok: true }
+  | { ok: false; message: string };
+
+/**
+ * Ensures both preset ids are present before create/update (shared by web and mobile UIs).
+ *
+ * @param symptomPresetId - Selected symptom preset id.
+ * @param healthMarkerPresetId - Selected health marker preset id.
+ */
+export function validateEpisodeTemplatePresetPair(
+  symptomPresetId: string | undefined | null,
+  healthMarkerPresetId: string | undefined | null,
+): EpisodeTemplatePairValidation {
+  const s = typeof symptomPresetId === 'string' ? symptomPresetId.trim() : '';
+  const h =
+    typeof healthMarkerPresetId === 'string' ? healthMarkerPresetId.trim() : '';
+  if (!s) {
+    return { ok: false, message: 'Choose a symptom preset.' };
+  }
+  if (!h) {
+    return { ok: false, message: 'Choose a health marker preset.' };
+  }
+  return { ok: true };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,6 +249,9 @@ importers:
       '@expo/metro-config':
         specifier: '*'
         version: 54.0.14(expo@54.0.33)
+      '@expo/react-native-action-sheet':
+        specifier: ^4.1.1
+        version: 4.1.1(@types/react@19.1.17)(react@19.1.0)
       '@expo/vector-icons':
         specifier: '*'
         version: 15.1.1(expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -2107,6 +2110,14 @@ packages:
       }
     peerDependencies:
       expo: '*'
+
+  '@expo/react-native-action-sheet@4.1.1':
+    resolution:
+      {
+        integrity: sha512-4KRaba2vhqDRR7ObBj6nrD5uJw8ePoNHdIOMETTpgGTX7StUbrF4j/sfrP1YUyaPEa1P8FXdwG6pB+2WtrJd1A==,
+      }
+    peerDependencies:
+      react: '>=18.0.0'
 
   '@expo/schema-utils@0.1.8':
     resolution:
@@ -5377,6 +5388,14 @@ packages:
       {
         integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==,
       }
+
+  '@types/hoist-non-react-statics@3.3.7':
+    resolution:
+      {
+        integrity: sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
 
   '@types/http-cache-semantics@4.2.0':
     resolution:
@@ -9888,6 +9907,12 @@ packages:
     resolution:
       {
         integrity: sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==,
+      }
+
+  hoist-non-react-statics@3.3.2:
+    resolution:
+      {
+        integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==,
       }
 
   homedir-polyfill@1.0.3:
@@ -18254,6 +18279,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@expo/react-native-action-sheet@4.1.1(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      '@types/hoist-non-react-statics': 3.3.7(@types/react@19.1.17)
+      hoist-non-react-statics: 3.3.2
+      react: 19.1.0
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@expo/schema-utils@0.1.8': {}
 
   '@expo/sdk-runtime-versions@1.0.0': {}
@@ -21057,6 +21090,11 @@ snapshots:
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 20.19.9
+
+  '@types/hoist-non-react-statics@3.3.7(@types/react@19.1.17)':
+    dependencies:
+      '@types/react': 19.1.17
+      hoist-non-react-statics: 3.3.2
 
   '@types/http-cache-semantics@4.2.0': {}
 
@@ -24219,6 +24257,10 @@ snapshots:
   hermes-parser@0.33.3:
     dependencies:
       hermes-estree: 0.33.3
+
+  hoist-non-react-statics@3.3.2:
+    dependencies:
+      react-is: 16.13.1
 
   homedir-polyfill@1.0.3:
     dependencies:


### PR DESCRIPTION
Closes #72

## Summary

Adds episode template flows end-to-end (shared types + Supabase helpers, web UI, mobile tab stack) and tightens mobile UX around leaving create/edit: header/back, Cancel, and other bottom tabs share the same discard behavior, with interception implemented at the tab bar (draft context) so nested-stack + `tabPress` timing issues don’t block alerts or leave stale edit state.

## Changes

- **Shared:** `@abstrack/types` episode template validation/pairing; `@abstrack/supabase` CRUD + integration coverage where applicable.
- **Web:** Episode templates list / create / edit under presets; unsaved-leave guard aligned with existing patterns.
- **Mobile:** Templates tab with list → create → edit; preset selection via action sheet (not inline picker); `useUnsavedChangesBeforeRemove` for stack back; `EpisodeTemplatesDraftProvider` + `EpisodeTemplatesLeavingGuardTabButton` so switching tabs can’t bypass discard or strand the stack in a state that blocks follow-up actions (e.g. list delete).

## How to test

- Web: create/edit templates, navigate away with unsaved edits, confirm discard dialogs.
- Mobile: same on create/edit; switch bottom tabs with/without edits; confirm discard or reset to list; delete from list after aborted edit session.