### PR TITLE
feat(episode-start): add template picker, persist preset IDs, auto-start when only one template

### DIFF
--- a/apps/mobile/src/app/App.tsx
+++ b/apps/mobile/src/app/App.tsx
@@ -385,7 +385,10 @@ function AppBootstrap() {
             <MainStack.Screen
               name="EpisodeStart"
               component={EpisodeStartScreen}
-              options={{ title: 'Start an episode' }}
+              options={{
+                title: '',
+                headerBackTitle: 'Home',
+              }}
             />
             <MainStack.Screen
               name="Settings"

--- a/apps/mobile/src/app/components/ScreenShell.tsx
+++ b/apps/mobile/src/app/components/ScreenShell.tsx
@@ -3,8 +3,20 @@ import { View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { nw } from '../theme/app-nativewind-classes';
 
+export type ScreenShellContentAlign = 'center' | 'stretch';
+
+export type ScreenShellProps = {
+  children: React.ReactNode;
+  /**
+   * `center` (default): vertically centers the card for short forms (auth, settings).
+   * `stretch`: card fills the safe area from the top — use for scrollable or multi-section flows
+   * so headings stay fully inside the card surface.
+   */
+  contentAlign?: ScreenShellContentAlign;
+};
+
 /**
- * Auth and form screens: safe area, centered layout, card surface aligned with web app shell.
+ * Auth and form screens: safe area, card surface aligned with web app shell.
  *
  * Semantic colors use static `rgb()` tokens from `tailwind.config.js` with `dark:` pairs
  * (`nw` in `app-nativewind-classes.ts`).
@@ -12,13 +24,20 @@ import { nw } from '../theme/app-nativewind-classes';
  * @param props - Child content inside the card.
  * @returns Themed shell layout.
  */
-export function ScreenShell({ children }: { children: React.ReactNode }) {
+export function ScreenShell({
+  children,
+  contentAlign = 'center',
+}: ScreenShellProps) {
+  const stretch = contentAlign === 'stretch';
+
   return (
     <SafeAreaView
-      className={`flex-1 justify-center p-4 ${nw.screenBg}`}
+      className={`flex-1 p-4 ${stretch ? '' : 'justify-center'} ${nw.screenBg}`}
       edges={['top', 'left', 'right', 'bottom']}
     >
-      <View className={`gap-3 rounded-xl p-4 ${nw.card} ${nw.cardShadow}`}>
+      <View
+        className={`gap-3 rounded-xl p-4 ${stretch ? 'min-h-0 w-full flex-1' : ''} ${nw.card} ${nw.cardShadow}`}
+      >
         {children}
       </View>
     </SafeAreaView>

--- a/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
@@ -35,6 +35,13 @@ type FlowPhase = 'pick' | 'done';
 export function EpisodeStartScreen() {
   const navigation = useNavigation<EpisodeStartNav>();
   const phaseRef = useRef<FlowPhase>('pick');
+  /** Increments on each screen focus; scopes single-template auto-start idempotency to the current focus cycle. */
+  const focusCycleIdRef = useRef(0);
+  /** Prevents concurrent `saveEpisodeWithTemplatePresets` on the single-template path when `load` runs more than once before success. */
+  const singleTemplateAutoInFlightRef = useRef(false);
+  /** `focusCycleId` for which single-template auto-start already succeeded (skips duplicate inserts until a new focus cycle). */
+  const singleTemplateAutoSucceededCycleIdRef = useRef<number | null>(null);
+
   const [status, setStatus] = useState<'loading' | 'error' | 'ready'>(
     'loading',
   );
@@ -49,80 +56,102 @@ export function EpisodeStartScreen() {
   const [phase, setPhase] = useState<FlowPhase>('pick');
   phaseRef.current = phase;
 
-  const load = useCallback(async (focusCancel?: FocusLoadCancel) => {
-    const stale = () => focusCancel?.cancelled === true;
+  const load = useCallback(
+    async (focusCancel?: FocusLoadCancel, focusCycle?: number) => {
+      const cycleId = focusCycle ?? focusCycleIdRef.current;
+      const stale = () => focusCancel?.cancelled === true;
 
-    setStatus('loading');
-    setErrorMessage(null);
-    setEpisodeStartError(null);
-    const authResult = await getCurrentUserId();
-    if (stale()) {
-      return;
-    }
-    if (!authResult.ok) {
-      setErrorMessage(authResult.error.message);
-      setStatus('error');
-      return;
-    }
-    if (authResult.data === null) {
-      setErrorMessage('You need to be signed in to start an episode.');
-      setStatus('error');
-      return;
-    }
-    const userId = authResult.data;
-    const result = await fetchEpisodeTemplates();
-    if (stale()) {
-      return;
-    }
-    if (!result.ok) {
-      setErrorMessage(result.error.message);
-      setStatus('error');
-      return;
-    }
-
-    setRows(result.data);
-
-    if (result.data.length === 1) {
-      const template = result.data[0];
-      setSubmitting(true);
-      const saveResult = await saveEpisodeWithTemplatePresets({
-        userId,
-        symptomPresetId: template.symptom_preset_id,
-        healthMarkerPresetId: template.health_marker_preset_id,
-      });
-      setSubmitting(false);
+      setStatus('loading');
+      setErrorMessage(null);
+      setEpisodeStartError(null);
+      const authResult = await getCurrentUserId();
       if (stale()) {
         return;
       }
-      if (!saveResult.ok) {
-        setSelectedId(template.id);
-        setEpisodeStartError(saveResult.error.message);
-        announce(saveResult.error.message);
-        setStatus('ready');
+      if (!authResult.ok) {
+        setErrorMessage(authResult.error.message);
+        setStatus('error');
         return;
       }
-      announce('Episode started.');
-      setPhase('done');
-      setStatus('ready');
-      return;
-    }
-
-    setSelectedId((prev) => {
-      if (prev && result.data.some((r) => r.id === prev)) {
-        return prev;
+      if (authResult.data === null) {
+        setErrorMessage('You need to be signed in to start an episode.');
+        setStatus('error');
+        return;
       }
-      return null;
-    });
-    setStatus('ready');
-  }, []);
+      const userId = authResult.data;
+      const result = await fetchEpisodeTemplates();
+      if (stale()) {
+        return;
+      }
+      if (!result.ok) {
+        setErrorMessage(result.error.message);
+        setStatus('error');
+        return;
+      }
+
+      setRows(result.data);
+
+      if (result.data.length === 1) {
+        if (singleTemplateAutoSucceededCycleIdRef.current === cycleId) {
+          setPhase('done');
+          setStatus('ready');
+          return;
+        }
+        if (singleTemplateAutoInFlightRef.current) {
+          setStatus('loading');
+          return;
+        }
+
+        const template = result.data[0];
+        singleTemplateAutoInFlightRef.current = true;
+        setSubmitting(true);
+        try {
+          const saveResult = await saveEpisodeWithTemplatePresets({
+            userId,
+            symptomPresetId: template.symptom_preset_id,
+            healthMarkerPresetId: template.health_marker_preset_id,
+          });
+          if (stale()) {
+            return;
+          }
+          if (!saveResult.ok) {
+            setSelectedId(template.id);
+            setEpisodeStartError(saveResult.error.message);
+            announce(saveResult.error.message);
+            setStatus('ready');
+            return;
+          }
+          singleTemplateAutoSucceededCycleIdRef.current = cycleId;
+          announce('Episode started.');
+          setPhase('done');
+          setStatus('ready');
+        } finally {
+          singleTemplateAutoInFlightRef.current = false;
+          setSubmitting(false);
+        }
+        return;
+      }
+
+      setSelectedId((prev) => {
+        if (prev && result.data.some((r) => r.id === prev)) {
+          return prev;
+        }
+        return null;
+      });
+      setStatus('ready');
+    },
+    [],
+  );
 
   useFocusEffect(
     useCallback(() => {
       if (phaseRef.current === 'done') {
         return;
       }
+      focusCycleIdRef.current += 1;
+      const cycleId = focusCycleIdRef.current;
       const focusCancel: FocusLoadCancel = { cancelled: false };
-      void load(focusCancel);
+      void load(focusCancel, cycleId);
       return () => {
         focusCancel.cancelled = true;
       };

--- a/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
@@ -127,11 +127,14 @@ export function EpisodeStartScreen() {
           setStatus('ready');
         } finally {
           singleTemplateAutoInFlightRef.current = false;
-          setSubmitting(false);
+          if (!stale()) {
+            setSubmitting(false);
+          }
         }
         return;
       }
 
+      setSubmitting(false);
       setSelectedId((prev) => {
         if (prev && result.data.some((r) => r.id === prev)) {
           return prev;
@@ -176,11 +179,14 @@ export function EpisodeStartScreen() {
     try {
       const authResult = await getCurrentUserId();
       if (!authResult.ok) {
+        setEpisodeStartError(authResult.error.message);
         announce(authResult.error.message);
         return;
       }
       if (authResult.data === null) {
-        announce('You need to be signed in to start an episode.');
+        const message = 'You need to be signed in to start an episode.';
+        setEpisodeStartError(message);
+        announce(message);
         return;
       }
       const result = await saveEpisodeWithTemplatePresets({

--- a/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
@@ -41,6 +41,8 @@ export function EpisodeStartScreen() {
   const singleTemplateAutoInFlightRef = useRef(false);
   /** `focusCycleId` for which single-template auto-start already succeeded (skips duplicate inserts until a new focus cycle). */
   const singleTemplateAutoSucceededCycleIdRef = useRef<number | null>(null);
+  /** Current focus session’s cancellation token; set in `useFocusEffect` and passed to every `load()` so blur cancels in-flight work (including Retry). */
+  const focusCancelRef = useRef<FocusLoadCancel | null>(null);
 
   const [status, setStatus] = useState<'loading' | 'error' | 'ready'>(
     'loading',
@@ -154,6 +156,7 @@ export function EpisodeStartScreen() {
       focusCycleIdRef.current += 1;
       const cycleId = focusCycleIdRef.current;
       const focusCancel: FocusLoadCancel = { cancelled: false };
+      focusCancelRef.current = focusCancel;
       void load(focusCancel, cycleId);
       return () => {
         focusCancel.cancelled = true;
@@ -163,6 +166,7 @@ export function EpisodeStartScreen() {
 
   const onSelectTemplate = (id: string) => {
     setSelectedId(id);
+    setEpisodeStartError(null);
     announce(`${rows.find((r) => r.id === id)?.name ?? 'Template'} selected.`);
   };
 
@@ -251,7 +255,11 @@ export function EpisodeStartScreen() {
             errorTitle="Could not load templates"
             errorMessage={errorMessage ?? undefined}
             onRetry={() => {
-              void load();
+              const token = focusCancelRef.current;
+              if (token == null) {
+                return;
+              }
+              void load(token, focusCycleIdRef.current);
             }}
           >
             <ScrollView

--- a/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
@@ -1,44 +1,342 @@
-import React from 'react';
-import { Text, View } from 'react-native';
+import React, { useCallback, useRef, useState } from 'react';
+import { Pressable, ScrollView, Text, View } from 'react-native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { EpisodeTemplateWithPresetsRow } from '@abstrack/types';
+import { announce } from '@abstrack/ui/native';
+import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
+import {
+  fetchEpisodeTemplates,
+  getCurrentUserId,
+} from '../../lib/episode-templates/episode-template-service';
+import { saveEpisodeWithTemplatePresets } from '../../lib/episodes/episode-start-service';
+import { AsyncScreenContainer } from '../components/AsyncScreenContainer';
 import { ScreenShell } from '../components/ScreenShell';
+import type { MainStackParamList } from '../navigation/types';
 import { nw } from '../theme/app-nativewind-classes';
 
+/** Token for focus-scoped loads. */
+type FocusLoadCancel = { cancelled: boolean };
+
+type EpisodeStartNav = NativeStackNavigationProp<
+  MainStackParamList,
+  'EpisodeStart'
+>;
+
+type FlowPhase = 'pick' | 'done';
+
 /**
- * Episode-start flow shell: reached from the home CTA. Template selection and prompts are added in
- * follow-up work.
+ * Episode-start flow: if there is exactly one episode template, start the episode immediately
+ * (no tap-through). Otherwise pick a template, then create an episode with both preset ids from
+ * that template (no separate symptom or health-marker pickers).
  *
- * @returns Placeholder content with stack header back navigation.
+ * @returns Template picker and start action for the impaired-use pathway.
  */
 export function EpisodeStartScreen() {
-  return (
-    <ScreenShell>
-      <Text
-        testID="episode-start-screen-title"
-        className={`text-[22px] font-semibold ${nw.textInk}`}
-        maxFontSizeMultiplier={2}
-      >
-        Start an episode
-      </Text>
-      <Text
-        className={`mt-3 text-base leading-relaxed ${nw.textMuted}`}
-        maxFontSizeMultiplier={2}
-      >
-        You are in the episode logging flow. Choosing an episode template and
-        stepping through prompts will be added here in follow-up work.
-      </Text>
+  const navigation = useNavigation<EpisodeStartNav>();
+  const phaseRef = useRef<FlowPhase>('pick');
+  const [status, setStatus] = useState<'loading' | 'error' | 'ready'>(
+    'loading',
+  );
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  /** Set when auto-start (single template) fails; user can retry with Start episode. */
+  const [episodeStartError, setEpisodeStartError] = useState<string | null>(
+    null,
+  );
+  const [rows, setRows] = useState<EpisodeTemplateWithPresetsRow[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [phase, setPhase] = useState<FlowPhase>('pick');
+  phaseRef.current = phase;
 
-      <View
-        className="mt-6 rounded-lg bg-app-bg p-4 dark:bg-app-bg-dark"
-        accessibilityLiveRegion="polite"
-      >
+  const load = useCallback(async (focusCancel?: FocusLoadCancel) => {
+    const stale = () => focusCancel?.cancelled === true;
+
+    setStatus('loading');
+    setErrorMessage(null);
+    setEpisodeStartError(null);
+    const authResult = await getCurrentUserId();
+    if (stale()) {
+      return;
+    }
+    if (!authResult.ok) {
+      setErrorMessage(authResult.error.message);
+      setStatus('error');
+      return;
+    }
+    if (authResult.data === null) {
+      setErrorMessage('You need to be signed in to start an episode.');
+      setStatus('error');
+      return;
+    }
+    const userId = authResult.data;
+    const result = await fetchEpisodeTemplates();
+    if (stale()) {
+      return;
+    }
+    if (!result.ok) {
+      setErrorMessage(result.error.message);
+      setStatus('error');
+      return;
+    }
+
+    setRows(result.data);
+
+    if (result.data.length === 1) {
+      const template = result.data[0];
+      setSubmitting(true);
+      const saveResult = await saveEpisodeWithTemplatePresets({
+        userId,
+        symptomPresetId: template.symptom_preset_id,
+        healthMarkerPresetId: template.health_marker_preset_id,
+      });
+      setSubmitting(false);
+      if (stale()) {
+        return;
+      }
+      if (!saveResult.ok) {
+        setSelectedId(template.id);
+        setEpisodeStartError(saveResult.error.message);
+        announce(saveResult.error.message);
+        setStatus('ready');
+        return;
+      }
+      announce('Episode started.');
+      setPhase('done');
+      setStatus('ready');
+      return;
+    }
+
+    setSelectedId((prev) => {
+      if (prev && result.data.some((r) => r.id === prev)) {
+        return prev;
+      }
+      return null;
+    });
+    setStatus('ready');
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (phaseRef.current === 'done') {
+        return;
+      }
+      const focusCancel: FocusLoadCancel = { cancelled: false };
+      void load(focusCancel);
+      return () => {
+        focusCancel.cancelled = true;
+      };
+    }, [load]),
+  );
+
+  const onSelectTemplate = (id: string) => {
+    setSelectedId(id);
+    announce(`${rows.find((r) => r.id === id)?.name ?? 'Template'} selected.`);
+  };
+
+  const onStartEpisode = async () => {
+    if (selectedId === null || submitting) {
+      return;
+    }
+    const template = rows.find((r) => r.id === selectedId);
+    if (!template) {
+      return;
+    }
+    setEpisodeStartError(null);
+    setSubmitting(true);
+    try {
+      const authResult = await getCurrentUserId();
+      if (!authResult.ok) {
+        announce(authResult.error.message);
+        return;
+      }
+      if (authResult.data === null) {
+        announce('You need to be signed in to start an episode.');
+        return;
+      }
+      const result = await saveEpisodeWithTemplatePresets({
+        userId: authResult.data,
+        symptomPresetId: template.symptom_preset_id,
+        healthMarkerPresetId: template.health_marker_preset_id,
+      });
+      if (!result.ok) {
+        setEpisodeStartError(result.error.message);
+        announce(result.error.message);
+        return;
+      }
+      setEpisodeStartError(null);
+      announce('Episode started.');
+      setPhase('done');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <ScreenShell contentAlign="stretch">
+      <View className="min-h-0 flex-1 gap-4">
         <Text
-          className={`text-base leading-relaxed ${nw.textInk}`}
+          testID="episode-start-screen-title"
+          accessibilityRole="header"
+          className={`text-[22px] font-semibold ${nw.textInk}`}
           maxFontSizeMultiplier={2}
         >
-          This screen confirms you reached the episode-start pathway from home.
-          Template selection and symptom prompts are not implemented on this
-          screen yet.
+          Start an episode
         </Text>
+
+        {phase === 'done' ? (
+          <View className="gap-4" accessibilityLiveRegion="polite">
+            <Text
+              className={`text-base leading-relaxed ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            >
+              Your episode has been started with the template you chose. Use
+              Back when you are ready to return home.
+            </Text>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Back to home"
+              onPress={() => {
+                navigation.goBack();
+              }}
+              style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+              className="items-center justify-center rounded-xl bg-red-700 px-4 py-4 active:opacity-90 dark:bg-red-600"
+            >
+              <Text className="text-center text-[17px] font-semibold text-white">
+                Back to home
+              </Text>
+            </Pressable>
+          </View>
+        ) : (
+          <AsyncScreenContainer
+            status={status}
+            loadingAccessibilityLabel={
+              submitting ? 'Starting episode' : 'Loading episode templates'
+            }
+            errorTitle="Could not load templates"
+            errorMessage={errorMessage ?? undefined}
+            onRetry={() => {
+              void load();
+            }}
+          >
+            <ScrollView
+              testID="episode-start-template-scroll"
+              className="flex-1"
+              keyboardShouldPersistTaps="handled"
+              contentContainerStyle={{ paddingBottom: 16 }}
+            >
+              {rows.length === 1 ? (
+                <Text
+                  className={`mb-4 text-base leading-relaxed ${nw.textMuted}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  Your episode uses the template below for symptoms and health
+                  markers.
+                </Text>
+              ) : rows.length > 1 ? (
+                <Text
+                  className={`mb-4 text-base leading-relaxed ${nw.textMuted}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  Tap one template for this episode. It sets both your symptom
+                  list and health markers for this episode.
+                </Text>
+              ) : null}
+
+              {episodeStartError ? (
+                <Text
+                  accessibilityRole="alert"
+                  className={`mb-4 text-base leading-relaxed ${nw.textError}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  {episodeStartError}
+                </Text>
+              ) : null}
+
+              {rows.length === 0 ? (
+                <View
+                  className="rounded-xl bg-app-bg p-4 dark:bg-app-bg-dark"
+                  accessibilityRole="text"
+                >
+                  <Text
+                    className={`text-base leading-relaxed ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    You do not have any episode templates yet. Open the
+                    Templates tab, create a template, then come back here.
+                  </Text>
+                </View>
+              ) : (
+                <View
+                  accessibilityRole="radiogroup"
+                  accessibilityLabel="Episode templates"
+                >
+                  {rows.map((row) => {
+                    const selected = selectedId === row.id;
+                    return (
+                      <Pressable
+                        key={row.id}
+                        testID={`episode-start-template-option-${row.id}`}
+                        accessibilityRole="radio"
+                        accessibilityState={{ selected, disabled: submitting }}
+                        accessibilityLabel={`${row.name}. Symptoms: ${row.symptom_preset.name}. Health markers: ${row.health_marker_preset.name}.`}
+                        onPress={() => {
+                          if (!submitting) {
+                            onSelectTemplate(row.id);
+                          }
+                        }}
+                        className={`mb-3 rounded-2xl border-2 p-4 active:opacity-90 ${
+                          selected
+                            ? 'border-red-600 bg-red-50 dark:border-red-500 dark:bg-red-950/40'
+                            : 'border-app-border bg-app-bg dark:border-app-border-dark dark:bg-app-bg-dark'
+                        }`}
+                      >
+                        <Text
+                          className={`text-[18px] font-semibold ${nw.textInk}`}
+                          maxFontSizeMultiplier={2}
+                        >
+                          {row.name}
+                        </Text>
+                        <Text
+                          className={`mt-2 text-sm leading-relaxed ${nw.textMuted}`}
+                          maxFontSizeMultiplier={2}
+                        >
+                          Symptoms: {row.symptom_preset.name}
+                        </Text>
+                        <Text
+                          className={`mt-1 text-sm leading-relaxed ${nw.textMuted}`}
+                          maxFontSizeMultiplier={2}
+                        >
+                          Markers: {row.health_marker_preset.name}
+                        </Text>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              )}
+
+              {rows.length > 0 ? (
+                <Pressable
+                  testID="episode-start-submit"
+                  accessibilityRole="button"
+                  accessibilityLabel="Start episode with selected template"
+                  accessibilityState={{
+                    disabled: selectedId === null || submitting,
+                  }}
+                  disabled={selectedId === null || submitting}
+                  onPress={() => {
+                    void onStartEpisode();
+                  }}
+                  className={`mt-4 min-h-[56px] items-center justify-center rounded-xl bg-red-700 px-4 py-4 active:opacity-90 disabled:opacity-50 dark:bg-red-600`}
+                >
+                  <Text className="text-center text-[18px] font-semibold text-white">
+                    {submitting ? 'Starting…' : 'Start episode'}
+                  </Text>
+                </Pressable>
+              ) : null}
+            </ScrollView>
+          </AsyncScreenContainer>
+        )}
       </View>
     </ScreenShell>
   );

--- a/apps/mobile/src/lib/episodes/episode-start-service.ts
+++ b/apps/mobile/src/lib/episodes/episode-start-service.ts
@@ -1,0 +1,25 @@
+/**
+ * Episode start persistence: inserts an `episodes` row with preset ids resolved from a template.
+ */
+import type { EpisodeRow } from '@abstrack/types';
+import type { PresetDataResult } from '@abstrack/supabase';
+import { createEpisode } from '@abstrack/supabase';
+import { getMobileSupabaseClient } from '../supabase-wiring';
+
+/**
+ * Creates an episode row with both preset columns set (symptom + health marker from the template).
+ *
+ * @param args - Signed-in user id and preset ids from the chosen {@link EpisodeTemplateRow}.
+ */
+export function saveEpisodeWithTemplatePresets(args: {
+  userId: string;
+  symptomPresetId: string;
+  healthMarkerPresetId: string;
+}): Promise<PresetDataResult<EpisodeRow>> {
+  return createEpisode(getMobileSupabaseClient(), {
+    user_id: args.userId,
+    started_at: new Date().toISOString(),
+    symptom_preset_id: args.symptomPresetId,
+    health_marker_preset_id: args.healthMarkerPresetId,
+  });
+}

--- a/apps/mobile/src/lib/episodes/episode-start-service.ts
+++ b/apps/mobile/src/lib/episodes/episode-start-service.ts
@@ -7,9 +7,13 @@ import { createEpisode } from '@abstrack/supabase';
 import { getMobileSupabaseClient } from '../supabase-wiring';
 
 /**
- * Creates an episode row with both preset columns set (symptom + health marker from the template).
+ * Creates an episode row with `symptom_preset_id` and `health_marker_preset_id` set (typically the
+ * pair taken from an episode template or an explicit picker).
  *
- * @param args - Signed-in user id and preset ids from the chosen {@link EpisodeTemplateRow}.
+ * @param args - Insert payload.
+ * @param args.userId - Authenticated user id for `episodes.user_id` (must satisfy RLS).
+ * @param args.symptomPresetId - `symptom_presets.id`.
+ * @param args.healthMarkerPresetId - `health_marker_presets.id`.
  */
 export function saveEpisodeWithTemplatePresets(args: {
   userId: string;

--- a/apps/web/src/app/(app)/episode/start/page.tsx
+++ b/apps/web/src/app/(app)/episode/start/page.tsx
@@ -1,10 +1,10 @@
 import Link from 'next/link';
+import { EpisodeStartFlow } from '@/components/episode-flow/EpisodeStartFlow';
 
 /**
- * Episode-start flow shell: entry route after the home CTA. Template selection and prompts are
- * implemented in follow-up work.
+ * Episode-start flow: template picker and episode row creation after the home CTA.
  *
- * @returns Episode start placeholder within the authenticated shell.
+ * @returns Authenticated episode start page.
  */
 export default function EpisodeStartPage() {
   return (
@@ -18,26 +18,8 @@ export default function EpisodeStartPage() {
             ← Back to dashboard
           </Link>
         </p>
-        <h1 className="mt-4 text-2xl font-bold tracking-tight text-app-ink">
-          Start an episode
-        </h1>
-        <p className="mt-2 text-sm leading-relaxed text-app-muted">
-          You are in the episode logging flow. Choosing an episode template and
-          stepping through prompts will be added here in follow-up work.
-        </p>
       </div>
-
-      <div
-        className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
-        role="status"
-        aria-live="polite"
-      >
-        <p className="text-sm leading-relaxed text-app-ink">
-          This screen confirms you reached the episode-start pathway from home.
-          Template selection and symptom prompts are not implemented on this
-          page yet.
-        </p>
-      </div>
+      <EpisodeStartFlow />
     </div>
   );
 }

--- a/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
@@ -22,6 +22,9 @@ export function EpisodeStartFlow() {
   const { announce } = useAnnounce();
   const groupLegendId = useId();
   const phaseRef = useRef<FlowPhase>('pick');
+  /** Prevents concurrent or repeated `createEpisode` on the single-template auto-start path when `refresh` runs more than once before `phase` is `done`. */
+  const singleTemplateAutoInFlightRef = useRef(false);
+  const singleTemplateAutoSucceededRef = useRef(false);
 
   const [rows, setRows] = useState<EpisodeTemplateWithPresetsRow[]>([]);
   const [loadState, setLoadState] = useState<'idle' | 'loading' | 'error'>(
@@ -52,25 +55,41 @@ export function EpisodeStartFlow() {
     setRows(result.data);
 
     if (result.data.length === 1) {
-      const template = result.data[0];
-      setSubmitting(true);
-      const saveResult = await createEpisode(supabase, {
-        user_id: userId,
-        started_at: new Date().toISOString(),
-        symptom_preset_id: template.symptom_preset_id,
-        health_marker_preset_id: template.health_marker_preset_id,
-      });
-      setSubmitting(false);
-      if (!saveResult.ok) {
-        setSelectedId(template.id);
-        setSubmitError(saveResult.error.message);
-        announce(saveResult.error.message, { politeness: 'assertive' });
+      if (singleTemplateAutoSucceededRef.current) {
+        setPhase('done');
         setLoadState('idle');
         return;
       }
-      announce('Episode started.', { politeness: 'polite' });
-      setPhase('done');
-      setLoadState('idle');
+      if (singleTemplateAutoInFlightRef.current) {
+        setLoadState('loading');
+        return;
+      }
+
+      const template = result.data[0];
+      singleTemplateAutoInFlightRef.current = true;
+      setSubmitting(true);
+      try {
+        const saveResult = await createEpisode(supabase, {
+          user_id: userId,
+          started_at: new Date().toISOString(),
+          symptom_preset_id: template.symptom_preset_id,
+          health_marker_preset_id: template.health_marker_preset_id,
+        });
+        if (!saveResult.ok) {
+          setSelectedId(template.id);
+          setSubmitError(saveResult.error.message);
+          announce(saveResult.error.message, { politeness: 'assertive' });
+          setLoadState('idle');
+          return;
+        }
+        singleTemplateAutoSucceededRef.current = true;
+        announce('Episode started.', { politeness: 'polite' });
+        setPhase('done');
+        setLoadState('idle');
+      } finally {
+        singleTemplateAutoInFlightRef.current = false;
+        setSubmitting(false);
+      }
       return;
     }
 

--- a/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
@@ -1,0 +1,322 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import type { EpisodeTemplateWithPresetsRow } from '@abstrack/types';
+import { createEpisode, listEpisodeTemplates } from '@abstrack/supabase';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import { createBrowserClient } from '@/lib/supabase/browser-client';
+import { useAuth } from '@/lib/auth-provider';
+
+type FlowPhase = 'pick' | 'done';
+
+/**
+ * Impaired-friendly episode start: load templates; if there is exactly one template, create the
+ * episode immediately. Otherwise require one selection, then insert an episode row with both
+ * linked preset ids.
+ *
+ * @returns Client UI for `/episode/start`.
+ */
+export function EpisodeStartFlow() {
+  const { session, loading: authLoading } = useAuth();
+  const { announce } = useAnnounce();
+  const groupLegendId = useId();
+  const phaseRef = useRef<FlowPhase>('pick');
+
+  const [rows, setRows] = useState<EpisodeTemplateWithPresetsRow[]>([]);
+  const [loadState, setLoadState] = useState<'idle' | 'loading' | 'error'>(
+    'loading',
+  );
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [phase, setPhase] = useState<FlowPhase>('pick');
+  phaseRef.current = phase;
+
+  const refresh = useCallback(async (): Promise<void> => {
+    const userId = session?.user?.id;
+    if (!userId) {
+      return;
+    }
+    const supabase = createBrowserClient();
+    setLoadState('loading');
+    setLoadError(null);
+    setSubmitError(null);
+    const result = await listEpisodeTemplates(supabase);
+    if (!result.ok) {
+      setLoadState('error');
+      setLoadError(result.error.message);
+      return;
+    }
+    setRows(result.data);
+
+    if (result.data.length === 1) {
+      const template = result.data[0];
+      setSubmitting(true);
+      const saveResult = await createEpisode(supabase, {
+        user_id: userId,
+        started_at: new Date().toISOString(),
+        symptom_preset_id: template.symptom_preset_id,
+        health_marker_preset_id: template.health_marker_preset_id,
+      });
+      setSubmitting(false);
+      if (!saveResult.ok) {
+        setSelectedId(template.id);
+        setSubmitError(saveResult.error.message);
+        announce(saveResult.error.message, { politeness: 'assertive' });
+        setLoadState('idle');
+        return;
+      }
+      announce('Episode started.', { politeness: 'polite' });
+      setPhase('done');
+      setLoadState('idle');
+      return;
+    }
+
+    setLoadState('idle');
+    setSelectedId((prev) => {
+      if (prev && result.data.some((r) => r.id === prev)) {
+        return prev;
+      }
+      return null;
+    });
+  }, [announce, session?.user?.id]);
+
+  useEffect(() => {
+    if (authLoading || !session?.user?.id || phaseRef.current === 'done') {
+      return;
+    }
+    void refresh();
+  }, [authLoading, session?.user?.id, refresh]);
+
+  const onSubmit = async (): Promise<void> => {
+    if (!session?.user?.id || selectedId === null || submitting) {
+      return;
+    }
+    const template = rows.find((r) => r.id === selectedId);
+    if (!template) {
+      return;
+    }
+    setSubmitting(true);
+    setSubmitError(null);
+    const supabase = createBrowserClient();
+    const result = await createEpisode(supabase, {
+      user_id: session.user.id,
+      started_at: new Date().toISOString(),
+      symptom_preset_id: template.symptom_preset_id,
+      health_marker_preset_id: template.health_marker_preset_id,
+    });
+    setSubmitting(false);
+    if (!result.ok) {
+      setSubmitError(result.error.message);
+      announce(result.error.message, { politeness: 'assertive' });
+      return;
+    }
+    announce('Episode started.', { politeness: 'polite' });
+    setPhase('done');
+  };
+
+  if (authLoading) {
+    return (
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Start an episode
+        </h1>
+        <p className="text-sm text-app-muted">Loading…</p>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Start an episode
+        </h1>
+        <p className="text-sm text-app-muted" role="status">
+          You need to be signed in to start an episode.
+        </p>
+        <Link
+          href="/login"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-app-primary px-5 text-sm font-semibold text-white shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+        >
+          Sign in
+        </Link>
+      </div>
+    );
+  }
+
+  if (phase === 'done') {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Start an episode
+        </h1>
+        <div
+          className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
+          role="status"
+          aria-live="polite"
+        >
+          <p className="text-sm leading-relaxed text-app-ink">
+            Your episode has been started with the template you chose. You can
+            continue from the dashboard when you are ready.
+          </p>
+        </div>
+        <Link
+          href="/dashboard"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-xl bg-app-primary px-5 text-sm font-semibold text-white shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+        >
+          Back to dashboard
+        </Link>
+      </div>
+    );
+  }
+
+  if (loadState === 'loading') {
+    return (
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Start an episode
+        </h1>
+        <p className="text-sm text-app-muted" role="status">
+          {submitting ? 'Starting episode…' : 'Loading templates…'}
+        </p>
+      </div>
+    );
+  }
+
+  if (loadState === 'error' && loadError) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Start an episode
+        </h1>
+        <p className="text-sm text-red-700 dark:text-red-300" role="alert">
+          {loadError}
+        </p>
+        <button
+          type="button"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-xl border border-app-border bg-app-surface px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          onClick={() => {
+            void refresh();
+          }}
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Start an episode
+        </h1>
+        {rows.length === 0 ? null : (
+          <p className="mt-2 text-sm leading-relaxed text-app-muted">
+            {rows.length === 1
+              ? 'Your episode uses the template below for symptoms and health markers.'
+              : 'Choose the episode template that matches what you want to log. One template applies to this episode.'}
+          </p>
+        )}
+      </div>
+
+      {rows.length === 0 ? (
+        <div
+          className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
+          role="status"
+          aria-live="polite"
+        >
+          <p className="text-sm leading-relaxed text-app-ink">
+            You do not have any episode templates yet. Create a template under{' '}
+            <Link
+              href="/presets/episode-templates"
+              className="font-medium text-app-primary underline decoration-app-primary/40 underline-offset-2 outline-none hover:text-app-ink focus-visible:ring-2 focus-visible:ring-app-ring"
+            >
+              Episode templates
+            </Link>{' '}
+            before starting an episode.
+          </p>
+        </div>
+      ) : (
+        <fieldset className="space-y-4 border-0 p-0">
+          <legend
+            id={groupLegendId}
+            className="text-base font-semibold text-app-ink"
+          >
+            {rows.length === 1 ? 'Your template' : 'Choose one template'}
+          </legend>
+          <div
+            className="space-y-3"
+            role="radiogroup"
+            aria-labelledby={groupLegendId}
+          >
+            {rows.map((row) => {
+              const inputId = `episode-start-template-${row.id}`;
+              const selected = selectedId === row.id;
+              return (
+                <label
+                  key={row.id}
+                  htmlFor={inputId}
+                  className={`flex cursor-pointer flex-col gap-1 rounded-2xl border-2 p-4 transition sm:p-5 ${
+                    selected
+                      ? 'border-app-primary bg-app-primary/5 ring-1 ring-app-primary/20'
+                      : 'border-app-border/90 bg-app-surface hover:border-app-border'
+                  }`}
+                >
+                  <span className="flex items-start gap-3">
+                    <input
+                      id={inputId}
+                      className="mt-1 h-4 w-4 shrink-0 border-app-border text-app-primary focus:ring-app-ring"
+                      type="radio"
+                      name="episode-template"
+                      value={row.id}
+                      checked={selected}
+                      onChange={() => {
+                        setSelectedId(row.id);
+                        setSubmitError(null);
+                      }}
+                      disabled={submitting}
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block text-base font-semibold text-app-ink">
+                        {row.name}
+                      </span>
+                      <span className="mt-1 block text-sm text-app-muted">
+                        Symptoms: {row.symptom_preset.name}. Markers:{' '}
+                        {row.health_marker_preset.name}.
+                      </span>
+                    </span>
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+        </fieldset>
+      )}
+
+      {submitError ? (
+        <p className="text-sm text-red-700 dark:text-red-300" role="alert">
+          {submitError}
+        </p>
+      ) : null}
+
+      {rows.length > 0 ? (
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <button
+            type="button"
+            className="inline-flex min-h-[56px] w-full items-center justify-center rounded-xl bg-red-700 px-5 text-base font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-50 dark:bg-red-600 dark:hover:bg-red-500 sm:w-auto sm:min-w-[220px]"
+            disabled={selectedId === null || submitting}
+            onClick={() => {
+              void onSubmit();
+            }}
+          >
+            {submitting ? 'Starting…' : 'Start episode'}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -75,3 +75,4 @@ export {
   listEpisodeTemplates,
   updateEpisodeTemplate,
 } from './lib/episode-template-data.js';
+export { createEpisode } from './lib/episode-data.js';

--- a/packages/supabase/src/lib/episode-data.spec.ts
+++ b/packages/supabase/src/lib/episode-data.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { EpisodeInsert, EpisodeRow } from '@abstrack/types';
+import { createEpisode } from './episode-data.js';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+
+describe('createEpisode', () => {
+  it('inserts and returns the created row', async () => {
+    const inserted: EpisodeInsert = {
+      user_id: 'user-1',
+      started_at: '2026-04-18T12:00:00.000Z',
+      symptom_preset_id: 'sym-1',
+      health_marker_preset_id: 'hm-1',
+    };
+    const returned: EpisodeRow = {
+      id: 'ep-1',
+      user_id: 'user-1',
+      symptom_preset_id: 'sym-1',
+      health_marker_preset_id: 'hm-1',
+      episode_type: 'Other',
+      episode_label: null,
+      note: null,
+      started_at: inserted.started_at,
+      ended_at: null,
+      created_at: '2026-04-18T12:00:00.000Z',
+      updated_at: '2026-04-18T12:00:00.000Z',
+    };
+    const single = vi.fn(async () => ({
+      data: returned,
+      error: null,
+    }));
+    const client = {
+      from: vi.fn(() => ({
+        insert: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single,
+          })),
+        })),
+      })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await createEpisode(client, inserted);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.id).toBe('ep-1');
+      expect(result.data.health_marker_preset_id).toBe('hm-1');
+    }
+    expect(client.from).toHaveBeenCalledWith('episodes');
+  });
+});

--- a/packages/supabase/src/lib/episode-data.ts
+++ b/packages/supabase/src/lib/episode-data.ts
@@ -1,0 +1,23 @@
+import type { EpisodeInsert, EpisodeRow } from '@abstrack/types';
+import type { PresetDataResult } from './preset-data.js';
+import { wrap } from './preset-data.js';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+
+/**
+ * Inserts a new episode row (patient or caretaker per RLS).
+ *
+ * @param client - Supabase client (RLS applies).
+ * @param row - Insert payload; `user_id` must satisfy `episodes_insert` policies.
+ */
+export async function createEpisode(
+  client: AbstrackSupabaseClient,
+  row: EpisodeInsert,
+): Promise<PresetDataResult<EpisodeRow>> {
+  return wrap(async () => {
+    const r = await client.from('episodes').insert(row).select('*').single();
+    return {
+      data: r.data as EpisodeRow | null,
+      error: r.error,
+    };
+  });
+}

--- a/packages/types/src/lib/types.ts
+++ b/packages/types/src/lib/types.ts
@@ -335,6 +335,7 @@ export interface EpisodeRow {
   id: Uuid;
   user_id: Uuid;
   symptom_preset_id: Uuid | null;
+  health_marker_preset_id: Uuid | null;
   episode_type: EpisodeType;
   episode_label: string | null;
   note: string | null;
@@ -347,6 +348,7 @@ export interface EpisodeRow {
 export type EpisodeInsert = Pick<EpisodeRow, 'user_id' | 'started_at'> & {
   id?: Uuid;
   symptom_preset_id?: Uuid | null;
+  health_marker_preset_id?: Uuid | null;
   episode_type?: EpisodeType;
   episode_label?: string | null;
   note?: string | null;
@@ -357,6 +359,7 @@ export type EpisodeUpdate = Partial<
   Pick<
     EpisodeRow,
     | 'symptom_preset_id'
+    | 'health_marker_preset_id'
     | 'episode_type'
     | 'episode_label'
     | 'note'


### PR DESCRIPTION
Close #74

## Summary

Implements the impaired-use episode start flow on **mobile and web**: users choose **exactly one episode template** (or skip the chooser when they only have **one** template), and a new `episodes` row is inserted with **`symptom_preset_id`** and **`health_marker_preset_id`** resolved from that template.

## Scope

- **Shared data layer**: `createEpisode` in `@abstrack/supabase`; `EpisodeRow` / `EpisodeInsert` / `EpisodeUpdate` in `@abstrack/types` include `health_marker_preset_id` (aligned with existing schema / `database.types.ts`).
- **Mobile**: `EpisodeStartScreen` — load templates, radio-style selection, primary **Start episode** action, success state with **Back to home**; **single-template** path creates the episode during load (no picker); `ScreenShell` supports `contentAlign="stretch"` for scroll-friendly layouts; stack title deduped for this screen.
- **Web**: `EpisodeStartFlow` on `/episode/start` — same behaviors, including auto-start when one template exists.

## Out of scope (unchanged)

- Home CTA wiring beyond existing navigation to episode start.
- Prompt-step / symptom response persistence beyond creating the episode row.

## Testing

- `nx run @abstrack/supabase:test` (includes `episode-data` unit test).
- `nx run mobile:lint`, `nx run web:lint`, and mobile `App.spec.tsx` (and related suites) as run locally.

## Notes

- No new migrations in this work; `episodes.health_marker_preset_id` is already present in migrations / generated types. If anything drifts from cloud, follow the usual `db push` + `gen types` workflow from `docs/SUPABASE_CLOUD_DEVELOPER.md`.