### PR TITLE
feat(episode): add home “I'm having an episode” CTA and episode-start shell on web and mobile

### DIFF
--- a/apps/mobile/src/app/App.spec.tsx
+++ b/apps/mobile/src/app/App.spec.tsx
@@ -540,6 +540,53 @@ describe('mobile auth state sync', () => {
     expect(await findByTestId('episode-template-list-screen')).toBeTruthy();
   });
 
+  test('opens episode start shell from home episode CTA', async () => {
+    const signedInSession = {
+      access_token: 'access',
+      refresh_token: 'refresh',
+      token_type: 'bearer',
+      expires_in: 3600,
+      expires_at: 9999999999,
+      user: { id: 'user-1' },
+    } as unknown as Session;
+
+    const mockClient = {
+      auth: {
+        getSession: jest.fn(async () => ({
+          data: { session: signedInSession },
+        })),
+        getUser: jest.fn(async () => ({
+          data: { user: { id: 'user-1' } },
+          error: null,
+        })),
+        signOut: jest.fn(async () => ({ error: null })),
+        onAuthStateChange: jest.fn(() => ({
+          data: {
+            subscription: {
+              unsubscribe: jest.fn(),
+            },
+          },
+        })),
+      },
+      from: jest.fn(() => ({
+        select: jest.fn(() => ({
+          order: jest.fn(() => ({
+            order: jest.fn(() => Promise.resolve({ data: [], error: null })),
+          })),
+        })),
+      })),
+    } as unknown as AbstrackSupabaseClient;
+
+    jest.mocked(SecureStore.getItemAsync).mockResolvedValue('false');
+    jest.mocked(getMobileSupabaseClient).mockReturnValue(mockClient);
+
+    const { findByLabelText, findByTestId } = render(<App />);
+
+    expect(await findByTestId('episode-start-home-cta')).toBeTruthy();
+    fireEvent.press(await findByLabelText("I'm having an episode"));
+    expect(await findByTestId('episode-start-screen-title')).toBeTruthy();
+  });
+
   test('exposes the re-authentication toggle in settings', async () => {
     const signedInSession = {
       access_token: 'access',

--- a/apps/mobile/src/app/App.tsx
+++ b/apps/mobile/src/app/App.tsx
@@ -11,6 +11,7 @@ import { ForgotPasswordScreen } from './screens/ForgotPasswordScreen';
 import { MainTabNavigator } from './navigation/MainTabNavigator';
 import type { MainStackParamList } from './navigation/types';
 import { LoginScreen } from './screens/LoginScreen';
+import { EpisodeStartScreen } from './screens/EpisodeStartScreen';
 import { SettingsScreen } from './screens/SettingsScreen';
 import { SignupScreen } from './screens/SignupScreen';
 import { UpdatePasswordScreen } from './screens/UpdatePasswordScreen';
@@ -380,6 +381,11 @@ function AppBootstrap() {
               name="MainTabs"
               component={MainTabNavigator}
               options={{ headerShown: false }}
+            />
+            <MainStack.Screen
+              name="EpisodeStart"
+              component={EpisodeStartScreen}
+              options={{ title: 'Start an episode' }}
             />
             <MainStack.Screen
               name="Settings"

--- a/apps/mobile/src/app/components/episode-flow/EpisodeStartHomeCta.tsx
+++ b/apps/mobile/src/app/components/episode-flow/EpisodeStartHomeCta.tsx
@@ -49,7 +49,7 @@ export function EpisodeStartHomeCta({
           className="text-center text-[18px] font-semibold text-white"
           maxFontSizeMultiplier={2}
         >
-          I&apos;m having an episode
+          I'm having an episode
         </Text>
       </Pressable>
     </View>

--- a/apps/mobile/src/app/components/episode-flow/EpisodeStartHomeCta.tsx
+++ b/apps/mobile/src/app/components/episode-flow/EpisodeStartHomeCta.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Pressable, Text, View } from 'react-native';
+import { nw } from '../../theme/app-nativewind-classes';
+
+export type EpisodeStartHomeCtaProps = {
+  /** Invoked when the user starts the episode flow. */
+  onStartEpisode: () => void;
+};
+
+/**
+ * Prominent home entry point for episode logging: large touch target, high-contrast control, and
+ * supporting copy for VoiceOver and TalkBack.
+ *
+ * @param props - Props.
+ * @returns Episode CTA section for the home screen.
+ */
+export function EpisodeStartHomeCta({
+  onStartEpisode,
+}: EpisodeStartHomeCtaProps) {
+  return (
+    <View
+      testID="episode-start-home-cta"
+      accessibilityRole="none"
+      className={`mb-4 gap-3 rounded-2xl border-2 border-red-600/40 bg-red-50 p-4 dark:border-red-500/45 dark:bg-red-950/50`}
+    >
+      <Text
+        accessibilityRole="header"
+        className={`text-lg font-semibold ${nw.textInk}`}
+        maxFontSizeMultiplier={2}
+      >
+        Episode logging
+      </Text>
+      <Text
+        className={`text-base leading-relaxed ${nw.textMuted}`}
+        maxFontSizeMultiplier={2}
+      >
+        Opens the guided flow to record what you are experiencing during this
+        episode.
+      </Text>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="I'm having an episode"
+        accessibilityHint="Opens the guided episode logging flow"
+        accessibilityState={{ disabled: false }}
+        onPress={onStartEpisode}
+        className="min-h-[56px] items-center justify-center rounded-xl bg-red-700 px-4 py-4 active:opacity-90 dark:bg-red-600"
+      >
+        <Text
+          className="text-center text-[18px] font-semibold text-white"
+          maxFontSizeMultiplier={2}
+        >
+          I&apos;m having an episode
+        </Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/mobile/src/app/navigation/MainTabNavigator.tsx
+++ b/apps/mobile/src/app/navigation/MainTabNavigator.tsx
@@ -35,6 +35,19 @@ function navigateFromHomeTabToSettings(
   stackNavigation.navigate('Settings');
 }
 
+function navigateFromHomeTabToEpisodeStart(
+  navigation: BottomTabNavigationProp<MainTabParamList, 'Home'>,
+) {
+  const stackNavigation =
+    navigation.getParent<NativeStackNavigationProp<MainStackParamList>>();
+  if (stackNavigation == null) {
+    throw new Error(
+      'MainTabNavigator: expected native stack parent (MainStack) to open EpisodeStart.',
+    );
+  }
+  stackNavigation.navigate('EpisodeStart');
+}
+
 type IonName = React.ComponentProps<typeof Ionicons>['name'];
 
 /**
@@ -96,6 +109,9 @@ export function MainTabNavigator() {
             <HomeScreen
               onGoToSettings={() => {
                 navigateFromHomeTabToSettings(navigation);
+              }}
+              onStartEpisode={() => {
+                navigateFromHomeTabToEpisodeStart(navigation);
               }}
             />
           )}

--- a/apps/mobile/src/app/navigation/types.ts
+++ b/apps/mobile/src/app/navigation/types.ts
@@ -32,5 +32,7 @@ export type MainTabParamList = {
 
 export type MainStackParamList = {
   MainTabs: undefined;
+  /** Episode logging entry: shell until template selection and prompts ship. */
+  EpisodeStart: undefined;
   Settings: undefined;
 };

--- a/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import { ScreenShell } from '../components/ScreenShell';
+import { nw } from '../theme/app-nativewind-classes';
+
+/**
+ * Episode-start flow shell: reached from the home CTA. Template selection and prompts are added in
+ * follow-up work.
+ *
+ * @returns Placeholder content with stack header back navigation.
+ */
+export function EpisodeStartScreen() {
+  return (
+    <ScreenShell>
+      <Text
+        testID="episode-start-screen-title"
+        className={`text-[22px] font-semibold ${nw.textInk}`}
+        maxFontSizeMultiplier={2}
+      >
+        Start an episode
+      </Text>
+      <Text
+        className={`mt-3 text-base leading-relaxed ${nw.textMuted}`}
+        maxFontSizeMultiplier={2}
+      >
+        You are in the episode logging flow. Choosing an episode template and
+        stepping through prompts will be added here in follow-up work.
+      </Text>
+
+      <View
+        className="mt-6 rounded-lg bg-app-bg p-4 dark:bg-app-bg-dark"
+        accessibilityLiveRegion="polite"
+      >
+        <Text
+          className={`text-base leading-relaxed ${nw.textInk}`}
+          maxFontSizeMultiplier={2}
+        >
+          This screen confirms you reached the episode-start pathway from home.
+          Template selection and symptom prompts are not implemented on this
+          screen yet.
+        </Text>
+      </View>
+    </ScreenShell>
+  );
+}

--- a/apps/mobile/src/app/screens/HomeScreen.tsx
+++ b/apps/mobile/src/app/screens/HomeScreen.tsx
@@ -7,6 +7,7 @@ import {
 } from '@abstrack/supabase';
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { mapAuthError } from '../auth-helpers';
+import { EpisodeStartHomeCta } from '../components/episode-flow/EpisodeStartHomeCta';
 import { AppNavigationShell } from '../components/AppNavigationShell';
 import { nw } from '../theme/app-nativewind-classes';
 
@@ -18,9 +19,13 @@ interface HealthCheckResult {
 
 type HomeScreenProps = {
   onGoToSettings: () => void;
+  onStartEpisode: () => void;
 };
 
-export function HomeScreen({ onGoToSettings }: HomeScreenProps) {
+export function HomeScreen({
+  onGoToSettings,
+  onStartEpisode,
+}: HomeScreenProps) {
   const isTestEnv =
     typeof process !== 'undefined' && process.env.NODE_ENV === 'test';
   const showHealthCheck = __DEV__ && !isTestEnv;
@@ -125,10 +130,13 @@ export function HomeScreen({ onGoToSettings }: HomeScreenProps) {
         contentContainerStyle={{
           flexGrow: 1,
           padding: 16,
-          justifyContent: 'center',
+          paddingBottom: 24,
+          justifyContent: 'flex-start',
         }}
         keyboardShouldPersistTaps="handled"
       >
+        <EpisodeStartHomeCta onStartEpisode={onStartEpisode} />
+
         <View className={`gap-3 rounded-xl p-4 ${nw.card} ${nw.cardShadow}`}>
           <Text
             className={`text-[22px] font-semibold ${nw.textInk}`}

--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from 'next/navigation';
+import { EpisodeStartHomeCta } from '@/components/episode-flow/EpisodeStartHomeCta';
 import { createServerClient } from '@/lib/supabase/server-client';
 import { healthCheckProfilesLimit1 } from '@abstrack/supabase';
 
@@ -80,6 +81,8 @@ export default async function DashboardPage() {
           Account overview and development health checks.
         </p>
       </div>
+
+      <EpisodeStartHomeCta />
 
       <div className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8">
         {showHealthCheck && healthCheck && (

--- a/apps/web/src/app/(app)/episode/start/loading.tsx
+++ b/apps/web/src/app/(app)/episode/start/loading.tsx
@@ -1,0 +1,10 @@
+import { PageLoading } from '@/components/page-states/PageLoading';
+
+/**
+ * Route-level loading UI for the episode-start shell.
+ *
+ * @returns Loading fallback.
+ */
+export default function EpisodeStartLoading() {
+  return <PageLoading title="Start an episode" />;
+}

--- a/apps/web/src/app/(app)/episode/start/page.tsx
+++ b/apps/web/src/app/(app)/episode/start/page.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link';
+
+/**
+ * Episode-start flow shell: entry route after the home CTA. Template selection and prompts are
+ * implemented in follow-up work.
+ *
+ * @returns Episode start placeholder within the authenticated shell.
+ */
+export default function EpisodeStartPage() {
+  return (
+    <div className="w-full space-y-8">
+      <div>
+        <p className="text-sm font-medium text-app-muted">
+          <Link
+            href="/dashboard"
+            className="rounded-md text-app-primary underline decoration-app-primary/40 underline-offset-2 outline-none transition hover:text-app-ink hover:decoration-app-primary focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          >
+            ← Back to dashboard
+          </Link>
+        </p>
+        <h1 className="mt-4 text-2xl font-bold tracking-tight text-app-ink">
+          Start an episode
+        </h1>
+        <p className="mt-2 text-sm leading-relaxed text-app-muted">
+          You are in the episode logging flow. Choosing an episode template and
+          stepping through prompts will be added here in follow-up work.
+        </p>
+      </div>
+
+      <div
+        className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
+        role="status"
+        aria-live="polite"
+      >
+        <p className="text-sm leading-relaxed text-app-ink">
+          This screen confirms you reached the episode-start pathway from home.
+          Template selection and symptom prompts are not implemented on this
+          page yet.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(public)/page.tsx
+++ b/apps/web/src/app/(public)/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { EpisodeStartHomeCta } from '../../components/episode-flow/EpisodeStartHomeCta';
 import { useAuth } from '../../lib/auth-provider';
 import Link from 'next/link';
 
@@ -32,7 +33,8 @@ export default function Index() {
             dashboard.
           </p>
 
-          <div className="mt-8 space-y-3">
+          <div className="mt-8 space-y-4">
+            <EpisodeStartHomeCta />
             <Link
               href="/dashboard"
               className="block w-full rounded-full bg-app-primary py-3 text-center text-sm font-semibold text-white shadow-sm transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"

--- a/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import Link from 'next/link';
+import { useId } from 'react';
 
 export type EpisodeStartHomeCtaProps = {
   /** Extra classes for the outer section (spacing, etc.). */
@@ -7,7 +10,8 @@ export type EpisodeStartHomeCtaProps = {
 
 /**
  * Prominent home entry point for the episode logging flow: large target, high-contrast primary
- * control, and supporting copy for keyboard and touch users.
+ * control, and supporting copy for keyboard and touch users. Uses {@link useId} so multiple
+ * instances on one page do not duplicate DOM ids or break ARIA references.
  *
  * @param props - Props.
  * @returns Section with link to the episode-start shell route.
@@ -15,21 +19,22 @@ export type EpisodeStartHomeCtaProps = {
 export function EpisodeStartHomeCta({
   className = '',
 }: EpisodeStartHomeCtaProps) {
+  const instanceId = useId();
+  const headingId = `episode-start-home-cta-heading${instanceId}`;
+  const descId = `episode-start-home-cta-desc${instanceId}`;
+
   return (
     <section
       className={`rounded-2xl border-2 border-red-600/35 bg-red-50 p-5 shadow-sm ring-1 ring-red-900/10 dark:border-red-500/40 dark:bg-red-950/45 dark:ring-red-950/40 sm:p-6 ${className}`.trim()}
-      aria-labelledby="episode-start-home-cta-heading"
+      aria-labelledby={headingId}
     >
       <h2
-        id="episode-start-home-cta-heading"
+        id={headingId}
         className="text-lg font-semibold tracking-tight text-app-ink"
       >
         Episode logging
       </h2>
-      <p
-        id="episode-start-home-cta-desc"
-        className="mt-1.5 text-sm leading-relaxed text-app-muted"
-      >
+      <p id={descId} className="mt-1.5 text-sm leading-relaxed text-app-muted">
         Opens the guided flow to record what you are experiencing during this
         episode.
       </p>
@@ -37,7 +42,7 @@ export function EpisodeStartHomeCta({
         <Link
           href="/episode/start"
           className="inline-flex min-h-[56px] w-full items-center justify-center rounded-xl bg-red-700 px-5 py-4 text-center text-base font-semibold leading-snug text-white shadow-md outline-none ring-2 ring-transparent transition hover:bg-red-800 focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-red-50 dark:bg-red-600 dark:hover:bg-red-500 dark:focus-visible:ring-offset-red-950"
-          aria-describedby="episode-start-home-cta-desc"
+          aria-describedby={descId}
         >
           I&apos;m having an episode
         </Link>

--- a/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link';
+
+export type EpisodeStartHomeCtaProps = {
+  /** Extra classes for the outer section (spacing, etc.). */
+  className?: string;
+};
+
+/**
+ * Prominent home entry point for the episode logging flow: large target, high-contrast primary
+ * control, and supporting copy for keyboard and touch users.
+ *
+ * @param props - Props.
+ * @returns Section with link to the episode-start shell route.
+ */
+export function EpisodeStartHomeCta({
+  className = '',
+}: EpisodeStartHomeCtaProps) {
+  return (
+    <section
+      className={`rounded-2xl border-2 border-red-600/35 bg-red-50 p-5 shadow-sm ring-1 ring-red-900/10 dark:border-red-500/40 dark:bg-red-950/45 dark:ring-red-950/40 sm:p-6 ${className}`.trim()}
+      aria-labelledby="episode-start-home-cta-heading"
+    >
+      <h2
+        id="episode-start-home-cta-heading"
+        className="text-lg font-semibold tracking-tight text-app-ink"
+      >
+        Episode logging
+      </h2>
+      <p
+        id="episode-start-home-cta-desc"
+        className="mt-1.5 text-sm leading-relaxed text-app-muted"
+      >
+        Opens the guided flow to record what you are experiencing during this
+        episode.
+      </p>
+      <div className="mt-5">
+        <Link
+          href="/episode/start"
+          className="inline-flex min-h-[56px] w-full items-center justify-center rounded-xl bg-red-700 px-5 py-4 text-center text-base font-semibold leading-snug text-white shadow-md outline-none ring-2 ring-transparent transition hover:bg-red-800 focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-red-50 dark:bg-red-600 dark:hover:bg-red-500 dark:focus-visible:ring-offset-red-950"
+          aria-describedby="episode-start-home-cta-desc"
+        >
+          I&apos;m having an episode
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/proxy.spec.ts
+++ b/apps/web/src/proxy.spec.ts
@@ -127,6 +127,25 @@ describe('web auth proxy', () => {
     );
   });
 
+  it('redirects unauthenticated user from episode routes to /login', async () => {
+    createServerClientMock.mockImplementation(() =>
+      Promise.resolve({
+        auth: {
+          getUser: jest.fn(async () => ({ data: { user: null } })),
+        },
+      } as unknown as ServerClient),
+    );
+
+    const result = await proxy(makeRequest('/episode/start'));
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        type: 'redirect',
+        location: 'https://example.com/login',
+      }),
+    );
+  });
+
   it('redirects unauthenticated user from preset routes to /login', async () => {
     createServerClientMock.mockImplementation(() =>
       Promise.resolve({
@@ -161,6 +180,25 @@ describe('web auth proxy', () => {
       expect.objectContaining({
         type: 'redirect',
         location: 'https://example.com/',
+      }),
+    );
+  });
+
+  it('does not treat lookalike paths as protected (e.g. /episode-foo)', async () => {
+    const getUser = jest.fn(async () => ({ data: { user: null } }));
+
+    createServerClientMock.mockReturnValue(
+      Promise.resolve({
+        auth: { getUser },
+      } as unknown as ServerClient),
+    );
+
+    const result = await proxy(makeRequest('/episode-foo'));
+
+    expect(getUser).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(
+      expect.objectContaining({
+        type: 'next',
       }),
     );
   });

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from './lib/supabase/server-client';
 
 // Protected routes that require authentication
-const protectedRoutes = ['/dashboard', '/presets'];
+const protectedRoutes = ['/dashboard', '/presets', '/episode'];
 
 /**
  * True when `pathname` is exactly `route` or a nested path under it (e.g. `/presets/x`), not

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -86,7 +86,7 @@
 **Second half (April 16-19, school finished):**
 
 - [x] Database: migrations for (1) `episodes.health_marker_preset_id` (nullable FK to `health_marker_presets`, same-owner pattern as `symptom_preset_id`) and (2) **episode preset templates** table—each template row **requires both** `symptom_preset_id` and `health_marker_preset_id` (NOT NULL; CASCADE if either preset is deleted) + RLS; regenerate `database.types.ts` and clients per [SUPABASE_CLOUD_DEVELOPER.md](SUPABASE_CLOUD_DEVELOPER.md). Template rows must exist **before** the episode-start template picker can list choices ([PRD](PRD.md) §4, [user story](user-stories/episode-and-health-marker-flows.md))
-- [ ] **Settings:** UI to create/edit **episode templates** (pair a symptom preset with a health marker preset under one name, e.g. ABS vs CVS)—done when the user is well, so episode start stays one-tap
+- [x] **Settings:** UI to create/edit **episode templates** (pair a symptom preset with a health marker preset under one name, e.g. ABS vs CVS)—done when the user is well, so episode start stays one-tap
 - [ ] "I'm having an episode" button on home screen
 - [ ] Episode start: user selects **one episode template** per session; insert episode with both `symptom_preset_id` and `health_marker_preset_id` resolved from that template ([user story](user-stories/episode-and-health-marker-flows.md))
 - [ ] Prompt flow skeleton: step through symptoms one at a time, render correct input type per symptom

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -87,7 +87,7 @@
 
 - [x] Database: migrations for (1) `episodes.health_marker_preset_id` (nullable FK to `health_marker_presets`, same-owner pattern as `symptom_preset_id`) and (2) **episode preset templates** table—each template row **requires both** `symptom_preset_id` and `health_marker_preset_id` (NOT NULL; CASCADE if either preset is deleted) + RLS; regenerate `database.types.ts` and clients per [SUPABASE_CLOUD_DEVELOPER.md](SUPABASE_CLOUD_DEVELOPER.md). Template rows must exist **before** the episode-start template picker can list choices ([PRD](PRD.md) §4, [user story](user-stories/episode-and-health-marker-flows.md))
 - [x] **Settings:** UI to create/edit **episode templates** (pair a symptom preset with a health marker preset under one name, e.g. ABS vs CVS)—done when the user is well, so episode start stays one-tap
-- [ ] "I'm having an episode" button on home screen
+- [x] "I'm having an episode" button on home screen
 - [ ] Episode start: user selects **one episode template** per session; insert episode with both `symptom_preset_id` and `health_marker_preset_id` resolved from that template ([user story](user-stories/episode-and-health-marker-flows.md))
 - [ ] Prompt flow skeleton: step through symptoms one at a time, render correct input type per symptom
 - [ ] Episode data wired to Supabase: plaintext columns under RLS (no client-side field encryption)


### PR DESCRIPTION
Closes #73

## Summary

Adds the prominent **“I’m having an episode”** entry point on patient home (web and mobile) and routes into a dedicated **episode-start shell** so the pathway is stable before template selection and prompts land.

## Web (`apps/web`)

- New **`EpisodeStartHomeCta`** section with a large, high-contrast primary control and supporting copy; **`aria-describedby`** on the link for context.
- Surfaces the CTA on **Dashboard**, the **signed-in** landing at `/`, and **`/episode/start`** as the shell route (placeholder copy; template/symptom work out of scope).
- Auth **proxy** treats **`/episode`** as protected; **Jest** covers redirects and `/episode-foo` lookalikes.

## Mobile (`apps/mobile`)

- **`EpisodeStartHomeCta`** at the **top** of Home (no vertical centering) so the action is visible immediately; **56dp** minimum height, label + hint, capped dynamic type on key text.
- **`EpisodeStart`** pushed on **`MainStack`** (same pattern as Settings) with stack header back navigation.
- **App test** asserts navigation from the home CTA to the episode-start screen.

## How to verify

- **Web:** Sign in → Dashboard and/or `/` → tap CTA → `/episode/start`; sign out → `/episode/start` redirects to login.
- **Mobile:** Sign in → Home → tap **I’m having an episode** → episode-start screen; use back to return.

## Notes

Template picker, episode row creation, and symptom prompts remain future work; this PR only establishes the entry path and shell.