### PR TITLE
feat(episode): add linear symptom prompt stepper with session-scoped progress on web and mobile

### DIFF
--- a/apps/mobile/src/app/App.tsx
+++ b/apps/mobile/src/app/App.tsx
@@ -12,6 +12,7 @@ import { MainTabNavigator } from './navigation/MainTabNavigator';
 import type { MainStackParamList } from './navigation/types';
 import { LoginScreen } from './screens/LoginScreen';
 import { EpisodeStartScreen } from './screens/EpisodeStartScreen';
+import { SymptomPromptScreen } from './screens/SymptomPromptScreen';
 import { SettingsScreen } from './screens/SettingsScreen';
 import { SignupScreen } from './screens/SignupScreen';
 import { UpdatePasswordScreen } from './screens/UpdatePasswordScreen';
@@ -387,6 +388,14 @@ function AppBootstrap() {
               component={EpisodeStartScreen}
               options={{
                 title: '',
+                headerBackTitle: 'Home',
+              }}
+            />
+            <MainStack.Screen
+              name="SymptomPrompt"
+              component={SymptomPromptScreen}
+              options={{
+                title: 'Symptoms',
                 headerBackTitle: 'Home',
               }}
             />

--- a/apps/mobile/src/app/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/mobile/src/app/components/episode-flow/SymptomPromptResponseField.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import { Pressable, Text, TextInput, View } from 'react-native';
+import type {
+  PresetSymptomRow,
+  SymptomPromptAnswer,
+  SymptomResponseType,
+} from '@abstrack/types';
+import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
+import { nw } from '../../theme/app-nativewind-classes';
+
+export type SymptomPromptResponseFieldProps = {
+  line: PresetSymptomRow;
+  answer: SymptomPromptAnswer | undefined;
+  onChange: (next: SymptomPromptAnswer) => void;
+  disabled: boolean;
+};
+
+function defaultAnswerForType(type: SymptomResponseType): SymptomPromptAnswer {
+  switch (type) {
+    case 'yes_no':
+      return { type: 'yes_no', value: null };
+    case 'severity_scale':
+      return { type: 'severity_scale', value: null };
+    case 'free_text':
+      return { type: 'free_text', value: '' };
+    case 'photo':
+      return { type: 'photo', value: null };
+    case 'video':
+      return { type: 'video', value: null };
+    default: {
+      const _exhaustive: never = type;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * Renders the capture UI for one preset symptom line (Week 5 skeleton: no media pipeline).
+ *
+ * @param props - Line metadata, current answer, change handler, disabled flag.
+ * @returns Response-type-specific controls.
+ */
+export function SymptomPromptResponseField({
+  line,
+  answer,
+  onChange,
+  disabled,
+}: SymptomPromptResponseFieldProps) {
+  const effective = answer ?? defaultAnswerForType(line.response_type);
+
+  switch (line.response_type) {
+    case 'yes_no': {
+      const v = effective.type === 'yes_no' ? effective.value : null;
+      return (
+        <View
+          accessibilityRole="radiogroup"
+          accessibilityLabel={`${line.symptom_name} yes or no`}
+          className="gap-3"
+        >
+          {(['yes', 'no'] as const).map((which) => {
+            const boolVal = which === 'yes';
+            const selected = v === boolVal;
+            return (
+              <Pressable
+                key={which}
+                accessibilityRole="radio"
+                accessibilityState={{ selected, disabled }}
+                disabled={disabled}
+                onPress={() => {
+                  onChange({ type: 'yes_no', value: boolVal });
+                }}
+                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                className={`items-center justify-center rounded-xl border-2 px-4 py-4 active:opacity-90 ${
+                  selected
+                    ? 'border-red-600 bg-red-50 dark:border-red-500 dark:bg-red-950/40'
+                    : 'border-app-border bg-app-bg dark:border-app-border-dark dark:bg-app-bg-dark'
+                }`}
+              >
+                <Text
+                  className={`text-[17px] font-semibold capitalize ${nw.textInk}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  {which}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      );
+    }
+    case 'severity_scale': {
+      const sev = effective.type === 'severity_scale' ? effective.value : null;
+      return (
+        <View
+          accessibilityRole="radiogroup"
+          accessibilityLabel={`${line.symptom_name} severity 1 to 5`}
+          className="flex-row flex-wrap gap-2"
+        >
+          {[1, 2, 3, 4, 5].map((n) => {
+            const selected = sev === n;
+            return (
+              <Pressable
+                key={n}
+                accessibilityRole="radio"
+                accessibilityLabel={`Severity ${n}`}
+                accessibilityState={{ selected, disabled }}
+                disabled={disabled}
+                onPress={() => {
+                  onChange({ type: 'severity_scale', value: n });
+                }}
+                style={{
+                  minWidth: COMFORTABLE_TOUCH_TARGET_DP,
+                  minHeight: COMFORTABLE_TOUCH_TARGET_DP,
+                }}
+                className={`items-center justify-center rounded-xl border-2 px-3 py-3 active:opacity-90 ${
+                  selected
+                    ? 'border-red-600 bg-red-50 dark:border-red-500 dark:bg-red-950/40'
+                    : 'border-app-border bg-app-bg dark:border-app-border-dark dark:bg-app-bg-dark'
+                }`}
+              >
+                <Text
+                  className={`text-[17px] font-semibold ${nw.textInk}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  {n}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      );
+    }
+    case 'free_text': {
+      const text = effective.type === 'free_text' ? effective.value : '';
+      return (
+        <TextInput
+          editable={!disabled}
+          accessibilityLabel={`${line.symptom_name} notes`}
+          multiline
+          value={text}
+          onChangeText={(t) => {
+            onChange({ type: 'free_text', value: t });
+          }}
+          placeholder="Type a short note (optional)"
+          placeholderTextColor="#888"
+          className={`min-h-[120px] rounded-xl border border-app-border bg-white p-4 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
+          maxFontSizeMultiplier={2}
+        />
+      );
+    }
+    case 'photo':
+      return (
+        <View
+          accessibilityRole="text"
+          className="rounded-xl border border-dashed border-app-border bg-app-bg p-6 dark:border-app-border-dark dark:bg-app-bg-dark"
+        >
+          <Text
+            className={`text-center text-base leading-relaxed ${nw.textInk}`}
+            maxFontSizeMultiplier={2}
+          >
+            Photo capture will open here during an episode. This step is a
+            placeholder for now.
+          </Text>
+        </View>
+      );
+    case 'video':
+      return (
+        <View
+          accessibilityRole="text"
+          className="rounded-xl border border-dashed border-app-border bg-app-bg p-6 dark:border-app-border-dark dark:bg-app-bg-dark"
+        >
+          <Text
+            className={`text-center text-base leading-relaxed ${nw.textInk}`}
+            maxFontSizeMultiplier={2}
+          >
+            Video capture will open here during an episode. This step is a
+            placeholder for now.
+          </Text>
+        </View>
+      );
+    default: {
+      const _exhaustive: never = line.response_type;
+      return _exhaustive;
+    }
+  }
+}

--- a/apps/mobile/src/app/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/mobile/src/app/components/episode-flow/SymptomPromptResponseField.tsx
@@ -6,6 +6,7 @@ import type {
   SymptomResponseType,
 } from '@abstrack/types';
 import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
+import { useAppTheme } from '../../theme/AppThemeContext';
 import { nw } from '../../theme/app-nativewind-classes';
 
 export type SymptomPromptResponseFieldProps = {
@@ -46,6 +47,7 @@ export function SymptomPromptResponseField({
   onChange,
   disabled,
 }: SymptomPromptResponseFieldProps) {
+  const { colors } = useAppTheme();
   const effective = answer ?? defaultAnswerForType(line.response_type);
 
   switch (line.response_type) {
@@ -142,7 +144,7 @@ export function SymptomPromptResponseField({
             onChange({ type: 'free_text', value: t });
           }}
           placeholder="Type a short note (optional)"
-          placeholderTextColor="#888"
+          placeholderTextColor={colors.inputPlaceholder}
           className={`min-h-[120px] rounded-xl border border-app-border bg-white p-4 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
           maxFontSizeMultiplier={2}
         />

--- a/apps/mobile/src/app/navigation/types.ts
+++ b/apps/mobile/src/app/navigation/types.ts
@@ -34,5 +34,7 @@ export type MainStackParamList = {
   MainTabs: undefined;
   /** Episode logging entry: shell until template selection and prompts ship. */
   EpisodeStart: undefined;
+  /** Linear symptom prompts for the active episode (preset lines). */
+  SymptomPrompt: { episodeId: string; symptomPresetId: string };
   Settings: undefined;
 };

--- a/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
@@ -100,6 +100,7 @@ export function EpisodeStartScreen() {
         const template = result.data[0];
         singleTemplateAutoInFlightRef.current = true;
         setSubmitting(true);
+        let didNavigateToSymptomPrompt = false;
         try {
           const saveResult = await saveEpisodeWithTemplatePresets({
             userId,
@@ -130,9 +131,10 @@ export function EpisodeStartScreen() {
             episodeId: saveResult.data.id,
             symptomPresetId: template.symptom_preset_id,
           });
+          didNavigateToSymptomPrompt = true;
         } finally {
           singleTemplateAutoInFlightRef.current = false;
-          if (!stale()) {
+          if (!stale() && !didNavigateToSymptomPrompt) {
             setSubmitting(false);
           }
         }
@@ -180,6 +182,7 @@ export function EpisodeStartScreen() {
     }
     setEpisodeStartError(null);
     setSubmitting(true);
+    let didNavigateToSymptomPrompt = false;
     try {
       const authResult = await getCurrentUserId();
       if (!authResult.ok) {
@@ -215,8 +218,11 @@ export function EpisodeStartScreen() {
         episodeId: result.data.id,
         symptomPresetId: template.symptom_preset_id,
       });
+      didNavigateToSymptomPrompt = true;
     } finally {
-      setSubmitting(false);
+      if (!didNavigateToSymptomPrompt) {
+        setSubmitting(false);
+      }
     }
   };
 

--- a/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
@@ -117,13 +117,6 @@ export function EpisodeStartScreen() {
             setStatus('ready');
             return;
           }
-          if (!saveResult.data) {
-            setSelectedId(template.id);
-            setEpisodeStartError('Could not start episode.');
-            announce('Could not start episode.');
-            setStatus('ready');
-            return;
-          }
           singleTemplateAutoSucceededCycleIdRef.current = cycleId;
           announce('Episode started.');
           // Keep `loading` until navigation unmounts — `ready` would flash the template chooser briefly.
@@ -204,12 +197,6 @@ export function EpisodeStartScreen() {
       if (!result.ok) {
         setEpisodeStartError(result.error.message);
         announce(result.error.message);
-        return;
-      }
-      if (!result.data) {
-        const message = 'Could not start episode.';
-        setEpisodeStartError(message);
-        announce(message);
         return;
       }
       setEpisodeStartError(null);

--- a/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
@@ -89,7 +89,7 @@ export function EpisodeStartScreen() {
 
       if (result.data.length === 1) {
         if (singleTemplateAutoSucceededCycleIdRef.current === cycleId) {
-          setStatus('ready');
+          // Stay on `loading` until `navigation.replace` unmounts — `ready` would flash the chooser if `load` re-runs.
           return;
         }
         if (singleTemplateAutoInFlightRef.current) {

--- a/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
@@ -4,7 +4,6 @@ import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { EpisodeTemplateWithPresetsRow } from '@abstrack/types';
 import { announce } from '@abstrack/ui/native';
-import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
 import {
   fetchEpisodeTemplates,
   getCurrentUserId,
@@ -23,8 +22,6 @@ type EpisodeStartNav = NativeStackNavigationProp<
   'EpisodeStart'
 >;
 
-type FlowPhase = 'pick' | 'done';
-
 /**
  * Episode-start flow: if there is exactly one episode template, start the episode immediately
  * (no tap-through). Otherwise pick a template, then create an episode with both preset ids from
@@ -34,7 +31,6 @@ type FlowPhase = 'pick' | 'done';
  */
 export function EpisodeStartScreen() {
   const navigation = useNavigation<EpisodeStartNav>();
-  const phaseRef = useRef<FlowPhase>('pick');
   /** Increments on each screen focus; scopes single-template auto-start idempotency to the current focus cycle. */
   const focusCycleIdRef = useRef(0);
   /** Prevents concurrent `saveEpisodeWithTemplatePresets` on the single-template path when `load` runs more than once before success. */
@@ -55,8 +51,6 @@ export function EpisodeStartScreen() {
   const [rows, setRows] = useState<EpisodeTemplateWithPresetsRow[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [phase, setPhase] = useState<FlowPhase>('pick');
-  phaseRef.current = phase;
 
   const load = useCallback(
     async (focusCancel?: FocusLoadCancel, focusCycle?: number) => {
@@ -95,7 +89,6 @@ export function EpisodeStartScreen() {
 
       if (result.data.length === 1) {
         if (singleTemplateAutoSucceededCycleIdRef.current === cycleId) {
-          setPhase('done');
           setStatus('ready');
           return;
         }
@@ -123,10 +116,20 @@ export function EpisodeStartScreen() {
             setStatus('ready');
             return;
           }
+          if (!saveResult.data) {
+            setSelectedId(template.id);
+            setEpisodeStartError('Could not start episode.');
+            announce('Could not start episode.');
+            setStatus('ready');
+            return;
+          }
           singleTemplateAutoSucceededCycleIdRef.current = cycleId;
           announce('Episode started.');
-          setPhase('done');
-          setStatus('ready');
+          // Keep `loading` until navigation unmounts — `ready` would flash the template chooser briefly.
+          navigation.replace('SymptomPrompt', {
+            episodeId: saveResult.data.id,
+            symptomPresetId: template.symptom_preset_id,
+          });
         } finally {
           singleTemplateAutoInFlightRef.current = false;
           if (!stale()) {
@@ -145,14 +148,11 @@ export function EpisodeStartScreen() {
       });
       setStatus('ready');
     },
-    [],
+    [navigation],
   );
 
   useFocusEffect(
     useCallback(() => {
-      if (phaseRef.current === 'done') {
-        return;
-      }
       focusCycleIdRef.current += 1;
       const cycleId = focusCycleIdRef.current;
       const focusCancel: FocusLoadCancel = { cancelled: false };
@@ -203,9 +203,18 @@ export function EpisodeStartScreen() {
         announce(result.error.message);
         return;
       }
+      if (!result.data) {
+        const message = 'Could not start episode.';
+        setEpisodeStartError(message);
+        announce(message);
+        return;
+      }
       setEpisodeStartError(null);
       announce('Episode started.');
-      setPhase('done');
+      navigation.replace('SymptomPrompt', {
+        episodeId: result.data.id,
+        symptomPresetId: template.symptom_preset_id,
+      });
     } finally {
       setSubmitting(false);
     }
@@ -223,163 +232,138 @@ export function EpisodeStartScreen() {
           Start an episode
         </Text>
 
-        {phase === 'done' ? (
-          <View className="gap-4" accessibilityLiveRegion="polite">
-            <Text
-              className={`text-base leading-relaxed ${nw.textInk}`}
-              maxFontSizeMultiplier={2}
-            >
-              Your episode has been started with the template you chose. Use
-              Back when you are ready to return home.
-            </Text>
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Back to home"
-              onPress={() => {
-                navigation.goBack();
-              }}
-              style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-              className="items-center justify-center rounded-xl bg-red-700 px-4 py-4 active:opacity-90 dark:bg-red-600"
-            >
-              <Text className="text-center text-[17px] font-semibold text-white">
-                Back to home
-              </Text>
-            </Pressable>
-          </View>
-        ) : (
-          <AsyncScreenContainer
-            status={status}
-            loadingAccessibilityLabel={
-              submitting ? 'Starting episode' : 'Loading episode templates'
+        <AsyncScreenContainer
+          status={status}
+          loadingAccessibilityLabel={
+            submitting ? 'Starting episode' : 'Loading episode templates'
+          }
+          errorTitle="Could not load templates"
+          errorMessage={errorMessage ?? undefined}
+          onRetry={() => {
+            const token = focusCancelRef.current;
+            if (token == null) {
+              return;
             }
-            errorTitle="Could not load templates"
-            errorMessage={errorMessage ?? undefined}
-            onRetry={() => {
-              const token = focusCancelRef.current;
-              if (token == null) {
-                return;
-              }
-              void load(token, focusCycleIdRef.current);
-            }}
+            void load(token, focusCycleIdRef.current);
+          }}
+        >
+          <ScrollView
+            testID="episode-start-template-scroll"
+            className="flex-1"
+            keyboardShouldPersistTaps="handled"
+            contentContainerStyle={{ paddingBottom: 16 }}
           >
-            <ScrollView
-              testID="episode-start-template-scroll"
-              className="flex-1"
-              keyboardShouldPersistTaps="handled"
-              contentContainerStyle={{ paddingBottom: 16 }}
-            >
-              {rows.length === 1 ? (
-                <Text
-                  className={`mb-4 text-base leading-relaxed ${nw.textMuted}`}
-                  maxFontSizeMultiplier={2}
-                >
-                  Your episode uses the template below for symptoms and health
-                  markers.
-                </Text>
-              ) : rows.length > 1 ? (
-                <Text
-                  className={`mb-4 text-base leading-relaxed ${nw.textMuted}`}
-                  maxFontSizeMultiplier={2}
-                >
-                  Tap one template for this episode. It sets both your symptom
-                  list and health markers for this episode.
-                </Text>
-              ) : null}
+            {rows.length === 1 ? (
+              <Text
+                className={`mb-4 text-base leading-relaxed ${nw.textMuted}`}
+                maxFontSizeMultiplier={2}
+              >
+                Your episode uses the template below for symptoms and health
+                markers.
+              </Text>
+            ) : rows.length > 1 ? (
+              <Text
+                className={`mb-4 text-base leading-relaxed ${nw.textMuted}`}
+                maxFontSizeMultiplier={2}
+              >
+                Tap one template for this episode. It sets both your symptom
+                list and health markers for this episode.
+              </Text>
+            ) : null}
 
-              {episodeStartError ? (
+            {episodeStartError ? (
+              <Text
+                accessibilityRole="alert"
+                className={`mb-4 text-base leading-relaxed ${nw.textError}`}
+                maxFontSizeMultiplier={2}
+              >
+                {episodeStartError}
+              </Text>
+            ) : null}
+
+            {rows.length === 0 ? (
+              <View
+                className="rounded-xl bg-app-bg p-4 dark:bg-app-bg-dark"
+                accessibilityRole="text"
+              >
                 <Text
-                  accessibilityRole="alert"
-                  className={`mb-4 text-base leading-relaxed ${nw.textError}`}
+                  className={`text-base leading-relaxed ${nw.textInk}`}
                   maxFontSizeMultiplier={2}
                 >
-                  {episodeStartError}
+                  You do not have any episode templates yet. Open the Templates
+                  tab, create a template, then come back here.
                 </Text>
-              ) : null}
-
-              {rows.length === 0 ? (
-                <View
-                  className="rounded-xl bg-app-bg p-4 dark:bg-app-bg-dark"
-                  accessibilityRole="text"
-                >
-                  <Text
-                    className={`text-base leading-relaxed ${nw.textInk}`}
-                    maxFontSizeMultiplier={2}
-                  >
-                    You do not have any episode templates yet. Open the
-                    Templates tab, create a template, then come back here.
-                  </Text>
-                </View>
-              ) : (
-                <View
-                  accessibilityRole="radiogroup"
-                  accessibilityLabel="Episode templates"
-                >
-                  {rows.map((row) => {
-                    const selected = selectedId === row.id;
-                    return (
-                      <Pressable
-                        key={row.id}
-                        testID={`episode-start-template-option-${row.id}`}
-                        accessibilityRole="radio"
-                        accessibilityState={{ selected, disabled: submitting }}
-                        accessibilityLabel={`${row.name}. Symptoms: ${row.symptom_preset.name}. Health markers: ${row.health_marker_preset.name}.`}
-                        onPress={() => {
-                          if (!submitting) {
-                            onSelectTemplate(row.id);
-                          }
-                        }}
-                        className={`mb-3 rounded-2xl border-2 p-4 active:opacity-90 ${
-                          selected
-                            ? 'border-red-600 bg-red-50 dark:border-red-500 dark:bg-red-950/40'
-                            : 'border-app-border bg-app-bg dark:border-app-border-dark dark:bg-app-bg-dark'
-                        }`}
+              </View>
+            ) : (
+              <View
+                accessibilityRole="radiogroup"
+                accessibilityLabel="Episode templates"
+              >
+                {rows.map((row) => {
+                  const selected = selectedId === row.id;
+                  return (
+                    <Pressable
+                      key={row.id}
+                      testID={`episode-start-template-option-${row.id}`}
+                      accessibilityRole="radio"
+                      accessibilityState={{ selected, disabled: submitting }}
+                      accessibilityLabel={`${row.name}. Symptoms: ${row.symptom_preset.name}. Health markers: ${row.health_marker_preset.name}.`}
+                      onPress={() => {
+                        if (!submitting) {
+                          onSelectTemplate(row.id);
+                        }
+                      }}
+                      className={`mb-3 rounded-2xl border-2 p-4 active:opacity-90 ${
+                        selected
+                          ? 'border-red-600 bg-red-50 dark:border-red-500 dark:bg-red-950/40'
+                          : 'border-app-border bg-app-bg dark:border-app-border-dark dark:bg-app-bg-dark'
+                      }`}
+                    >
+                      <Text
+                        className={`text-[18px] font-semibold ${nw.textInk}`}
+                        maxFontSizeMultiplier={2}
                       >
-                        <Text
-                          className={`text-[18px] font-semibold ${nw.textInk}`}
-                          maxFontSizeMultiplier={2}
-                        >
-                          {row.name}
-                        </Text>
-                        <Text
-                          className={`mt-2 text-sm leading-relaxed ${nw.textMuted}`}
-                          maxFontSizeMultiplier={2}
-                        >
-                          Symptoms: {row.symptom_preset.name}
-                        </Text>
-                        <Text
-                          className={`mt-1 text-sm leading-relaxed ${nw.textMuted}`}
-                          maxFontSizeMultiplier={2}
-                        >
-                          Markers: {row.health_marker_preset.name}
-                        </Text>
-                      </Pressable>
-                    );
-                  })}
-                </View>
-              )}
+                        {row.name}
+                      </Text>
+                      <Text
+                        className={`mt-2 text-sm leading-relaxed ${nw.textMuted}`}
+                        maxFontSizeMultiplier={2}
+                      >
+                        Symptoms: {row.symptom_preset.name}
+                      </Text>
+                      <Text
+                        className={`mt-1 text-sm leading-relaxed ${nw.textMuted}`}
+                        maxFontSizeMultiplier={2}
+                      >
+                        Markers: {row.health_marker_preset.name}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            )}
 
-              {rows.length > 0 ? (
-                <Pressable
-                  testID="episode-start-submit"
-                  accessibilityRole="button"
-                  accessibilityLabel="Start episode with selected template"
-                  accessibilityState={{
-                    disabled: selectedId === null || submitting,
-                  }}
-                  disabled={selectedId === null || submitting}
-                  onPress={() => {
-                    void onStartEpisode();
-                  }}
-                  className={`mt-4 min-h-[56px] items-center justify-center rounded-xl bg-red-700 px-4 py-4 active:opacity-90 disabled:opacity-50 dark:bg-red-600`}
-                >
-                  <Text className="text-center text-[18px] font-semibold text-white">
-                    {submitting ? 'Starting…' : 'Start episode'}
-                  </Text>
-                </Pressable>
-              ) : null}
-            </ScrollView>
-          </AsyncScreenContainer>
-        )}
+            {rows.length > 0 ? (
+              <Pressable
+                testID="episode-start-submit"
+                accessibilityRole="button"
+                accessibilityLabel="Start episode with selected template"
+                accessibilityState={{
+                  disabled: selectedId === null || submitting,
+                }}
+                disabled={selectedId === null || submitting}
+                onPress={() => {
+                  void onStartEpisode();
+                }}
+                className={`mt-4 min-h-[56px] items-center justify-center rounded-xl bg-red-700 px-4 py-4 active:opacity-90 disabled:opacity-50 dark:bg-red-600`}
+              >
+                <Text className="text-center text-[18px] font-semibold text-white">
+                  {submitting ? 'Starting…' : 'Start episode'}
+                </Text>
+              </Pressable>
+            ) : null}
+          </ScrollView>
+        </AsyncScreenContainer>
       </View>
     </ScreenShell>
   );

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
@@ -50,16 +50,18 @@ jest.mock('@abstrack/ui/native', () => {
 
 const episodeId = 'episode-1';
 const symptomPresetId = 'preset-sym-1';
+const symptomPresetIdB = 'preset-sym-2';
 
 function makeLine(
   id: string,
   sortOrder: number,
   symptomName: string,
   responseType: PresetSymptomRow['response_type'],
+  presetId: string = symptomPresetId,
 ): PresetSymptomRow {
   return {
     id,
-    preset_id: symptomPresetId,
+    preset_id: presetId,
     sort_order: sortOrder,
     symptom_name: symptomName,
     response_type: responseType,
@@ -169,6 +171,58 @@ describe('SymptomPromptScreen', () => {
     fireEvent.press(screen.getByLabelText('Go back to previous screen'));
 
     expect(mockGoBack).toHaveBeenCalled();
+  });
+
+  test('changing symptomPresetId after completion shows prompting again for new lines', async () => {
+    const lineOnly = makeLine(
+      'line-only',
+      0,
+      'Fatigue',
+      'yes_no',
+      symptomPresetIdB,
+    );
+
+    const screen = render(<SymptomPromptScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 1 of 2')).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByLabelText('Next symptom'));
+    await waitFor(() => {
+      expect(screen.getByLabelText('Finish symptom list')).toBeTruthy();
+    });
+    fireEvent.press(screen.getByLabelText('Finish symptom list'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/You reached the end of your symptom list/),
+      ).toBeTruthy();
+    });
+
+    jest.mocked(listPresetSymptomsForPreset).mockResolvedValue({
+      ok: true,
+      data: [lineOnly],
+    });
+    jest.mocked(useRoute).mockReturnValue({
+      key: 'SymptomPrompt',
+      name: 'SymptomPrompt',
+      params: { episodeId, symptomPresetId: symptomPresetIdB },
+    } as never);
+
+    screen.rerender(<SymptomPromptScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 1 of 1')).toBeTruthy();
+    });
+    expect(screen.getByText('Fatigue')).toBeTruthy();
+    expect(
+      screen.queryByText(/You reached the end of your symptom list/),
+    ).toBeNull();
+    expect(listPresetSymptomsForPreset).toHaveBeenCalledWith(
+      expect.objectContaining({ mockClient: true }),
+      symptomPresetIdB,
+    );
   });
 
   test('Finish shows completion and Return home clears session and resets stack', async () => {

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
@@ -1,0 +1,205 @@
+import * as React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { CommonActions, DefaultTheme } from '@react-navigation/native';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import { listPresetSymptomsForPreset } from '@abstrack/supabase';
+import { createInitialSymptomPromptSession } from '@abstrack/types';
+import type { PresetSymptomRow } from '@abstrack/types';
+
+import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
+import {
+  clearSymptomPromptSession,
+  getSymptomPromptSession,
+  setSymptomPromptSession,
+} from '../../lib/episodes/symptom-prompt-session-store';
+import { useAppTheme } from '../theme/AppThemeContext';
+import { lightAppColors } from '../theme/app-colors';
+import { SymptomPromptScreen } from './SymptomPromptScreen';
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useRoute: jest.fn(),
+  useNavigation: jest.fn(),
+}));
+
+jest.mock('@abstrack/supabase', () => ({
+  listPresetSymptomsForPreset: jest.fn(),
+}));
+
+jest.mock('../../lib/supabase-wiring', () => ({
+  getMobileSupabaseClient: jest.fn(() => ({ mockClient: true })),
+}));
+
+jest.mock('../../lib/episodes/symptom-prompt-session-store', () => ({
+  getSymptomPromptSession: jest.fn(),
+  setSymptomPromptSession: jest.fn(),
+  clearSymptomPromptSession: jest.fn(),
+}));
+
+jest.mock('../theme/AppThemeContext', () => ({
+  useAppTheme: jest.fn(),
+}));
+
+jest.mock('@abstrack/ui/native', () => {
+  const actual = jest.requireActual('@abstrack/ui/native');
+  return {
+    ...actual,
+    announce: jest.fn(),
+  };
+});
+
+const episodeId = 'episode-1';
+const symptomPresetId = 'preset-sym-1';
+
+function makeLine(
+  id: string,
+  sortOrder: number,
+  symptomName: string,
+  responseType: PresetSymptomRow['response_type'],
+): PresetSymptomRow {
+  return {
+    id,
+    preset_id: symptomPresetId,
+    sort_order: sortOrder,
+    symptom_name: symptomName,
+    response_type: responseType,
+    prompt_instruction: null,
+    created_at: '2020-01-01T00:00:00Z',
+    updated_at: '2020-01-01T00:00:00Z',
+  };
+}
+
+describe('SymptomPromptScreen', () => {
+  const mockGoBack = jest.fn();
+  const mockDispatch = jest.fn();
+
+  const lineA = makeLine('line-a', 0, 'Nausea', 'yes_no');
+  const lineB = makeLine('line-b', 1, 'Headache', 'severity_scale');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.mocked(useRoute).mockReturnValue({
+      key: 'SymptomPrompt',
+      name: 'SymptomPrompt',
+      params: { episodeId, symptomPresetId },
+    } as never);
+
+    jest.mocked(useNavigation).mockReturnValue({
+      goBack: mockGoBack,
+      dispatch: mockDispatch,
+    } as never);
+
+    jest.mocked(useAppTheme).mockReturnValue({
+      colorScheme: 'light',
+      colors: lightAppColors,
+      themePreference: 'system',
+      setThemePreference: jest.fn(() => Promise.resolve()),
+      navigationTheme: DefaultTheme,
+      statusBarStyle: 'dark',
+    });
+
+    jest
+      .mocked(getSymptomPromptSession)
+      .mockReturnValue(createInitialSymptomPromptSession());
+
+    jest.mocked(listPresetSymptomsForPreset).mockResolvedValue({
+      ok: true,
+      data: [lineA, lineB],
+    });
+  });
+
+  test('loads symptoms and shows step 1 of N', async () => {
+    const screen = render(<SymptomPromptScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 1 of 2')).toBeTruthy();
+    });
+
+    expect(screen.getByText('Nausea')).toBeTruthy();
+    expect(listPresetSymptomsForPreset).toHaveBeenCalledWith(
+      expect.objectContaining({ mockClient: true }),
+      symptomPresetId,
+    );
+    expect(getMobileSupabaseClient).toHaveBeenCalled();
+  });
+
+  test('Next advances step and persists session index', async () => {
+    const screen = render(<SymptomPromptScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 1 of 2')).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByLabelText('Next symptom'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 2 of 2')).toBeTruthy();
+    });
+
+    expect(screen.getByText('Headache')).toBeTruthy();
+    expect(setSymptomPromptSession).toHaveBeenCalledWith(episodeId, {
+      activeIndex: 1,
+      answers: {},
+    });
+  });
+
+  test('restores activeIndex from session after load', async () => {
+    jest.mocked(getSymptomPromptSession).mockReturnValue({
+      activeIndex: 1,
+      answers: {},
+    });
+
+    const screen = render(<SymptomPromptScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 2 of 2')).toBeTruthy();
+    });
+
+    expect(screen.getByText('Headache')).toBeTruthy();
+  });
+
+  test('Back on step 0 calls navigation.goBack', async () => {
+    const screen = render(<SymptomPromptScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Go back to previous screen')).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByLabelText('Go back to previous screen'));
+
+    expect(mockGoBack).toHaveBeenCalled();
+  });
+
+  test('Finish shows completion and Return home clears session and resets stack', async () => {
+    const screen = render(<SymptomPromptScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 1 of 2')).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByLabelText('Next symptom'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Finish symptom list')).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByLabelText('Finish symptom list'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/You reached the end of your symptom list/),
+      ).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByLabelText('Return to home'));
+
+    expect(clearSymptomPromptSession).toHaveBeenCalledWith(episodeId);
+    expect(mockDispatch).toHaveBeenCalledWith(
+      CommonActions.reset({
+        index: 0,
+        routes: [{ name: 'MainTabs' }],
+      }),
+    );
+  });
+});

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -91,27 +91,40 @@ export function SymptomPromptScreen() {
 
     setStatus('loading');
     setErrorMessage(null);
-    const supabase = getMobileSupabaseClient();
-    const result = await listPresetSymptomsForPreset(supabase, symptomPresetId);
-    if (stale()) {
-      return;
-    }
-    if (!result.ok) {
-      setErrorMessage(result.error.message);
+    try {
+      const supabase = getMobileSupabaseClient();
+      const result = await listPresetSymptomsForPreset(
+        supabase,
+        symptomPresetId,
+      );
+      if (stale()) {
+        return;
+      }
+      if (!result.ok) {
+        setErrorMessage(result.error.message);
+        setStatus('error');
+        return;
+      }
+      setLines(result.data);
+      const session = getSymptomPromptSession(episodeId);
+      const idx = clampIndex(session.activeIndex, result.data.length);
+      setActiveIndex(idx);
+      setAnswers(session.answers);
+      answersRef.current = session.answers;
+      setSymptomPromptSession(episodeId, {
+        activeIndex: idx,
+        answers: session.answers,
+      });
+      setStatus('ready');
+    } catch (caught: unknown) {
+      if (stale()) {
+        return;
+      }
+      const message =
+        caught instanceof Error ? caught.message : 'Could not load symptoms.';
+      setErrorMessage(message);
       setStatus('error');
-      return;
     }
-    setLines(result.data);
-    const session = getSymptomPromptSession(episodeId);
-    const idx = clampIndex(session.activeIndex, result.data.length);
-    setActiveIndex(idx);
-    setAnswers(session.answers);
-    answersRef.current = session.answers;
-    setSymptomPromptSession(episodeId, {
-      activeIndex: idx,
-      answers: session.answers,
-    });
-    setStatus('ready');
   }, [episodeId, symptomPresetId]);
 
   useEffect(() => {

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Pressable, ScrollView, Text, View } from 'react-native';
 import type { RouteProp } from '@react-navigation/native';
 import {
@@ -7,7 +7,11 @@ import {
   useRoute,
 } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import type { PresetSymptomRow, SymptomPromptAnswer } from '@abstrack/types';
+import type {
+  PresetSymptomRow,
+  SymptomPromptAnswer,
+  SymptomPromptAnswers,
+} from '@abstrack/types';
 import { listPresetSymptomsForPreset } from '@abstrack/supabase';
 import { announce } from '@abstrack/ui/native';
 import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
@@ -63,6 +67,11 @@ export function SymptomPromptScreen() {
   const [answers, setAnswers] = useState(
     () => getSymptomPromptSession(episodeId).answers,
   );
+  const answersRef = useRef(answers);
+
+  useEffect(() => {
+    answersRef.current = answers;
+  }, [answers]);
 
   const persist = useCallback(
     (nextIndex: number, nextAnswers: typeof answers) => {
@@ -89,6 +98,7 @@ export function SymptomPromptScreen() {
     const idx = clampIndex(session.activeIndex, result.data.length);
     setActiveIndex(idx);
     setAnswers(session.answers);
+    answersRef.current = session.answers;
     setSymptomPromptSession(episodeId, {
       activeIndex: idx,
       answers: session.answers,
@@ -104,6 +114,7 @@ export function SymptomPromptScreen() {
     const s = getSymptomPromptSession(episodeId);
     setActiveIndex(s.activeIndex);
     setAnswers(s.answers);
+    answersRef.current = s.answers;
     setPhase('prompting');
   }, [episodeId]);
 
@@ -124,18 +135,20 @@ export function SymptomPromptScreen() {
     if (!currentLine) {
       return;
     }
-    setAnswers((prev) => {
-      const merged = { ...prev, [currentLine.id]: next };
-      persist(activeIndex, merged);
-      return merged;
-    });
+    const merged: SymptomPromptAnswers = {
+      ...answersRef.current,
+      [currentLine.id]: next,
+    };
+    answersRef.current = merged;
+    setAnswers(merged);
+    persist(activeIndex, merged);
   };
 
   const goBackStep = () => {
     if (activeIndex > 0) {
       const next = activeIndex - 1;
       setActiveIndex(next);
-      persist(next, answers);
+      persist(next, answersRef.current);
       announce(`Back to step ${next + 1} of ${lines.length}.`);
     } else {
       navigation.goBack();
@@ -150,7 +163,7 @@ export function SymptomPromptScreen() {
     if (activeIndex < lines.length - 1) {
       const next = activeIndex + 1;
       setActiveIndex(next);
-      persist(next, answers);
+      persist(next, answersRef.current);
       return;
     }
     setPhase('complete');

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -68,6 +68,8 @@ export function SymptomPromptScreen() {
     () => getSymptomPromptSession(episodeId).answers,
   );
   const answersRef = useRef(answers);
+  /** Bumps on each `load()` start and on effect cleanup so in-flight loads ignore stale results after unmount, retry, or param change. */
+  const loadGenRef = useRef(0);
 
   useEffect(() => {
     answersRef.current = answers;
@@ -84,10 +86,16 @@ export function SymptomPromptScreen() {
   );
 
   const load = useCallback(async () => {
+    const myGen = ++loadGenRef.current;
+    const stale = () => myGen !== loadGenRef.current;
+
     setStatus('loading');
     setErrorMessage(null);
     const supabase = getMobileSupabaseClient();
     const result = await listPresetSymptomsForPreset(supabase, symptomPresetId);
+    if (stale()) {
+      return;
+    }
     if (!result.ok) {
       setErrorMessage(result.error.message);
       setStatus('error');
@@ -108,6 +116,9 @@ export function SymptomPromptScreen() {
 
   useEffect(() => {
     void load();
+    return () => {
+      loadGenRef.current += 1;
+    };
   }, [load]);
 
   useEffect(() => {

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import { Pressable, ScrollView, Text, View } from 'react-native';
 import type { RouteProp } from '@react-navigation/native';
 import {
@@ -96,6 +102,7 @@ export function SymptomPromptScreen() {
 
     setStatus('loading');
     setErrorMessage(null);
+    setPhase('prompting');
     try {
       const supabase = getMobileSupabaseClient();
       const result = await listPresetSymptomsForPreset(
@@ -140,14 +147,14 @@ export function SymptomPromptScreen() {
     };
   }, [load]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const s = getSymptomPromptSession(episodeId);
     activeIndexRef.current = s.activeIndex;
     setActiveIndex(s.activeIndex);
     setAnswers(s.answers);
     answersRef.current = s.answers;
     setPhase('prompting');
-  }, [episodeId]);
+  }, [episodeId, symptomPresetId]);
 
   const currentLine = lines[activeIndex] ?? null;
   const stepLabel =

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -154,6 +154,9 @@ export function SymptomPromptScreen() {
     setAnswers(s.answers);
     answersRef.current = s.answers;
     setPhase('prompting');
+    setStatus('loading');
+    setErrorMessage(null);
+    setLines([]);
   }, [episodeId, symptomPresetId]);
 
   const currentLine = lines[activeIndex] ?? null;

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -1,0 +1,300 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Pressable, ScrollView, Text, View } from 'react-native';
+import type { RouteProp } from '@react-navigation/native';
+import {
+  CommonActions,
+  useNavigation,
+  useRoute,
+} from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { PresetSymptomRow, SymptomPromptAnswer } from '@abstrack/types';
+import { listPresetSymptomsForPreset } from '@abstrack/supabase';
+import { announce } from '@abstrack/ui/native';
+import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
+import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
+import {
+  clearSymptomPromptSession,
+  getSymptomPromptSession,
+  setSymptomPromptSession,
+} from '../../lib/episodes/symptom-prompt-session-store';
+import { AsyncScreenContainer } from '../components/AsyncScreenContainer';
+import { SymptomPromptResponseField } from '../components/episode-flow/SymptomPromptResponseField';
+import { ScreenShell } from '../components/ScreenShell';
+import type { MainStackParamList } from '../navigation/types';
+import { nw } from '../theme/app-nativewind-classes';
+
+type SymptomPromptRoute = RouteProp<MainStackParamList, 'SymptomPrompt'>;
+type SymptomPromptNav = NativeStackNavigationProp<
+  MainStackParamList,
+  'SymptomPrompt'
+>;
+
+function clampIndex(index: number, length: number): number {
+  if (length <= 0) {
+    return 0;
+  }
+  return Math.max(0, Math.min(index, length - 1));
+}
+
+/**
+ * Linear symptom stepper for the active episode’s selected preset (Week 5 skeleton).
+ *
+ * @returns One symptom at a time with back/next and session-scoped progress.
+ */
+export function SymptomPromptScreen() {
+  const navigation = useNavigation<SymptomPromptNav>();
+  const route = useRoute<SymptomPromptRoute>();
+  const { episodeId, symptomPresetId } = route.params;
+
+  const [status, setStatus] = useState<'loading' | 'error' | 'ready'>(
+    'loading',
+  );
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [lines, setLines] = useState<PresetSymptomRow[]>([]);
+  const [phase, setPhase] = useState<'prompting' | 'complete'>('prompting');
+
+  const [activeIndex, setActiveIndex] = useState(
+    () => getSymptomPromptSession(episodeId).activeIndex,
+  );
+  const [answers, setAnswers] = useState(
+    () => getSymptomPromptSession(episodeId).answers,
+  );
+
+  const persist = useCallback(
+    (nextIndex: number, nextAnswers: typeof answers) => {
+      setSymptomPromptSession(episodeId, {
+        activeIndex: nextIndex,
+        answers: nextAnswers,
+      });
+    },
+    [episodeId],
+  );
+
+  const load = useCallback(async () => {
+    setStatus('loading');
+    setErrorMessage(null);
+    const supabase = getMobileSupabaseClient();
+    const result = await listPresetSymptomsForPreset(supabase, symptomPresetId);
+    if (!result.ok) {
+      setErrorMessage(result.error.message);
+      setStatus('error');
+      return;
+    }
+    setLines(result.data);
+    const session = getSymptomPromptSession(episodeId);
+    const idx = clampIndex(session.activeIndex, result.data.length);
+    setActiveIndex(idx);
+    setAnswers(session.answers);
+    setSymptomPromptSession(episodeId, {
+      activeIndex: idx,
+      answers: session.answers,
+    });
+    setStatus('ready');
+  }, [episodeId, symptomPresetId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    const s = getSymptomPromptSession(episodeId);
+    setActiveIndex(s.activeIndex);
+    setAnswers(s.answers);
+    setPhase('prompting');
+  }, [episodeId]);
+
+  const currentLine = lines[activeIndex] ?? null;
+  const stepLabel =
+    lines.length === 0
+      ? 'No symptoms'
+      : `Step ${activeIndex + 1} of ${lines.length}`;
+
+  useEffect(() => {
+    if (phase !== 'prompting' || !currentLine) {
+      return;
+    }
+    announce(`${stepLabel}. ${currentLine.symptom_name}.`);
+  }, [activeIndex, currentLine, lines.length, phase, stepLabel]);
+
+  const onChangeAnswer = (next: SymptomPromptAnswer) => {
+    if (!currentLine) {
+      return;
+    }
+    setAnswers((prev) => {
+      const merged = { ...prev, [currentLine.id]: next };
+      persist(activeIndex, merged);
+      return merged;
+    });
+  };
+
+  const goBackStep = () => {
+    if (activeIndex > 0) {
+      const next = activeIndex - 1;
+      setActiveIndex(next);
+      persist(next, answers);
+      announce(`Back to step ${next + 1} of ${lines.length}.`);
+    } else {
+      navigation.goBack();
+    }
+  };
+
+  const goNext = () => {
+    if (lines.length === 0) {
+      setPhase('complete');
+      return;
+    }
+    if (activeIndex < lines.length - 1) {
+      const next = activeIndex + 1;
+      setActiveIndex(next);
+      persist(next, answers);
+      return;
+    }
+    setPhase('complete');
+    announce('Symptom list complete.');
+  };
+
+  const onFinishToHome = () => {
+    clearSymptomPromptSession(episodeId);
+    navigation.dispatch(
+      CommonActions.reset({
+        index: 0,
+        routes: [{ name: 'MainTabs' }],
+      }),
+    );
+  };
+
+  return (
+    <ScreenShell contentAlign="stretch">
+      <View className="min-h-0 flex-1 gap-4">
+        <Text
+          accessibilityRole="header"
+          className={`text-[22px] font-semibold ${nw.textInk}`}
+          maxFontSizeMultiplier={2}
+        >
+          Episode symptoms
+        </Text>
+
+        {phase === 'complete' ? (
+          <View className="gap-4" accessibilityLiveRegion="polite">
+            <Text
+              className={`text-base leading-relaxed ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            >
+              You reached the end of your symptom list for this episode. You can
+              return home when you are ready.
+            </Text>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Return to home"
+              onPress={onFinishToHome}
+              style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+              className="items-center justify-center rounded-xl bg-red-700 px-4 py-4 active:opacity-90 dark:bg-red-600"
+            >
+              <Text className="text-center text-[17px] font-semibold text-white">
+                Return home
+              </Text>
+            </Pressable>
+          </View>
+        ) : (
+          <AsyncScreenContainer
+            status={status}
+            loadingAccessibilityLabel="Loading symptom list"
+            errorTitle="Could not load symptoms"
+            errorMessage={errorMessage ?? undefined}
+            onRetry={() => {
+              void load();
+            }}
+          >
+            <ScrollView
+              className="flex-1"
+              keyboardShouldPersistTaps="handled"
+              contentContainerStyle={{ paddingBottom: 24 }}
+            >
+              <Text
+                accessibilityRole="text"
+                className={`mb-2 text-base font-medium ${nw.textMuted}`}
+                maxFontSizeMultiplier={2}
+              >
+                {stepLabel}
+              </Text>
+
+              {lines.length === 0 ? (
+                <Text
+                  className={`text-base leading-relaxed ${nw.textInk}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  This preset has no symptoms yet. You can add symptoms under
+                  Templates when you are not in an episode.
+                </Text>
+              ) : currentLine ? (
+                <View className="gap-4">
+                  <Text
+                    accessibilityRole="header"
+                    className={`text-xl font-semibold ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    {currentLine.symptom_name}
+                  </Text>
+                  {currentLine.prompt_instruction ? (
+                    <Text
+                      className={`text-base leading-relaxed ${nw.textMuted}`}
+                      maxFontSizeMultiplier={2}
+                    >
+                      {currentLine.prompt_instruction}
+                    </Text>
+                  ) : null}
+                  <SymptomPromptResponseField
+                    line={currentLine}
+                    answer={answers[currentLine.id]}
+                    onChange={onChangeAnswer}
+                    disabled={status !== 'ready'}
+                  />
+                </View>
+              ) : null}
+
+              <View className="mt-6 flex-row gap-3">
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={
+                    activeIndex === 0
+                      ? 'Go back to previous screen'
+                      : 'Previous symptom'
+                  }
+                  onPress={goBackStep}
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                  className="min-w-[120px] flex-1 items-center justify-center rounded-xl border-2 border-app-border bg-app-bg px-3 py-4 active:opacity-90 dark:border-app-border-dark dark:bg-app-bg-dark"
+                >
+                  <Text
+                    className={`text-center text-[17px] font-semibold ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    {activeIndex === 0 ? 'Exit' : 'Back'}
+                  </Text>
+                </Pressable>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={
+                    lines.length > 0 && activeIndex >= lines.length - 1
+                      ? 'Finish symptom list'
+                      : 'Next symptom'
+                  }
+                  onPress={goNext}
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                  className="min-w-[120px] flex-1 items-center justify-center rounded-xl bg-red-700 px-3 py-4 active:opacity-90 dark:bg-red-600"
+                >
+                  <Text className="text-center text-[17px] font-semibold text-white">
+                    {lines.length === 0
+                      ? 'Done'
+                      : activeIndex >= lines.length - 1
+                        ? 'Finish'
+                        : 'Next'}
+                  </Text>
+                </Pressable>
+              </View>
+            </ScrollView>
+          </AsyncScreenContainer>
+        )}
+      </View>
+    </ScreenShell>
+  );
+}

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -33,7 +33,11 @@ function clampIndex(index: number, length: number): number {
   if (length <= 0) {
     return 0;
   }
-  return Math.max(0, Math.min(index, length - 1));
+  if (!Number.isFinite(index)) {
+    return 0;
+  }
+  const i = Math.trunc(index);
+  return Math.max(0, Math.min(i, length - 1));
 }
 
 /**

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -68,12 +68,17 @@ export function SymptomPromptScreen() {
     () => getSymptomPromptSession(episodeId).answers,
   );
   const answersRef = useRef(answers);
+  const activeIndexRef = useRef(activeIndex);
   /** Bumps on each `load()` start and on effect cleanup so in-flight loads ignore stale results after unmount, retry, or param change. */
   const loadGenRef = useRef(0);
 
   useEffect(() => {
     answersRef.current = answers;
   }, [answers]);
+
+  useEffect(() => {
+    activeIndexRef.current = activeIndex;
+  }, [activeIndex]);
 
   const persist = useCallback(
     (nextIndex: number, nextAnswers: typeof answers) => {
@@ -108,6 +113,7 @@ export function SymptomPromptScreen() {
       setLines(result.data);
       const session = getSymptomPromptSession(episodeId);
       const idx = clampIndex(session.activeIndex, result.data.length);
+      activeIndexRef.current = idx;
       setActiveIndex(idx);
       setAnswers(session.answers);
       answersRef.current = session.answers;
@@ -136,6 +142,7 @@ export function SymptomPromptScreen() {
 
   useEffect(() => {
     const s = getSymptomPromptSession(episodeId);
+    activeIndexRef.current = s.activeIndex;
     setActiveIndex(s.activeIndex);
     setAnswers(s.answers);
     answersRef.current = s.answers;
@@ -165,12 +172,14 @@ export function SymptomPromptScreen() {
     };
     answersRef.current = merged;
     setAnswers(merged);
-    persist(activeIndex, merged);
+    persist(activeIndexRef.current, merged);
   };
 
   const goBackStep = () => {
-    if (activeIndex > 0) {
-      const next = activeIndex - 1;
+    const idx = activeIndexRef.current;
+    if (idx > 0) {
+      const next = idx - 1;
+      activeIndexRef.current = next;
       setActiveIndex(next);
       persist(next, answersRef.current);
       announce(`Back to step ${next + 1} of ${lines.length}.`);
@@ -184,8 +193,10 @@ export function SymptomPromptScreen() {
       setPhase('complete');
       return;
     }
-    if (activeIndex < lines.length - 1) {
-      const next = activeIndex + 1;
+    const idx = activeIndexRef.current;
+    if (idx < lines.length - 1) {
+      const next = idx + 1;
+      activeIndexRef.current = next;
       setActiveIndex(next);
       persist(next, answersRef.current);
       return;

--- a/apps/mobile/src/lib/episodes/symptom-prompt-session-store.spec.ts
+++ b/apps/mobile/src/lib/episodes/symptom-prompt-session-store.spec.ts
@@ -21,6 +21,24 @@ describe('symptom-prompt-session-store', () => {
     }
   });
 
+  it('getSymptomPromptSession returns initial state when stored root is null', () => {
+    setSymptomPromptSession(EP_1, null as unknown as SymptomPromptSessionState);
+    expect(getSymptomPromptSession(EP_1)).toEqual(initial);
+  });
+
+  it('getSymptomPromptSession returns initial state when stored root is not an object', () => {
+    setSymptomPromptSession(
+      EP_1,
+      'oops' as unknown as SymptomPromptSessionState,
+    );
+    expect(getSymptomPromptSession(EP_1)).toEqual(initial);
+  });
+
+  it('getSymptomPromptSession returns initial state when stored root is an array', () => {
+    setSymptomPromptSession(EP_1, [] as unknown as SymptomPromptSessionState);
+    expect(getSymptomPromptSession(EP_1)).toEqual(initial);
+  });
+
   it('getSymptomPromptSession returns initial state when activeIndex is NaN', () => {
     setSymptomPromptSession(EP_1, {
       activeIndex: NaN,

--- a/apps/mobile/src/lib/episodes/symptom-prompt-session-store.spec.ts
+++ b/apps/mobile/src/lib/episodes/symptom-prompt-session-store.spec.ts
@@ -82,13 +82,38 @@ describe('symptom-prompt-session-store', () => {
         badType: { type: 'unknown', value: null },
         badYesNo: { type: 'yes_no', value: 'yes' },
         badScale: { type: 'severity_scale', value: '3' },
+        badSeverityOor: { type: 'severity_scale', value: 99 },
+        badSeverityFloat: { type: 'severity_scale', value: 3.5 },
         badFreeText: { type: 'free_text', value: 12 },
         badPhoto: { type: 'photo', value: 'x' },
       } as unknown as SymptomPromptSessionState['answers'],
     });
     expect(getSymptomPromptSession(EP_1)).toEqual({
       activeIndex: 1,
-      answers: { good: { type: 'yes_no', value: true } },
+      answers: {
+        good: { type: 'yes_no', value: true },
+        badSeverityOor: { type: 'severity_scale', value: null },
+        badSeverityFloat: { type: 'severity_scale', value: null },
+      },
+    });
+  });
+
+  it('getSymptomPromptSession keeps severity_scale only for integers 1–5 or null', () => {
+    setSymptomPromptSession(EP_1, {
+      activeIndex: 0,
+      answers: {
+        a: { type: 'severity_scale', value: 1 },
+        b: { type: 'severity_scale', value: 5 },
+        c: { type: 'severity_scale', value: null },
+      },
+    });
+    expect(getSymptomPromptSession(EP_1)).toEqual({
+      activeIndex: 0,
+      answers: {
+        a: { type: 'severity_scale', value: 1 },
+        b: { type: 'severity_scale', value: 5 },
+        c: { type: 'severity_scale', value: null },
+      },
     });
   });
 

--- a/apps/mobile/src/lib/episodes/symptom-prompt-session-store.spec.ts
+++ b/apps/mobile/src/lib/episodes/symptom-prompt-session-store.spec.ts
@@ -72,6 +72,39 @@ describe('symptom-prompt-session-store', () => {
     expect(getSymptomPromptSession(EP_1)).toEqual(initial);
   });
 
+  it('getSymptomPromptSession drops malformed answer entries but keeps valid ones and activeIndex', () => {
+    setSymptomPromptSession(EP_1, {
+      activeIndex: 1,
+      answers: {
+        good: { type: 'yes_no', value: true },
+        badNull: null,
+        badString: 'x',
+        badType: { type: 'unknown', value: null },
+        badYesNo: { type: 'yes_no', value: 'yes' },
+        badScale: { type: 'severity_scale', value: '3' },
+        badFreeText: { type: 'free_text', value: 12 },
+        badPhoto: { type: 'photo', value: 'x' },
+      } as unknown as SymptomPromptSessionState['answers'],
+    });
+    expect(getSymptomPromptSession(EP_1)).toEqual({
+      activeIndex: 1,
+      answers: { good: { type: 'yes_no', value: true } },
+    });
+  });
+
+  it('getSymptomPromptSession returns empty answers when all entries are invalid', () => {
+    setSymptomPromptSession(EP_1, {
+      activeIndex: 2,
+      answers: {
+        x: { type: 'yes_no', value: [] },
+      } as unknown as SymptomPromptSessionState['answers'],
+    });
+    expect(getSymptomPromptSession(EP_1)).toEqual({
+      activeIndex: 2,
+      answers: {},
+    });
+  });
+
   it('keeps state isolated per episode id', () => {
     setSymptomPromptSession(EP_A, {
       activeIndex: 1,

--- a/apps/mobile/src/lib/episodes/symptom-prompt-session-store.spec.ts
+++ b/apps/mobile/src/lib/episodes/symptom-prompt-session-store.spec.ts
@@ -117,6 +117,17 @@ describe('symptom-prompt-session-store', () => {
     });
   });
 
+  it('getSymptomPromptSession does not copy prototype-polluting answer keys', () => {
+    const answers = JSON.parse(
+      '{"__proto__":{"type":"yes_no","value":true},"constructor":{"type":"yes_no","value":false},"prototype":{"type":"yes_no","value":true},"legit":{"type":"yes_no","value":false}}',
+    ) as SymptomPromptSessionState['answers'];
+    setSymptomPromptSession(EP_1, { activeIndex: 0, answers });
+    expect(getSymptomPromptSession(EP_1)).toEqual({
+      activeIndex: 0,
+      answers: { legit: { type: 'yes_no', value: false } },
+    });
+  });
+
   it('getSymptomPromptSession returns empty answers when all entries are invalid', () => {
     setSymptomPromptSession(EP_1, {
       activeIndex: 2,

--- a/apps/mobile/src/lib/episodes/symptom-prompt-session-store.spec.ts
+++ b/apps/mobile/src/lib/episodes/symptom-prompt-session-store.spec.ts
@@ -1,0 +1,107 @@
+import { createInitialSymptomPromptSession } from '@abstrack/types';
+import type { SymptomPromptSessionState } from '@abstrack/types';
+import {
+  clearSymptomPromptSession,
+  getSymptomPromptSession,
+  setSymptomPromptSession,
+} from './symptom-prompt-session-store';
+
+const initial = createInitialSymptomPromptSession();
+
+/** Episode ids used in this suite — cleared between tests for isolation. */
+const EP_1 = 'ep-store-1';
+const EP_2 = 'ep-store-2';
+const EP_A = 'ep-isolation-a';
+const EP_B = 'ep-isolation-b';
+
+describe('symptom-prompt-session-store', () => {
+  beforeEach(() => {
+    for (const id of [EP_1, EP_2, EP_A, EP_B]) {
+      clearSymptomPromptSession(id);
+    }
+  });
+
+  it('getSymptomPromptSession returns initial state when activeIndex is NaN', () => {
+    setSymptomPromptSession(EP_1, {
+      activeIndex: NaN,
+      answers: {},
+    });
+    expect(getSymptomPromptSession(EP_1)).toEqual(initial);
+  });
+
+  it('getSymptomPromptSession returns initial state when activeIndex is Infinity', () => {
+    setSymptomPromptSession(EP_1, {
+      activeIndex: Number.POSITIVE_INFINITY,
+      answers: {},
+    });
+    expect(getSymptomPromptSession(EP_1)).toEqual(initial);
+  });
+
+  it('getSymptomPromptSession floors and clamps non-negative activeIndex', () => {
+    setSymptomPromptSession(EP_1, {
+      activeIndex: 2.7,
+      answers: { 'line-a': { type: 'yes_no', value: true } },
+    });
+    expect(getSymptomPromptSession(EP_1)).toEqual({
+      activeIndex: 2,
+      answers: { 'line-a': { type: 'yes_no', value: true } },
+    });
+  });
+
+  it('getSymptomPromptSession clamps negative activeIndex to 0', () => {
+    setSymptomPromptSession(EP_1, {
+      activeIndex: -3,
+      answers: {},
+    });
+    expect(getSymptomPromptSession(EP_1).activeIndex).toBe(0);
+  });
+
+  it('getSymptomPromptSession rejects answers array', () => {
+    setSymptomPromptSession(EP_1, {
+      activeIndex: 0,
+      answers: [] as unknown as SymptomPromptSessionState['answers'],
+    });
+    expect(getSymptomPromptSession(EP_1)).toEqual(initial);
+  });
+
+  it('getSymptomPromptSession rejects null answers', () => {
+    setSymptomPromptSession(EP_1, {
+      activeIndex: 0,
+      answers: null as unknown as SymptomPromptSessionState['answers'],
+    });
+    expect(getSymptomPromptSession(EP_1)).toEqual(initial);
+  });
+
+  it('keeps state isolated per episode id', () => {
+    setSymptomPromptSession(EP_A, {
+      activeIndex: 1,
+      answers: { x: { type: 'free_text', value: 'a' } },
+    });
+    setSymptomPromptSession(EP_B, {
+      activeIndex: 2,
+      answers: { y: { type: 'free_text', value: 'b' } },
+    });
+    expect(getSymptomPromptSession(EP_A)).toEqual({
+      activeIndex: 1,
+      answers: { x: { type: 'free_text', value: 'a' } },
+    });
+    expect(getSymptomPromptSession(EP_B)).toEqual({
+      activeIndex: 2,
+      answers: { y: { type: 'free_text', value: 'b' } },
+    });
+  });
+
+  it('clearSymptomPromptSession removes only that episode', () => {
+    setSymptomPromptSession(EP_1, { activeIndex: 0, answers: {} });
+    setSymptomPromptSession(EP_2, {
+      activeIndex: 1,
+      answers: { z: { type: 'yes_no', value: false } },
+    });
+    clearSymptomPromptSession(EP_1);
+    expect(getSymptomPromptSession(EP_1)).toEqual(initial);
+    expect(getSymptomPromptSession(EP_2)).toEqual({
+      activeIndex: 1,
+      answers: { z: { type: 'yes_no', value: false } },
+    });
+  });
+});

--- a/apps/mobile/src/lib/episodes/symptom-prompt-session-store.ts
+++ b/apps/mobile/src/lib/episodes/symptom-prompt-session-store.ts
@@ -7,6 +7,30 @@ import { createInitialSymptomPromptSession } from '@abstrack/types';
  */
 const sessions = new Map<Uuid, SymptomPromptSessionState>();
 
+function sanitizeActiveIndex(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null;
+  }
+  return Math.max(0, Math.floor(value));
+}
+
+function sanitizeStoredState(
+  raw: SymptomPromptSessionState,
+): SymptomPromptSessionState {
+  if (
+    typeof raw.answers !== 'object' ||
+    raw.answers === null ||
+    Array.isArray(raw.answers)
+  ) {
+    return createInitialSymptomPromptSession();
+  }
+  const activeIndex = sanitizeActiveIndex(raw.activeIndex);
+  if (activeIndex === null) {
+    return createInitialSymptomPromptSession();
+  }
+  return { activeIndex, answers: raw.answers };
+}
+
 /**
  * Reads traversal state for an episode, or returns a fresh initial state.
  *
@@ -16,7 +40,11 @@ const sessions = new Map<Uuid, SymptomPromptSessionState>();
 export function getSymptomPromptSession(
   episodeId: string,
 ): SymptomPromptSessionState {
-  return sessions.get(episodeId) ?? createInitialSymptomPromptSession();
+  const raw = sessions.get(episodeId);
+  if (!raw) {
+    return createInitialSymptomPromptSession();
+  }
+  return sanitizeStoredState(raw);
 }
 
 /**

--- a/apps/mobile/src/lib/episodes/symptom-prompt-session-store.ts
+++ b/apps/mobile/src/lib/episodes/symptom-prompt-session-store.ts
@@ -80,6 +80,15 @@ function sanitizeAnswerEntry(value: unknown): SymptomPromptAnswer | null {
   }
 }
 
+/** Rejects keys that must not be assigned when copying untrusted shapes into an object. */
+function isSafeAnswerKey(key: string): boolean {
+  return (
+    key !== '__proto__' &&
+    key !== 'constructor' &&
+    key !== 'prototype'
+  );
+}
+
 function sanitizeAnswers(answers: unknown): SymptomPromptAnswers {
   if (
     typeof answers !== 'object' ||
@@ -88,8 +97,11 @@ function sanitizeAnswers(answers: unknown): SymptomPromptAnswers {
   ) {
     return {};
   }
-  const out: SymptomPromptAnswers = {};
+  const out = Object.create(null) as SymptomPromptAnswers;
   for (const [key, val] of Object.entries(answers)) {
+    if (!isSafeAnswerKey(key)) {
+      continue;
+    }
     const cleaned = sanitizeAnswerEntry(val);
     if (cleaned !== null) {
       out[key] = cleaned;

--- a/apps/mobile/src/lib/episodes/symptom-prompt-session-store.ts
+++ b/apps/mobile/src/lib/episodes/symptom-prompt-session-store.ts
@@ -1,4 +1,9 @@
-import type { SymptomPromptSessionState, Uuid } from '@abstrack/types';
+import type {
+  SymptomPromptAnswer,
+  SymptomPromptAnswers,
+  SymptomPromptSessionState,
+  Uuid,
+} from '@abstrack/types';
 import { createInitialSymptomPromptSession } from '@abstrack/types';
 
 /**
@@ -12,6 +17,74 @@ function sanitizeActiveIndex(value: unknown): number | null {
     return null;
   }
   return Math.max(0, Math.floor(value));
+}
+
+/**
+ * Keeps only well-shaped {@link SymptomPromptAnswer} values so malformed in-memory state cannot crash the UI.
+ */
+function sanitizeAnswerEntry(value: unknown): SymptomPromptAnswer | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const o = value as Record<string, unknown>;
+  const t = o.type;
+  if (
+    t !== 'yes_no' &&
+    t !== 'severity_scale' &&
+    t !== 'free_text' &&
+    t !== 'photo' &&
+    t !== 'video'
+  ) {
+    return null;
+  }
+  const v = o.value;
+  switch (t) {
+    case 'yes_no':
+      if (typeof v === 'boolean' || v === null) {
+        return { type: 'yes_no', value: v };
+      }
+      return null;
+    case 'severity_scale':
+      if (v === null || (typeof v === 'number' && Number.isFinite(v))) {
+        return { type: 'severity_scale', value: v };
+      }
+      return null;
+    case 'free_text':
+      if (typeof v === 'string') {
+        return { type: 'free_text', value: v };
+      }
+      return null;
+    case 'photo':
+      if (v === null) {
+        return { type: 'photo', value: null };
+      }
+      return null;
+    case 'video':
+      if (v === null) {
+        return { type: 'video', value: null };
+      }
+      return null;
+    default:
+      return null;
+  }
+}
+
+function sanitizeAnswers(answers: unknown): SymptomPromptAnswers {
+  if (
+    typeof answers !== 'object' ||
+    answers === null ||
+    Array.isArray(answers)
+  ) {
+    return {};
+  }
+  const out: SymptomPromptAnswers = {};
+  for (const [key, val] of Object.entries(answers)) {
+    const cleaned = sanitizeAnswerEntry(val);
+    if (cleaned !== null) {
+      out[key] = cleaned;
+    }
+  }
+  return out;
 }
 
 function sanitizeStoredState(
@@ -28,7 +101,7 @@ function sanitizeStoredState(
   if (activeIndex === null) {
     return createInitialSymptomPromptSession();
   }
-  return { activeIndex, answers: raw.answers };
+  return { activeIndex, answers: sanitizeAnswers(raw.answers) };
 }
 
 /**

--- a/apps/mobile/src/lib/episodes/symptom-prompt-session-store.ts
+++ b/apps/mobile/src/lib/episodes/symptom-prompt-session-store.ts
@@ -12,6 +12,10 @@ import { createInitialSymptomPromptSession } from '@abstrack/types';
  */
 const sessions = new Map<Uuid, SymptomPromptSessionState>();
 
+/** Matches severity UI (1–5 scale); integers only. */
+const SEVERITY_MIN = 1;
+const SEVERITY_MAX = 5;
+
 function sanitizeActiveIndex(value: unknown): number | null {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
     return null;
@@ -44,11 +48,18 @@ function sanitizeAnswerEntry(value: unknown): SymptomPromptAnswer | null {
         return { type: 'yes_no', value: v };
       }
       return null;
-    case 'severity_scale':
-      if (v === null || (typeof v === 'number' && Number.isFinite(v))) {
+    case 'severity_scale': {
+      if (v === null) {
+        return { type: 'severity_scale', value: null };
+      }
+      if (typeof v !== 'number' || !Number.isFinite(v)) {
+        return null;
+      }
+      if (Number.isInteger(v) && v >= SEVERITY_MIN && v <= SEVERITY_MAX) {
         return { type: 'severity_scale', value: v };
       }
-      return null;
+      return { type: 'severity_scale', value: null };
+    }
     case 'free_text':
       if (typeof v === 'string') {
         return { type: 'free_text', value: v };

--- a/apps/mobile/src/lib/episodes/symptom-prompt-session-store.ts
+++ b/apps/mobile/src/lib/episodes/symptom-prompt-session-store.ts
@@ -1,110 +1,15 @@
-import type {
-  SymptomPromptAnswer,
-  SymptomPromptAnswers,
-  SymptomPromptSessionState,
-  Uuid,
+import type { SymptomPromptSessionState, Uuid } from '@abstrack/types';
+import {
+  createInitialSymptomPromptSession,
+  sanitizeSymptomPromptActiveIndex,
+  sanitizeSymptomPromptAnswers,
 } from '@abstrack/types';
-import { createInitialSymptomPromptSession } from '@abstrack/types';
 
 /**
  * In-memory session store so symptom prompt progress survives leaving and re-opening the
  * prompt screen during one app session (same episode id).
  */
 const sessions = new Map<Uuid, SymptomPromptSessionState>();
-
-/** Matches severity UI (1–5 scale); integers only. */
-const SEVERITY_MIN = 1;
-const SEVERITY_MAX = 5;
-
-function sanitizeActiveIndex(value: unknown): number | null {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    return null;
-  }
-  return Math.max(0, Math.floor(value));
-}
-
-/**
- * Keeps only well-shaped {@link SymptomPromptAnswer} values so malformed in-memory state cannot crash the UI.
- */
-function sanitizeAnswerEntry(value: unknown): SymptomPromptAnswer | null {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    return null;
-  }
-  const o = value as Record<string, unknown>;
-  const t = o.type;
-  if (
-    t !== 'yes_no' &&
-    t !== 'severity_scale' &&
-    t !== 'free_text' &&
-    t !== 'photo' &&
-    t !== 'video'
-  ) {
-    return null;
-  }
-  const v = o.value;
-  switch (t) {
-    case 'yes_no':
-      if (typeof v === 'boolean' || v === null) {
-        return { type: 'yes_no', value: v };
-      }
-      return null;
-    case 'severity_scale': {
-      if (v === null) {
-        return { type: 'severity_scale', value: null };
-      }
-      if (typeof v !== 'number' || !Number.isFinite(v)) {
-        return null;
-      }
-      if (Number.isInteger(v) && v >= SEVERITY_MIN && v <= SEVERITY_MAX) {
-        return { type: 'severity_scale', value: v };
-      }
-      return { type: 'severity_scale', value: null };
-    }
-    case 'free_text':
-      if (typeof v === 'string') {
-        return { type: 'free_text', value: v };
-      }
-      return null;
-    case 'photo':
-      if (v === null) {
-        return { type: 'photo', value: null };
-      }
-      return null;
-    case 'video':
-      if (v === null) {
-        return { type: 'video', value: null };
-      }
-      return null;
-    default:
-      return null;
-  }
-}
-
-/** Rejects keys that must not be assigned when copying untrusted shapes into an object. */
-function isSafeAnswerKey(key: string): boolean {
-  return key !== '__proto__' && key !== 'constructor' && key !== 'prototype';
-}
-
-function sanitizeAnswers(answers: unknown): SymptomPromptAnswers {
-  if (
-    typeof answers !== 'object' ||
-    answers === null ||
-    Array.isArray(answers)
-  ) {
-    return {};
-  }
-  const out = Object.create(null) as SymptomPromptAnswers;
-  for (const [key, val] of Object.entries(answers)) {
-    if (!isSafeAnswerKey(key)) {
-      continue;
-    }
-    const cleaned = sanitizeAnswerEntry(val);
-    if (cleaned !== null) {
-      out[key] = cleaned;
-    }
-  }
-  return out;
-}
 
 function sanitizeStoredState(
   raw: SymptomPromptSessionState,
@@ -116,11 +21,11 @@ function sanitizeStoredState(
   ) {
     return createInitialSymptomPromptSession();
   }
-  const activeIndex = sanitizeActiveIndex(raw.activeIndex);
+  const activeIndex = sanitizeSymptomPromptActiveIndex(raw.activeIndex);
   if (activeIndex === null) {
     return createInitialSymptomPromptSession();
   }
-  return { activeIndex, answers: sanitizeAnswers(raw.answers) };
+  return { activeIndex, answers: sanitizeSymptomPromptAnswers(raw.answers) };
 }
 
 /**

--- a/apps/mobile/src/lib/episodes/symptom-prompt-session-store.ts
+++ b/apps/mobile/src/lib/episodes/symptom-prompt-session-store.ts
@@ -1,0 +1,42 @@
+import type { SymptomPromptSessionState, Uuid } from '@abstrack/types';
+import { createInitialSymptomPromptSession } from '@abstrack/types';
+
+/**
+ * In-memory session store so symptom prompt progress survives leaving and re-opening the
+ * prompt screen during one app session (same episode id).
+ */
+const sessions = new Map<Uuid, SymptomPromptSessionState>();
+
+/**
+ * Reads traversal state for an episode, or returns a fresh initial state.
+ *
+ * @param episodeId - `episodes.id`.
+ * @returns Persisted state or {@link createInitialSymptomPromptSession}.
+ */
+export function getSymptomPromptSession(
+  episodeId: string,
+): SymptomPromptSessionState {
+  return sessions.get(episodeId) ?? createInitialSymptomPromptSession();
+}
+
+/**
+ * Persists traversal state for an episode (in-memory only).
+ *
+ * @param episodeId - `episodes.id`.
+ * @param state - Next {@link SymptomPromptSessionState}.
+ */
+export function setSymptomPromptSession(
+  episodeId: string,
+  state: SymptomPromptSessionState,
+): void {
+  sessions.set(episodeId, state);
+}
+
+/**
+ * Clears stored state when the user finishes or abandons a flow (optional hygiene).
+ *
+ * @param episodeId - `episodes.id`.
+ */
+export function clearSymptomPromptSession(episodeId: string): void {
+  sessions.delete(episodeId);
+}

--- a/apps/mobile/src/lib/episodes/symptom-prompt-session-store.ts
+++ b/apps/mobile/src/lib/episodes/symptom-prompt-session-store.ts
@@ -11,21 +11,24 @@ import {
  */
 const sessions = new Map<Uuid, SymptomPromptSessionState>();
 
-function sanitizeStoredState(
-  raw: SymptomPromptSessionState,
-): SymptomPromptSessionState {
+function sanitizeStoredState(raw: unknown): SymptomPromptSessionState {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    return createInitialSymptomPromptSession();
+  }
+  const o = raw as Record<string, unknown>;
+  const answers = o['answers'];
   if (
-    typeof raw.answers !== 'object' ||
-    raw.answers === null ||
-    Array.isArray(raw.answers)
+    typeof answers !== 'object' ||
+    answers === null ||
+    Array.isArray(answers)
   ) {
     return createInitialSymptomPromptSession();
   }
-  const activeIndex = sanitizeSymptomPromptActiveIndex(raw.activeIndex);
+  const activeIndex = sanitizeSymptomPromptActiveIndex(o['activeIndex']);
   if (activeIndex === null) {
     return createInitialSymptomPromptSession();
   }
-  return { activeIndex, answers: sanitizeSymptomPromptAnswers(raw.answers) };
+  return { activeIndex, answers: sanitizeSymptomPromptAnswers(answers) };
 }
 
 /**

--- a/apps/mobile/src/lib/episodes/symptom-prompt-session-store.ts
+++ b/apps/mobile/src/lib/episodes/symptom-prompt-session-store.ts
@@ -82,11 +82,7 @@ function sanitizeAnswerEntry(value: unknown): SymptomPromptAnswer | null {
 
 /** Rejects keys that must not be assigned when copying untrusted shapes into an object. */
 function isSafeAnswerKey(key: string): boolean {
-  return (
-    key !== '__proto__' &&
-    key !== 'constructor' &&
-    key !== 'prototype'
-  );
+  return key !== '__proto__' && key !== 'constructor' && key !== 'prototype';
 }
 
 function sanitizeAnswers(answers: unknown): SymptomPromptAnswers {

--- a/apps/web/src/app/(app)/episode/[episodeId]/symptoms/page.tsx
+++ b/apps/web/src/app/(app)/episode/[episodeId]/symptoms/page.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link';
+import { SymptomPromptFlow } from '@/components/episode-flow/SymptomPromptFlow';
+
+type PageProps = {
+  /** Next.js 16 passes dynamic route params as a Promise (await before use). */
+  params: Promise<{ episodeId: string }>;
+  searchParams: Promise<{ symptomPresetId?: string }>;
+};
+
+/**
+ * In-episode linear symptom prompts for the selected preset (Week 5 skeleton).
+ *
+ * @param props - Route and query params (`symptomPresetId` is required for this flow).
+ * @returns Symptom stepper or guidance when params are missing.
+ */
+export default async function EpisodeSymptomsPage({
+  params,
+  searchParams,
+}: PageProps) {
+  const { episodeId } = await params;
+  const { symptomPresetId } = await searchParams;
+
+  if (!symptomPresetId) {
+    return (
+      <div className="space-y-4">
+        <p className="text-sm font-medium text-app-muted">
+          <Link
+            href="/dashboard"
+            className="rounded-md text-app-primary underline decoration-app-primary/40 underline-offset-2 outline-none transition hover:text-app-ink focus-visible:ring-2 focus-visible:ring-app-ring"
+          >
+            ← Back to dashboard
+          </Link>
+        </p>
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Episode symptoms
+        </h1>
+        <p className="text-sm text-app-muted" role="status">
+          This page needs a symptom preset reference. Start an episode from the
+          dashboard and try again.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <SymptomPromptFlow
+      episodeId={episodeId}
+      symptomPresetId={symptomPresetId}
+    />
+  );
+}

--- a/apps/web/src/app/(app)/episode/start/loading.tsx
+++ b/apps/web/src/app/(app)/episode/start/loading.tsx
@@ -6,5 +6,5 @@ import { PageLoading } from '@/components/page-states/PageLoading';
  * @returns Loading fallback.
  */
 export default function EpisodeStartLoading() {
-  return <PageLoading title="Start an episode" />;
+  return <PageLoading title="Start an episode" message="Preparing…" />;
 }

--- a/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
@@ -54,7 +54,7 @@ export function EpisodeStartFlow() {
 
     if (result.data.length === 1) {
       if (singleTemplateAutoSucceededRef.current) {
-        setLoadState('idle');
+        // Stay on `loading` until `router.replace` unmounts — `idle` would flash the chooser (e.g. Strict Mode re-runs).
         return;
       }
       if (singleTemplateAutoInFlightRef.current) {

--- a/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import type { EpisodeTemplateWithPresetsRow } from '@abstrack/types';
 import { createEpisode, listEpisodeTemplates } from '@abstrack/supabase';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { useAuth } from '@/lib/auth-provider';
-
-type FlowPhase = 'pick' | 'done';
+import { PageLoading } from '@/components/page-states/PageLoading';
 
 /**
  * Impaired-friendly episode start: load templates; if there is exactly one template, create the
@@ -18,11 +18,11 @@ type FlowPhase = 'pick' | 'done';
  * @returns Client UI for `/episode/start`.
  */
 export function EpisodeStartFlow() {
+  const router = useRouter();
   const { session, loading: authLoading } = useAuth();
   const { announce } = useAnnounce();
   const groupLegendId = useId();
-  const phaseRef = useRef<FlowPhase>('pick');
-  /** Prevents concurrent or repeated `createEpisode` on the single-template auto-start path when `refresh` runs more than once before `phase` is `done`. */
+  /** Prevents concurrent or repeated `createEpisode` on the single-template auto-start path when `refresh` runs more than once before navigation. */
   const singleTemplateAutoInFlightRef = useRef(false);
   const singleTemplateAutoSucceededRef = useRef(false);
 
@@ -34,8 +34,6 @@ export function EpisodeStartFlow() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
-  const [phase, setPhase] = useState<FlowPhase>('pick');
-  phaseRef.current = phase;
 
   const refresh = useCallback(async (): Promise<void> => {
     const userId = session?.user?.id;
@@ -56,7 +54,6 @@ export function EpisodeStartFlow() {
 
     if (result.data.length === 1) {
       if (singleTemplateAutoSucceededRef.current) {
-        setPhase('done');
         setLoadState('idle');
         return;
       }
@@ -82,10 +79,19 @@ export function EpisodeStartFlow() {
           setLoadState('idle');
           return;
         }
+        if (!saveResult.data) {
+          setSelectedId(template.id);
+          setSubmitError('Could not start episode.');
+          announce('Could not start episode.', { politeness: 'assertive' });
+          setLoadState('idle');
+          return;
+        }
         singleTemplateAutoSucceededRef.current = true;
         announce('Episode started.', { politeness: 'polite' });
-        setPhase('done');
-        setLoadState('idle');
+        // Stay on `loading` until navigation unmounts this view — `idle` would paint the chooser for a frame.
+        router.replace(
+          `/episode/${saveResult.data.id}/symptoms?symptomPresetId=${encodeURIComponent(template.symptom_preset_id)}`,
+        );
       } finally {
         singleTemplateAutoInFlightRef.current = false;
         setSubmitting(false);
@@ -100,10 +106,10 @@ export function EpisodeStartFlow() {
       }
       return null;
     });
-  }, [announce, session?.user?.id]);
+  }, [announce, router, session?.user?.id]);
 
   useEffect(() => {
-    if (authLoading || !session?.user?.id || phaseRef.current === 'done') {
+    if (authLoading || !session?.user?.id) {
       return;
     }
     void refresh();
@@ -132,19 +138,20 @@ export function EpisodeStartFlow() {
       announce(result.error.message, { politeness: 'assertive' });
       return;
     }
+    if (!result.data) {
+      const message = 'Could not start episode.';
+      setSubmitError(message);
+      announce(message, { politeness: 'assertive' });
+      return;
+    }
     announce('Episode started.', { politeness: 'polite' });
-    setPhase('done');
+    router.replace(
+      `/episode/${result.data.id}/symptoms?symptomPresetId=${encodeURIComponent(template.symptom_preset_id)}`,
+    );
   };
 
   if (authLoading) {
-    return (
-      <div className="space-y-2">
-        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
-          Start an episode
-        </h1>
-        <p className="text-sm text-app-muted">Loading…</p>
-      </div>
-    );
+    return <PageLoading title="Start an episode" />;
   }
 
   if (!session) {
@@ -166,42 +173,12 @@ export function EpisodeStartFlow() {
     );
   }
 
-  if (phase === 'done') {
-    return (
-      <div className="space-y-4">
-        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
-          Start an episode
-        </h1>
-        <div
-          className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
-          role="status"
-          aria-live="polite"
-        >
-          <p className="text-sm leading-relaxed text-app-ink">
-            Your episode has been started with the template you chose. You can
-            continue from the dashboard when you are ready.
-          </p>
-        </div>
-        <Link
-          href="/dashboard"
-          className="inline-flex min-h-[44px] items-center justify-center rounded-xl bg-app-primary px-5 text-sm font-semibold text-white shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-        >
-          Back to dashboard
-        </Link>
-      </div>
-    );
-  }
-
   if (loadState === 'loading') {
     return (
-      <div className="space-y-2">
-        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
-          Start an episode
-        </h1>
-        <p className="text-sm text-app-muted" role="status">
-          {submitting ? 'Starting episode…' : 'Loading templates…'}
-        </p>
-      </div>
+      <PageLoading
+        title="Start an episode"
+        message={submitting ? 'Starting your episode…' : 'Preparing…'}
+      />
     );
   }
 

--- a/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
@@ -80,13 +80,6 @@ export function EpisodeStartFlow() {
           setLoadState('idle');
           return;
         }
-        if (!saveResult.data) {
-          setSelectedId(template.id);
-          setSubmitError('Could not start episode.');
-          announce('Could not start episode.', { politeness: 'assertive' });
-          setLoadState('idle');
-          return;
-        }
         singleTemplateAutoSucceededRef.current = true;
         announce('Episode started.', { politeness: 'polite' });
         // Stay on `loading` until navigation unmounts this view — `idle` would paint the chooser for a frame.
@@ -141,12 +134,6 @@ export function EpisodeStartFlow() {
       if (!result.ok) {
         setSubmitError(result.error.message);
         announce(result.error.message, { politeness: 'assertive' });
-        return;
-      }
-      if (!result.data) {
-        const message = 'Could not start episode.';
-        setSubmitError(message);
-        announce(message, { politeness: 'assertive' });
         return;
       }
       announce('Episode started.', { politeness: 'polite' });

--- a/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
@@ -65,6 +65,7 @@ export function EpisodeStartFlow() {
       const template = result.data[0];
       singleTemplateAutoInFlightRef.current = true;
       setSubmitting(true);
+      let didNavigateToSymptoms = false;
       try {
         const saveResult = await createEpisode(supabase, {
           user_id: userId,
@@ -92,9 +93,12 @@ export function EpisodeStartFlow() {
         router.replace(
           `/episode/${saveResult.data.id}/symptoms?symptomPresetId=${encodeURIComponent(template.symptom_preset_id)}`,
         );
+        didNavigateToSymptoms = true;
       } finally {
         singleTemplateAutoInFlightRef.current = false;
-        setSubmitting(false);
+        if (!didNavigateToSymptoms) {
+          setSubmitting(false);
+        }
       }
       return;
     }
@@ -125,29 +129,36 @@ export function EpisodeStartFlow() {
     }
     setSubmitting(true);
     setSubmitError(null);
-    const supabase = createBrowserClient();
-    const result = await createEpisode(supabase, {
-      user_id: session.user.id,
-      started_at: new Date().toISOString(),
-      symptom_preset_id: template.symptom_preset_id,
-      health_marker_preset_id: template.health_marker_preset_id,
-    });
-    setSubmitting(false);
-    if (!result.ok) {
-      setSubmitError(result.error.message);
-      announce(result.error.message, { politeness: 'assertive' });
-      return;
+    let didNavigateToSymptoms = false;
+    try {
+      const supabase = createBrowserClient();
+      const result = await createEpisode(supabase, {
+        user_id: session.user.id,
+        started_at: new Date().toISOString(),
+        symptom_preset_id: template.symptom_preset_id,
+        health_marker_preset_id: template.health_marker_preset_id,
+      });
+      if (!result.ok) {
+        setSubmitError(result.error.message);
+        announce(result.error.message, { politeness: 'assertive' });
+        return;
+      }
+      if (!result.data) {
+        const message = 'Could not start episode.';
+        setSubmitError(message);
+        announce(message, { politeness: 'assertive' });
+        return;
+      }
+      announce('Episode started.', { politeness: 'polite' });
+      router.replace(
+        `/episode/${result.data.id}/symptoms?symptomPresetId=${encodeURIComponent(template.symptom_preset_id)}`,
+      );
+      didNavigateToSymptoms = true;
+    } finally {
+      if (!didNavigateToSymptoms) {
+        setSubmitting(false);
+      }
     }
-    if (!result.data) {
-      const message = 'Could not start episode.';
-      setSubmitError(message);
-      announce(message, { politeness: 'assertive' });
-      return;
-    }
-    announce('Episode started.', { politeness: 'polite' });
-    router.replace(
-      `/episode/${result.data.id}/symptoms?symptomPresetId=${encodeURIComponent(template.symptom_preset_id)}`,
-    );
   };
 
   if (authLoading) {

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -2,7 +2,13 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import type {
   PresetSymptomRow,
   SymptomPromptAnswer,
@@ -83,7 +89,7 @@ export function SymptomPromptFlow({
     answersRef.current = answers;
   }, [answers]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const outgoingEpisodeId = episodeIdRef.current;
     if (textPersistTimerRef.current !== null) {
       clearTimeout(textPersistTimerRef.current);
@@ -101,7 +107,7 @@ export function SymptomPromptFlow({
     activeIndexRef.current = s.activeIndex;
     setPhase('prompting');
     setHydrated(true);
-  }, [episodeId]);
+  }, [episodeId, symptomPresetId]);
 
   const flushPendingTextPersist = useCallback(() => {
     if (textPersistTimerRef.current === null) {
@@ -145,6 +151,7 @@ export function SymptomPromptFlow({
 
     setStatus('loading');
     setErrorMessage(null);
+    setPhase('prompting');
     const supabase = createBrowserClient();
     const result = await listPresetSymptomsForPreset(supabase, symptomPresetId);
     if (stale()) {

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -72,6 +72,8 @@ export function SymptomPromptFlow({
   const textPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  /** Bumps on each `load()` start and on effect cleanup so in-flight loads ignore stale results after unmount, retry, or param change. */
+  const loadGenRef = useRef(0);
 
   useEffect(() => {
     activeIndexRef.current = activeIndex;
@@ -138,10 +140,16 @@ export function SymptomPromptFlow({
   );
 
   const load = useCallback(async () => {
+    const myGen = ++loadGenRef.current;
+    const stale = () => myGen !== loadGenRef.current;
+
     setStatus('loading');
     setErrorMessage(null);
     const supabase = createBrowserClient();
     const result = await listPresetSymptomsForPreset(supabase, symptomPresetId);
+    if (stale()) {
+      return;
+    }
     if (!result.ok) {
       setErrorMessage(result.error.message);
       setStatus('error');
@@ -163,6 +171,9 @@ export function SymptomPromptFlow({
 
   useEffect(() => {
     void load();
+    return () => {
+      loadGenRef.current += 1;
+    };
   }, [load]);
 
   const currentLine = lines[activeIndex] ?? null;

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -26,7 +26,11 @@ function clampIndex(index: number, length: number): number {
   if (length <= 0) {
     return 0;
   }
-  return Math.max(0, Math.min(index, length - 1));
+  if (!Number.isFinite(index)) {
+    return 0;
+  }
+  const i = Math.trunc(index);
+  return Math.max(0, Math.min(i, length - 1));
 }
 
 /**

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+import type { PresetSymptomRow, SymptomPromptAnswer } from '@abstrack/types';
+import { createInitialSymptomPromptSession } from '@abstrack/types';
+import { listPresetSymptomsForPreset } from '@abstrack/supabase';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import { createBrowserClient } from '@/lib/supabase/browser-client';
+import {
+  clearSymptomPromptSession,
+  getSymptomPromptSession,
+  setSymptomPromptSession,
+} from '@/lib/episode-flow/symptom-prompt-session-store';
+import { SymptomPromptResponseField } from './SymptomPromptResponseField';
+
+export type SymptomPromptFlowProps = {
+  /** `episodes.id` from the route. */
+  episodeId: string;
+  /** `symptom_presets.id` for the active episode (from template at start). */
+  symptomPresetId: string;
+};
+
+function clampIndex(index: number, length: number): number {
+  if (length <= 0) {
+    return 0;
+  }
+  return Math.max(0, Math.min(index, length - 1));
+}
+
+/**
+ * Linear symptom stepper for the active episode’s preset (Week 5 skeleton).
+ *
+ * @param props - Episode and symptom preset identifiers.
+ * @returns One symptom at a time with back/next and session-scoped progress.
+ */
+export function SymptomPromptFlow({
+  episodeId,
+  symptomPresetId,
+}: SymptomPromptFlowProps) {
+  const router = useRouter();
+  const { announce } = useAnnounce();
+
+  const [hydrated, setHydrated] = useState(false);
+  const [status, setStatus] = useState<'loading' | 'error' | 'ready'>(
+    'loading',
+  );
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [lines, setLines] = useState<PresetSymptomRow[]>([]);
+  const [phase, setPhase] = useState<'prompting' | 'complete'>('prompting');
+
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [answers, setAnswers] = useState(
+    () => createInitialSymptomPromptSession().answers,
+  );
+
+  useEffect(() => {
+    const s = getSymptomPromptSession(episodeId);
+    setActiveIndex(s.activeIndex);
+    setAnswers(s.answers);
+    setPhase('prompting');
+    setHydrated(true);
+  }, [episodeId]);
+
+  const persist = useCallback(
+    (nextIndex: number, nextAnswers: typeof answers) => {
+      setSymptomPromptSession(episodeId, {
+        activeIndex: nextIndex,
+        answers: nextAnswers,
+      });
+    },
+    [episodeId],
+  );
+
+  const load = useCallback(async () => {
+    setStatus('loading');
+    setErrorMessage(null);
+    const supabase = createBrowserClient();
+    const result = await listPresetSymptomsForPreset(supabase, symptomPresetId);
+    if (!result.ok) {
+      setErrorMessage(result.error.message);
+      setStatus('error');
+      return;
+    }
+    setLines(result.data);
+    const session = getSymptomPromptSession(episodeId);
+    const idx = clampIndex(session.activeIndex, result.data.length);
+    setActiveIndex(idx);
+    setAnswers(session.answers);
+    setSymptomPromptSession(episodeId, {
+      activeIndex: idx,
+      answers: session.answers,
+    });
+    setStatus('ready');
+  }, [episodeId, symptomPresetId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const currentLine = lines[activeIndex] ?? null;
+  const stepLabel =
+    lines.length === 0
+      ? 'No symptoms'
+      : `Step ${activeIndex + 1} of ${lines.length}`;
+
+  useEffect(() => {
+    if (!hydrated || phase !== 'prompting' || !currentLine) {
+      return;
+    }
+    announce(`${stepLabel}. ${currentLine.symptom_name}.`, {
+      politeness: 'polite',
+    });
+  }, [
+    activeIndex,
+    announce,
+    currentLine,
+    hydrated,
+    lines.length,
+    phase,
+    stepLabel,
+  ]);
+
+  const onChangeAnswer = (next: SymptomPromptAnswer) => {
+    if (!currentLine) {
+      return;
+    }
+    setAnswers((prev) => {
+      const merged = { ...prev, [currentLine.id]: next };
+      persist(activeIndex, merged);
+      return merged;
+    });
+  };
+
+  const goBackStep = () => {
+    if (activeIndex > 0) {
+      const next = activeIndex - 1;
+      setActiveIndex(next);
+      persist(next, answers);
+      announce(`Back to step ${next + 1} of ${lines.length}.`, {
+        politeness: 'polite',
+      });
+    } else {
+      router.push('/dashboard');
+    }
+  };
+
+  const goNext = () => {
+    if (lines.length === 0) {
+      setPhase('complete');
+      return;
+    }
+    if (activeIndex < lines.length - 1) {
+      const next = activeIndex + 1;
+      setActiveIndex(next);
+      persist(next, answers);
+      return;
+    }
+    setPhase('complete');
+    announce('Symptom list complete.', { politeness: 'polite' });
+  };
+
+  const onFinishToDashboard = () => {
+    clearSymptomPromptSession(episodeId);
+    router.push('/dashboard');
+  };
+
+  if (phase === 'complete') {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Episode symptoms
+        </h1>
+        <div
+          className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
+          role="status"
+          aria-live="polite"
+        >
+          <p className="text-sm leading-relaxed text-app-ink">
+            You reached the end of your symptom list for this episode. You can
+            return to the dashboard when you are ready.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="inline-flex min-h-[56px] items-center justify-center rounded-xl bg-red-700 px-5 text-base font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:bg-red-600 dark:hover:bg-red-500"
+          onClick={onFinishToDashboard}
+        >
+          Back to dashboard
+        </button>
+      </div>
+    );
+  }
+
+  if (status === 'loading') {
+    return (
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Episode symptoms
+        </h1>
+        <p className="text-sm text-app-muted" role="status">
+          Loading symptom list…
+        </p>
+      </div>
+    );
+  }
+
+  if (status === 'error' && errorMessage) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Episode symptoms
+        </h1>
+        <p className="text-sm text-red-700 dark:text-red-300" role="alert">
+          {errorMessage}
+        </p>
+        <button
+          type="button"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-xl border border-app-border bg-app-surface px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          onClick={() => {
+            void load();
+          }}
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <p className="text-sm font-medium text-app-muted">
+          <Link
+            href="/dashboard"
+            className="rounded-md text-app-primary underline decoration-app-primary/40 underline-offset-2 outline-none transition hover:text-app-ink hover:decoration-app-primary focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          >
+            ← Back to dashboard
+          </Link>
+        </p>
+        <h1 className="mt-4 text-2xl font-bold tracking-tight text-app-ink">
+          Episode symptoms
+        </h1>
+      </div>
+
+      <p className="text-base font-medium text-app-muted">{stepLabel}</p>
+
+      {lines.length === 0 ? (
+        <div
+          className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
+          role="status"
+        >
+          <p className="text-sm leading-relaxed text-app-ink">
+            This preset has no symptoms yet. You can add symptoms under
+            Templates when you are not in an episode.
+          </p>
+        </div>
+      ) : currentLine ? (
+        <div className="space-y-4">
+          <h2 className="text-xl font-semibold text-app-ink">
+            {currentLine.symptom_name}
+          </h2>
+          {currentLine.prompt_instruction ? (
+            <p className="text-sm leading-relaxed text-app-muted">
+              {currentLine.prompt_instruction}
+            </p>
+          ) : null}
+          <SymptomPromptResponseField
+            line={currentLine}
+            answer={answers[currentLine.id]}
+            onChange={onChangeAnswer}
+            disabled={status !== 'ready'}
+          />
+        </div>
+      ) : null}
+
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <button
+          type="button"
+          className="inline-flex min-h-[56px] flex-1 items-center justify-center rounded-xl border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          onClick={goBackStep}
+        >
+          {activeIndex === 0 ? 'Exit to dashboard' : 'Back'}
+        </button>
+        <button
+          type="button"
+          className="inline-flex min-h-[56px] flex-1 items-center justify-center rounded-xl bg-red-700 px-4 text-base font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:bg-red-600 dark:hover:bg-red-500"
+          onClick={goNext}
+        >
+          {lines.length === 0
+            ? 'Done'
+            : activeIndex >= lines.length - 1
+              ? 'Finish'
+              : 'Next'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { PresetSymptomRow, SymptomPromptAnswer } from '@abstrack/types';
 import { createInitialSymptomPromptSession } from '@abstrack/types';
 import { listPresetSymptomsForPreset } from '@abstrack/supabase';
@@ -21,6 +21,9 @@ export type SymptomPromptFlowProps = {
   /** `symptom_presets.id` for the active episode (from template at start). */
   symptomPresetId: string;
 };
+
+/** Delay before writing free-text drafts to `sessionStorage` (keystrokes stay snappy in React state). */
+const FREE_TEXT_PERSIST_DEBOUNCE_MS = 300;
 
 function clampIndex(index: number, length: number): number {
   if (length <= 0) {
@@ -59,22 +62,75 @@ export function SymptomPromptFlow({
     () => createInitialSymptomPromptSession().answers,
   );
 
+  const episodeIdRef = useRef(episodeId);
+  const activeIndexRef = useRef(activeIndex);
+  const answersRef = useRef(answers);
+  const textPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+
   useEffect(() => {
+    activeIndexRef.current = activeIndex;
+  }, [activeIndex]);
+
+  useEffect(() => {
+    answersRef.current = answers;
+  }, [answers]);
+
+  useEffect(() => {
+    const outgoingEpisodeId = episodeIdRef.current;
+    if (textPersistTimerRef.current !== null) {
+      clearTimeout(textPersistTimerRef.current);
+      textPersistTimerRef.current = null;
+      setSymptomPromptSession(outgoingEpisodeId, {
+        activeIndex: activeIndexRef.current,
+        answers: answersRef.current,
+      });
+    }
+    episodeIdRef.current = episodeId;
     const s = getSymptomPromptSession(episodeId);
     setActiveIndex(s.activeIndex);
     setAnswers(s.answers);
+    answersRef.current = s.answers;
+    activeIndexRef.current = s.activeIndex;
     setPhase('prompting');
     setHydrated(true);
   }, [episodeId]);
 
-  const persist = useCallback(
+  const flushPendingTextPersist = useCallback(() => {
+    if (textPersistTimerRef.current === null) {
+      return;
+    }
+    clearTimeout(textPersistTimerRef.current);
+    textPersistTimerRef.current = null;
+    setSymptomPromptSession(episodeIdRef.current, {
+      activeIndex: activeIndexRef.current,
+      answers: answersRef.current,
+    });
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (textPersistTimerRef.current === null) {
+        return;
+      }
+      clearTimeout(textPersistTimerRef.current);
+      textPersistTimerRef.current = null;
+      setSymptomPromptSession(episodeIdRef.current, {
+        activeIndex: activeIndexRef.current,
+        answers: answersRef.current,
+      });
+    };
+  }, []);
+
+  const persistImmediate = useCallback(
     (nextIndex: number, nextAnswers: typeof answers) => {
-      setSymptomPromptSession(episodeId, {
+      setSymptomPromptSession(episodeIdRef.current, {
         activeIndex: nextIndex,
         answers: nextAnswers,
       });
     },
-    [episodeId],
+    [],
   );
 
   const load = useCallback(async () => {
@@ -92,6 +148,8 @@ export function SymptomPromptFlow({
     const idx = clampIndex(session.activeIndex, result.data.length);
     setActiveIndex(idx);
     setAnswers(session.answers);
+    answersRef.current = session.answers;
+    activeIndexRef.current = idx;
     setSymptomPromptSession(episodeId, {
       activeIndex: idx,
       answers: session.answers,
@@ -132,16 +190,39 @@ export function SymptomPromptFlow({
     }
     setAnswers((prev) => {
       const merged = { ...prev, [currentLine.id]: next };
-      persist(activeIndex, merged);
+      answersRef.current = merged;
+      if (next.type === 'free_text') {
+        if (textPersistTimerRef.current !== null) {
+          clearTimeout(textPersistTimerRef.current);
+        }
+        textPersistTimerRef.current = setTimeout(() => {
+          textPersistTimerRef.current = null;
+          setSymptomPromptSession(episodeIdRef.current, {
+            activeIndex: activeIndexRef.current,
+            answers: answersRef.current,
+          });
+        }, FREE_TEXT_PERSIST_DEBOUNCE_MS);
+      } else {
+        if (textPersistTimerRef.current !== null) {
+          clearTimeout(textPersistTimerRef.current);
+          textPersistTimerRef.current = null;
+        }
+        setSymptomPromptSession(episodeIdRef.current, {
+          activeIndex: activeIndexRef.current,
+          answers: merged,
+        });
+      }
       return merged;
     });
   };
 
   const goBackStep = () => {
+    flushPendingTextPersist();
     if (activeIndex > 0) {
       const next = activeIndex - 1;
       setActiveIndex(next);
-      persist(next, answers);
+      activeIndexRef.current = next;
+      persistImmediate(next, answersRef.current);
       announce(`Back to step ${next + 1} of ${lines.length}.`, {
         politeness: 'polite',
       });
@@ -151,6 +232,7 @@ export function SymptomPromptFlow({
   };
 
   const goNext = () => {
+    flushPendingTextPersist();
     if (lines.length === 0) {
       setPhase('complete');
       return;
@@ -158,7 +240,8 @@ export function SymptomPromptFlow({
     if (activeIndex < lines.length - 1) {
       const next = activeIndex + 1;
       setActiveIndex(next);
-      persist(next, answers);
+      activeIndexRef.current = next;
+      persistImmediate(next, answersRef.current);
       return;
     }
     setPhase('complete');

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -235,10 +235,11 @@ export function SymptomPromptFlow({
 
   const goBackStep = () => {
     flushPendingTextPersist();
-    if (activeIndex > 0) {
-      const next = activeIndex - 1;
-      setActiveIndex(next);
+    const idx = activeIndexRef.current;
+    if (idx > 0) {
+      const next = idx - 1;
       activeIndexRef.current = next;
+      setActiveIndex(next);
       persistImmediate(next, answersRef.current);
       announce(`Back to step ${next + 1} of ${lines.length}.`, {
         politeness: 'polite',
@@ -254,10 +255,11 @@ export function SymptomPromptFlow({
       setPhase('complete');
       return;
     }
-    if (activeIndex < lines.length - 1) {
-      const next = activeIndex + 1;
-      setActiveIndex(next);
+    const idx = activeIndexRef.current;
+    if (idx < lines.length - 1) {
+      const next = idx + 1;
       activeIndexRef.current = next;
+      setActiveIndex(next);
       persistImmediate(next, answersRef.current);
       return;
     }

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -3,7 +3,11 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { PresetSymptomRow, SymptomPromptAnswer } from '@abstrack/types';
+import type {
+  PresetSymptomRow,
+  SymptomPromptAnswer,
+  SymptomPromptAnswers,
+} from '@abstrack/types';
 import { createInitialSymptomPromptSession } from '@abstrack/types';
 import { listPresetSymptomsForPreset } from '@abstrack/supabase';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
@@ -188,32 +192,34 @@ export function SymptomPromptFlow({
     if (!currentLine) {
       return;
     }
-    setAnswers((prev) => {
-      const merged = { ...prev, [currentLine.id]: next };
-      answersRef.current = merged;
-      if (next.type === 'free_text') {
-        if (textPersistTimerRef.current !== null) {
-          clearTimeout(textPersistTimerRef.current);
-        }
-        textPersistTimerRef.current = setTimeout(() => {
-          textPersistTimerRef.current = null;
-          setSymptomPromptSession(episodeIdRef.current, {
-            activeIndex: activeIndexRef.current,
-            answers: answersRef.current,
-          });
-        }, FREE_TEXT_PERSIST_DEBOUNCE_MS);
-      } else {
-        if (textPersistTimerRef.current !== null) {
-          clearTimeout(textPersistTimerRef.current);
-          textPersistTimerRef.current = null;
-        }
+    const merged: SymptomPromptAnswers = {
+      ...answersRef.current,
+      [currentLine.id]: next,
+    };
+    answersRef.current = merged;
+    setAnswers(merged);
+
+    if (next.type === 'free_text') {
+      if (textPersistTimerRef.current !== null) {
+        clearTimeout(textPersistTimerRef.current);
+      }
+      textPersistTimerRef.current = setTimeout(() => {
+        textPersistTimerRef.current = null;
         setSymptomPromptSession(episodeIdRef.current, {
           activeIndex: activeIndexRef.current,
-          answers: merged,
+          answers: answersRef.current,
         });
+      }, FREE_TEXT_PERSIST_DEBOUNCE_MS);
+    } else {
+      if (textPersistTimerRef.current !== null) {
+        clearTimeout(textPersistTimerRef.current);
+        textPersistTimerRef.current = null;
       }
-      return merged;
-    });
+      setSymptomPromptSession(episodeIdRef.current, {
+        activeIndex: activeIndexRef.current,
+        answers: merged,
+      });
+    }
   };
 
   const goBackStep = () => {

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -106,6 +106,9 @@ export function SymptomPromptFlow({
     answersRef.current = s.answers;
     activeIndexRef.current = s.activeIndex;
     setPhase('prompting');
+    setStatus('loading');
+    setErrorMessage(null);
+    setLines([]);
     setHydrated(true);
   }, [episodeId, symptomPresetId]);
 

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import type {
+  PresetSymptomRow,
+  SymptomPromptAnswer,
+  SymptomResponseType,
+} from '@abstrack/types';
+
+export type SymptomPromptResponseFieldProps = {
+  line: PresetSymptomRow;
+  answer: SymptomPromptAnswer | undefined;
+  onChange: (next: SymptomPromptAnswer) => void;
+  disabled: boolean;
+};
+
+function defaultAnswerForType(type: SymptomResponseType): SymptomPromptAnswer {
+  switch (type) {
+    case 'yes_no':
+      return { type: 'yes_no', value: null };
+    case 'severity_scale':
+      return { type: 'severity_scale', value: null };
+    case 'free_text':
+      return { type: 'free_text', value: '' };
+    case 'photo':
+      return { type: 'photo', value: null };
+    case 'video':
+      return { type: 'video', value: null };
+    default: {
+      const _exhaustive: never = type;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * Renders the capture UI for one preset symptom line (Week 5 skeleton: no media pipeline).
+ *
+ * @param props - Line metadata, current answer, change handler, disabled flag.
+ * @returns Response-type-specific controls.
+ */
+export function SymptomPromptResponseField({
+  line,
+  answer,
+  onChange,
+  disabled,
+}: SymptomPromptResponseFieldProps) {
+  const effective = answer ?? defaultAnswerForType(line.response_type);
+
+  switch (line.response_type) {
+    case 'yes_no': {
+      const v = effective.type === 'yes_no' ? effective.value : null;
+      return (
+        <div
+          role="radiogroup"
+          aria-label={`${line.symptom_name} yes or no`}
+          className="flex flex-col gap-3"
+        >
+          {(['yes', 'no'] as const).map((which) => {
+            const boolVal = which === 'yes';
+            const selected = v === boolVal;
+            return (
+              <label
+                key={which}
+                className={`flex min-h-[56px] cursor-pointer items-center justify-center rounded-xl border-2 px-4 py-4 text-base font-semibold transition ${
+                  selected
+                    ? 'border-app-primary bg-app-primary/10 text-app-ink ring-1 ring-app-primary/20'
+                    : 'border-app-border/90 bg-app-surface text-app-ink hover:border-app-border'
+                } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
+              >
+                <input
+                  type="radio"
+                  className="sr-only"
+                  name={`symptom-yesno-${line.id}`}
+                  checked={selected}
+                  disabled={disabled}
+                  onChange={() => {
+                    onChange({ type: 'yes_no', value: boolVal });
+                  }}
+                />
+                <span className="capitalize">{which}</span>
+              </label>
+            );
+          })}
+        </div>
+      );
+    }
+    case 'severity_scale': {
+      const sev = effective.type === 'severity_scale' ? effective.value : null;
+      return (
+        <div
+          role="radiogroup"
+          aria-label={`${line.symptom_name} severity 1 to 5`}
+          className="flex flex-wrap gap-2"
+        >
+          {[1, 2, 3, 4, 5].map((n) => {
+            const selected = sev === n;
+            return (
+              <label
+                key={n}
+                className={`flex h-14 min-w-[52px] cursor-pointer items-center justify-center rounded-xl border-2 px-3 text-base font-semibold transition ${
+                  selected
+                    ? 'border-app-primary bg-app-primary/10 text-app-ink ring-1 ring-app-primary/20'
+                    : 'border-app-border/90 bg-app-surface text-app-ink hover:border-app-border'
+                } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
+              >
+                <input
+                  type="radio"
+                  className="sr-only"
+                  name={`symptom-sev-${line.id}`}
+                  checked={selected}
+                  disabled={disabled}
+                  onChange={() => {
+                    onChange({ type: 'severity_scale', value: n });
+                  }}
+                />
+                {n}
+              </label>
+            );
+          })}
+        </div>
+      );
+    }
+    case 'free_text': {
+      const text = effective.type === 'free_text' ? effective.value : '';
+      return (
+        <textarea
+          id={`symptom-text-${line.id}`}
+          aria-label={`${line.symptom_name} notes`}
+          disabled={disabled}
+          value={text}
+          onChange={(e) => {
+            onChange({ type: 'free_text', value: e.target.value });
+          }}
+          placeholder="Type a short note (optional)"
+          rows={5}
+          className="w-full rounded-xl border border-app-border/90 bg-app-surface p-4 text-base text-app-ink shadow-sm outline-none transition focus-visible:ring-2 focus-visible:ring-app-ring disabled:opacity-50"
+        />
+      );
+    }
+    case 'photo':
+      return (
+        <div
+          role="status"
+          className="rounded-xl border border-dashed border-app-border/90 bg-app-surface/80 p-6 text-center text-sm leading-relaxed text-app-ink"
+        >
+          Photo capture will open here during an episode. This step is a
+          placeholder for now.
+        </div>
+      );
+    case 'video':
+      return (
+        <div
+          role="status"
+          className="rounded-xl border border-dashed border-app-border/90 bg-app-surface/80 p-6 text-center text-sm leading-relaxed text-app-ink"
+        >
+          Video capture will open here during an episode. This step is a
+          placeholder for now.
+        </div>
+      );
+    default: {
+      const _exhaustive: never = line.response_type;
+      return _exhaustive;
+    }
+  }
+}

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
@@ -6,6 +6,10 @@ import type {
   SymptomResponseType,
 } from '@abstrack/types';
 
+/** Visible focus ring on the card when the visually hidden radio is focused with keyboard (see `sr-only` inputs). */
+const radioLabelFocusVisibleClass =
+  'has-[input:focus-visible]:outline-none has-[input:focus-visible]:ring-2 has-[input:focus-visible]:ring-app-ring has-[input:focus-visible]:ring-offset-2 has-[input:focus-visible]:ring-offset-app-bg';
+
 export type SymptomPromptResponseFieldProps = {
   line: PresetSymptomRow;
   answer: SymptomPromptAnswer | undefined;
@@ -61,7 +65,7 @@ export function SymptomPromptResponseField({
             return (
               <label
                 key={which}
-                className={`flex min-h-[56px] cursor-pointer items-center justify-center rounded-xl border-2 px-4 py-4 text-base font-semibold transition ${
+                className={`flex min-h-[56px] cursor-pointer items-center justify-center rounded-xl border-2 px-4 py-4 text-base font-semibold transition ${radioLabelFocusVisibleClass} ${
                   selected
                     ? 'border-app-primary bg-app-primary/10 text-app-ink ring-1 ring-app-primary/20'
                     : 'border-app-border/90 bg-app-surface text-app-ink hover:border-app-border'
@@ -97,7 +101,7 @@ export function SymptomPromptResponseField({
             return (
               <label
                 key={n}
-                className={`flex h-14 min-w-[52px] cursor-pointer items-center justify-center rounded-xl border-2 px-3 text-base font-semibold transition ${
+                className={`flex h-14 min-w-[52px] cursor-pointer items-center justify-center rounded-xl border-2 px-3 text-base font-semibold transition ${radioLabelFocusVisibleClass} ${
                   selected
                     ? 'border-app-primary bg-app-primary/10 text-app-ink ring-1 ring-app-primary/20'
                     : 'border-app-border/90 bg-app-surface text-app-ink hover:border-app-border'

--- a/apps/web/src/components/page-states/PageLoading.tsx
+++ b/apps/web/src/components/page-states/PageLoading.tsx
@@ -3,9 +3,16 @@
  *
  * @param props - Props.
  * @param props.title - Accessible name for the loading region.
+ * @param props.message - Visible status line (defaults to “Loading…”).
  * @returns Loading section.
  */
-export function PageLoading({ title }: { title: string }) {
+export function PageLoading({
+  title,
+  message = 'Loading…',
+}: {
+  title: string;
+  message?: string;
+}) {
   return (
     <section
       className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]"
@@ -17,7 +24,7 @@ export function PageLoading({ title }: { title: string }) {
           className="h-5 w-5 shrink-0 animate-spin rounded-full border-2 border-app-primary border-t-transparent"
           aria-hidden
         />
-        <p className="text-sm font-medium text-app-muted">Loading…</p>
+        <p className="text-sm font-medium text-app-muted">{message}</p>
       </div>
     </section>
   );

--- a/apps/web/src/lib/episode-flow/symptom-prompt-session-store.spec.ts
+++ b/apps/web/src/lib/episode-flow/symptom-prompt-session-store.spec.ts
@@ -13,18 +13,36 @@ function setStored(episodeId: string, value: unknown): void {
   );
 }
 
+/** Writes a raw string (bypasses JSON.stringify) to exercise parse edge cases. */
+function setStoredRaw(episodeId: string, raw: string): void {
+  sessionStorage.setItem(`abstrack.symptomPrompt.${episodeId}`, raw);
+}
+
 describe('symptom-prompt-session-store', () => {
   beforeEach(() => {
     sessionStorage.clear();
   });
 
-  it('getSymptomPromptSession returns initial state when activeIndex is NaN', () => {
-    setStored('ep-1', { activeIndex: NaN, answers: {} });
+  it('getSymptomPromptSession returns initial state when activeIndex is null (JSON.stringify maps NaN/Infinity to null)', () => {
+    expect(JSON.stringify({ activeIndex: NaN, answers: {} })).toBe(
+      '{"activeIndex":null,"answers":{}}',
+    );
+    setStored('ep-1', { activeIndex: null, answers: {} });
     expect(getSymptomPromptSession('ep-1')).toEqual(initial);
   });
 
-  it('getSymptomPromptSession returns initial state when activeIndex is Infinity', () => {
-    setStored('ep-1', { activeIndex: Number.POSITIVE_INFINITY, answers: {} });
+  it('getSymptomPromptSession returns initial state when activeIndex is Infinity (JSON number literal in stored payload)', () => {
+    setStoredRaw('ep-1', '{"activeIndex":1e400,"answers":{}}');
+    expect(getSymptomPromptSession('ep-1')).toEqual(initial);
+  });
+
+  it('getSymptomPromptSession returns initial state when activeIndex is not a number (e.g. string)', () => {
+    setStoredRaw('ep-1', '{"activeIndex":"2","answers":{}}');
+    expect(getSymptomPromptSession('ep-1')).toEqual(initial);
+  });
+
+  it('getSymptomPromptSession returns initial state when stored JSON is invalid', () => {
+    setStoredRaw('ep-1', '{"activeIndex":');
     expect(getSymptomPromptSession('ep-1')).toEqual(initial);
   });
 

--- a/apps/web/src/lib/episode-flow/symptom-prompt-session-store.spec.ts
+++ b/apps/web/src/lib/episode-flow/symptom-prompt-session-store.spec.ts
@@ -77,13 +77,38 @@ describe('symptom-prompt-session-store', () => {
         badType: { type: 'unknown', value: null },
         badYesNo: { type: 'yes_no', value: 'yes' },
         badScale: { type: 'severity_scale', value: '3' },
+        badSeverityOor: { type: 'severity_scale', value: 99 },
+        badSeverityFloat: { type: 'severity_scale', value: 3.5 },
         badFreeText: { type: 'free_text', value: 12 },
         badPhoto: { type: 'photo', value: 'x' },
       },
     });
     expect(getSymptomPromptSession('ep-1')).toEqual({
       activeIndex: 1,
-      answers: { good: { type: 'yes_no', value: true } },
+      answers: {
+        good: { type: 'yes_no', value: true },
+        badSeverityOor: { type: 'severity_scale', value: null },
+        badSeverityFloat: { type: 'severity_scale', value: null },
+      },
+    });
+  });
+
+  it('getSymptomPromptSession keeps severity_scale only for integers 1–5 or null', () => {
+    setStored('ep-1', {
+      activeIndex: 0,
+      answers: {
+        a: { type: 'severity_scale', value: 1 },
+        b: { type: 'severity_scale', value: 5 },
+        c: { type: 'severity_scale', value: null },
+      },
+    });
+    expect(getSymptomPromptSession('ep-1')).toEqual({
+      activeIndex: 0,
+      answers: {
+        a: { type: 'severity_scale', value: 1 },
+        b: { type: 'severity_scale', value: 5 },
+        c: { type: 'severity_scale', value: null },
+      },
     });
   });
 

--- a/apps/web/src/lib/episode-flow/symptom-prompt-session-store.spec.ts
+++ b/apps/web/src/lib/episode-flow/symptom-prompt-session-store.spec.ts
@@ -93,6 +93,17 @@ describe('symptom-prompt-session-store', () => {
     });
   });
 
+  it('getSymptomPromptSession does not copy prototype-polluting answer keys', () => {
+    const answers = JSON.parse(
+      '{"__proto__":{"type":"yes_no","value":true},"constructor":{"type":"yes_no","value":false},"prototype":{"type":"yes_no","value":true},"legit":{"type":"yes_no","value":false}}',
+    ) as Record<string, unknown>;
+    setStored('ep-1', { activeIndex: 0, answers });
+    expect(getSymptomPromptSession('ep-1')).toEqual({
+      activeIndex: 0,
+      answers: { legit: { type: 'yes_no', value: false } },
+    });
+  });
+
   it('getSymptomPromptSession keeps severity_scale only for integers 1–5 or null', () => {
     setStored('ep-1', {
       activeIndex: 0,

--- a/apps/web/src/lib/episode-flow/symptom-prompt-session-store.spec.ts
+++ b/apps/web/src/lib/episode-flow/symptom-prompt-session-store.spec.ts
@@ -67,6 +67,37 @@ describe('symptom-prompt-session-store', () => {
     expect(getSymptomPromptSession('ep-1')).toEqual(initial);
   });
 
+  it('getSymptomPromptSession drops corrupted answer entries but keeps valid ones and activeIndex', () => {
+    setStored('ep-1', {
+      activeIndex: 1,
+      answers: {
+        good: { type: 'yes_no', value: true },
+        badString: 'not-an-object',
+        badNull: null,
+        badType: { type: 'unknown', value: null },
+        badYesNo: { type: 'yes_no', value: 'yes' },
+        badScale: { type: 'severity_scale', value: '3' },
+        badFreeText: { type: 'free_text', value: 12 },
+        badPhoto: { type: 'photo', value: 'x' },
+      },
+    });
+    expect(getSymptomPromptSession('ep-1')).toEqual({
+      activeIndex: 1,
+      answers: { good: { type: 'yes_no', value: true } },
+    });
+  });
+
+  it('getSymptomPromptSession returns empty answers when all entries are invalid', () => {
+    setStored('ep-1', {
+      activeIndex: 2,
+      answers: { x: { type: 'yes_no', value: [] } },
+    });
+    expect(getSymptomPromptSession('ep-1')).toEqual({
+      activeIndex: 2,
+      answers: {},
+    });
+  });
+
   it('clearSymptomPromptSession removes key', () => {
     setStored('ep-1', { activeIndex: 0, answers: {} });
     clearSymptomPromptSession('ep-1');

--- a/apps/web/src/lib/episode-flow/symptom-prompt-session-store.spec.ts
+++ b/apps/web/src/lib/episode-flow/symptom-prompt-session-store.spec.ts
@@ -1,0 +1,57 @@
+import { createInitialSymptomPromptSession } from '@abstrack/types';
+import {
+  clearSymptomPromptSession,
+  getSymptomPromptSession,
+} from './symptom-prompt-session-store';
+
+const initial = createInitialSymptomPromptSession();
+
+function setStored(episodeId: string, value: unknown): void {
+  sessionStorage.setItem(
+    `abstrack.symptomPrompt.${episodeId}`,
+    JSON.stringify(value),
+  );
+}
+
+describe('symptom-prompt-session-store', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('getSymptomPromptSession returns initial state when activeIndex is NaN', () => {
+    setStored('ep-1', { activeIndex: NaN, answers: {} });
+    expect(getSymptomPromptSession('ep-1')).toEqual(initial);
+  });
+
+  it('getSymptomPromptSession returns initial state when activeIndex is Infinity', () => {
+    setStored('ep-1', { activeIndex: Number.POSITIVE_INFINITY, answers: {} });
+    expect(getSymptomPromptSession('ep-1')).toEqual(initial);
+  });
+
+  it('getSymptomPromptSession floors and clamps non-negative index', () => {
+    setStored('ep-1', {
+      activeIndex: 2.7,
+      answers: { a: { type: 'yes_no', value: true } },
+    });
+    expect(getSymptomPromptSession('ep-1')).toEqual({
+      activeIndex: 2,
+      answers: { a: { type: 'yes_no', value: true } },
+    });
+  });
+
+  it('getSymptomPromptSession clamps negative index to 0', () => {
+    setStored('ep-1', { activeIndex: -3, answers: {} });
+    expect(getSymptomPromptSession('ep-1').activeIndex).toBe(0);
+  });
+
+  it('getSymptomPromptSession rejects answers array', () => {
+    setStored('ep-1', { activeIndex: 0, answers: [] });
+    expect(getSymptomPromptSession('ep-1')).toEqual(initial);
+  });
+
+  it('clearSymptomPromptSession removes key', () => {
+    setStored('ep-1', { activeIndex: 0, answers: {} });
+    clearSymptomPromptSession('ep-1');
+    expect(getSymptomPromptSession('ep-1')).toEqual(initial);
+  });
+});

--- a/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
+++ b/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
@@ -1,4 +1,8 @@
-import type { SymptomPromptSessionState } from '@abstrack/types';
+import type {
+  SymptomPromptAnswer,
+  SymptomPromptAnswers,
+  SymptomPromptSessionState,
+} from '@abstrack/types';
 import { createInitialSymptomPromptSession } from '@abstrack/types';
 
 const STORAGE_PREFIX = 'abstrack.symptomPrompt.';
@@ -19,6 +23,74 @@ function sanitizeActiveIndex(value: unknown): number | null {
     return null;
   }
   return Math.max(0, Math.floor(value));
+}
+
+/**
+ * Keeps only well-shaped {@link SymptomPromptAnswer} values so corrupted `sessionStorage` cannot crash the UI.
+ */
+function sanitizeAnswerEntry(value: unknown): SymptomPromptAnswer | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const o = value as Record<string, unknown>;
+  const t = o.type;
+  if (
+    t !== 'yes_no' &&
+    t !== 'severity_scale' &&
+    t !== 'free_text' &&
+    t !== 'photo' &&
+    t !== 'video'
+  ) {
+    return null;
+  }
+  const v = o.value;
+  switch (t) {
+    case 'yes_no':
+      if (typeof v === 'boolean' || v === null) {
+        return { type: 'yes_no', value: v };
+      }
+      return null;
+    case 'severity_scale':
+      if (v === null || (typeof v === 'number' && Number.isFinite(v))) {
+        return { type: 'severity_scale', value: v };
+      }
+      return null;
+    case 'free_text':
+      if (typeof v === 'string') {
+        return { type: 'free_text', value: v };
+      }
+      return null;
+    case 'photo':
+      if (v === null) {
+        return { type: 'photo', value: null };
+      }
+      return null;
+    case 'video':
+      if (v === null) {
+        return { type: 'video', value: null };
+      }
+      return null;
+    default:
+      return null;
+  }
+}
+
+function sanitizeAnswers(answers: unknown): SymptomPromptAnswers {
+  if (
+    typeof answers !== 'object' ||
+    answers === null ||
+    Array.isArray(answers)
+  ) {
+    return {};
+  }
+  const out: SymptomPromptAnswers = {};
+  for (const [key, val] of Object.entries(answers)) {
+    const cleaned = sanitizeAnswerEntry(val);
+    if (cleaned !== null) {
+      out[key] = cleaned;
+    }
+  }
+  return out;
 }
 
 /**
@@ -54,7 +126,7 @@ export function getSymptomPromptSession(
     }
     return {
       activeIndex,
-      answers: parsed.answers,
+      answers: sanitizeAnswers(parsed.answers),
     };
   } catch {
     return createInitialSymptomPromptSession();

--- a/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
+++ b/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
@@ -1,0 +1,80 @@
+import type { SymptomPromptSessionState } from '@abstrack/types';
+import { createInitialSymptomPromptSession } from '@abstrack/types';
+
+const STORAGE_PREFIX = 'abstrack.symptomPrompt.';
+
+function storageKey(episodeId: string): string {
+  return `${STORAGE_PREFIX}${episodeId}`;
+}
+
+/**
+ * Reads traversal state from `sessionStorage` for the current browser session.
+ *
+ * @param episodeId - `episodes.id`.
+ * @returns Parsed state or {@link createInitialSymptomPromptSession}.
+ */
+export function getSymptomPromptSession(
+  episodeId: string,
+): SymptomPromptSessionState {
+  if (typeof window === 'undefined') {
+    return createInitialSymptomPromptSession();
+  }
+  try {
+    const raw = sessionStorage.getItem(storageKey(episodeId));
+    if (!raw) {
+      return createInitialSymptomPromptSession();
+    }
+    const parsed = JSON.parse(raw) as SymptomPromptSessionState;
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      typeof parsed.activeIndex !== 'number' ||
+      typeof parsed.answers !== 'object' ||
+      parsed.answers === null
+    ) {
+      return createInitialSymptomPromptSession();
+    }
+    return {
+      activeIndex: parsed.activeIndex,
+      answers: parsed.answers,
+    };
+  } catch {
+    return createInitialSymptomPromptSession();
+  }
+}
+
+/**
+ * Persists traversal state for an episode in `sessionStorage`.
+ *
+ * @param episodeId - `episodes.id`.
+ * @param state - Next {@link SymptomPromptSessionState}.
+ */
+export function setSymptomPromptSession(
+  episodeId: string,
+  state: SymptomPromptSessionState,
+): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    sessionStorage.setItem(storageKey(episodeId), JSON.stringify(state));
+  } catch {
+    // Quota or private mode — ignore; in-flow state still works for the current mount.
+  }
+}
+
+/**
+ * Removes stored state for an episode (e.g. after finishing the skeleton flow).
+ *
+ * @param episodeId - `episodes.id`.
+ */
+export function clearSymptomPromptSession(episodeId: string): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    sessionStorage.removeItem(storageKey(episodeId));
+  } catch {
+    // ignore
+  }
+}

--- a/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
+++ b/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
@@ -88,11 +88,7 @@ function sanitizeAnswerEntry(value: unknown): SymptomPromptAnswer | null {
 
 /** Rejects keys that must not be assigned when copying untrusted JSON into an object. */
 function isSafeAnswerKey(key: string): boolean {
-  return (
-    key !== '__proto__' &&
-    key !== 'constructor' &&
-    key !== 'prototype'
-  );
+  return key !== '__proto__' && key !== 'constructor' && key !== 'prototype';
 }
 
 function sanitizeAnswers(answers: unknown): SymptomPromptAnswers {

--- a/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
+++ b/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
@@ -7,6 +7,10 @@ import { createInitialSymptomPromptSession } from '@abstrack/types';
 
 const STORAGE_PREFIX = 'abstrack.symptomPrompt.';
 
+/** Matches severity UI (1–5 scale); integers only. */
+const SEVERITY_MIN = 1;
+const SEVERITY_MAX = 5;
+
 function storageKey(episodeId: string): string {
   return `${STORAGE_PREFIX}${episodeId}`;
 }
@@ -50,11 +54,18 @@ function sanitizeAnswerEntry(value: unknown): SymptomPromptAnswer | null {
         return { type: 'yes_no', value: v };
       }
       return null;
-    case 'severity_scale':
-      if (v === null || (typeof v === 'number' && Number.isFinite(v))) {
+    case 'severity_scale': {
+      if (v === null) {
+        return { type: 'severity_scale', value: null };
+      }
+      if (typeof v !== 'number' || !Number.isFinite(v)) {
+        return null;
+      }
+      if (Number.isInteger(v) && v >= SEVERITY_MIN && v <= SEVERITY_MAX) {
         return { type: 'severity_scale', value: v };
       }
-      return null;
+      return { type: 'severity_scale', value: null };
+    }
     case 'free_text':
       if (typeof v === 'string') {
         return { type: 'free_text', value: v };

--- a/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
+++ b/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
@@ -86,6 +86,15 @@ function sanitizeAnswerEntry(value: unknown): SymptomPromptAnswer | null {
   }
 }
 
+/** Rejects keys that must not be assigned when copying untrusted JSON into an object. */
+function isSafeAnswerKey(key: string): boolean {
+  return (
+    key !== '__proto__' &&
+    key !== 'constructor' &&
+    key !== 'prototype'
+  );
+}
+
 function sanitizeAnswers(answers: unknown): SymptomPromptAnswers {
   if (
     typeof answers !== 'object' ||
@@ -94,8 +103,11 @@ function sanitizeAnswers(answers: unknown): SymptomPromptAnswers {
   ) {
     return {};
   }
-  const out: SymptomPromptAnswers = {};
+  const out = Object.create(null) as SymptomPromptAnswers;
   for (const [key, val] of Object.entries(answers)) {
+    if (!isSafeAnswerKey(key)) {
+      continue;
+    }
     const cleaned = sanitizeAnswerEntry(val);
     if (cleaned !== null) {
       out[key] = cleaned;

--- a/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
+++ b/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
@@ -8,6 +8,19 @@ function storageKey(episodeId: string): string {
 }
 
 /**
+ * Produces a safe non-negative step index from stored JSON (rejects NaN, ±Infinity, non-numbers).
+ *
+ * @param value - Parsed `activeIndex` field.
+ * @returns Integer ≥ 0, or `null` if unusable.
+ */
+function sanitizeActiveIndex(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null;
+  }
+  return Math.max(0, Math.floor(value));
+}
+
+/**
  * Reads traversal state from `sessionStorage` for the current browser session.
  *
  * @param episodeId - `episodes.id`.
@@ -28,14 +41,18 @@ export function getSymptomPromptSession(
     if (
       typeof parsed !== 'object' ||
       parsed === null ||
-      typeof parsed.activeIndex !== 'number' ||
       typeof parsed.answers !== 'object' ||
-      parsed.answers === null
+      parsed.answers === null ||
+      Array.isArray(parsed.answers)
     ) {
       return createInitialSymptomPromptSession();
     }
+    const activeIndex = sanitizeActiveIndex(parsed.activeIndex);
+    if (activeIndex === null) {
+      return createInitialSymptomPromptSession();
+    }
     return {
-      activeIndex: parsed.activeIndex,
+      activeIndex,
       answers: parsed.answers,
     };
   } catch {

--- a/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
+++ b/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
@@ -8,7 +8,8 @@ function storageKey(episodeId: string): string {
 }
 
 /**
- * Produces a safe non-negative step index from stored JSON (rejects NaN, ±Infinity, non-numbers).
+ * Produces a safe non-negative step index from stored JSON (rejects non-finite numbers and non-numbers).
+ * Examples include `Infinity` parsed from large exponent literals (e.g. `1e400`) and string values.
  *
  * @param value - Parsed `activeIndex` field.
  * @returns Integer ≥ 0, or `null` if unusable.

--- a/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
+++ b/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
@@ -1,115 +1,14 @@
-import type {
-  SymptomPromptAnswer,
-  SymptomPromptAnswers,
-  SymptomPromptSessionState,
+import type { SymptomPromptSessionState } from '@abstrack/types';
+import {
+  createInitialSymptomPromptSession,
+  sanitizeSymptomPromptActiveIndex,
+  sanitizeSymptomPromptAnswers,
 } from '@abstrack/types';
-import { createInitialSymptomPromptSession } from '@abstrack/types';
 
 const STORAGE_PREFIX = 'abstrack.symptomPrompt.';
 
-/** Matches severity UI (1–5 scale); integers only. */
-const SEVERITY_MIN = 1;
-const SEVERITY_MAX = 5;
-
 function storageKey(episodeId: string): string {
   return `${STORAGE_PREFIX}${episodeId}`;
-}
-
-/**
- * Produces a safe non-negative step index from stored JSON (rejects non-finite numbers and non-numbers).
- * Examples include `Infinity` parsed from large exponent literals (e.g. `1e400`) and string values.
- *
- * @param value - Parsed `activeIndex` field.
- * @returns Integer ≥ 0, or `null` if unusable.
- */
-function sanitizeActiveIndex(value: unknown): number | null {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    return null;
-  }
-  return Math.max(0, Math.floor(value));
-}
-
-/**
- * Keeps only well-shaped {@link SymptomPromptAnswer} values so corrupted `sessionStorage` cannot crash the UI.
- */
-function sanitizeAnswerEntry(value: unknown): SymptomPromptAnswer | null {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    return null;
-  }
-  const o = value as Record<string, unknown>;
-  const t = o.type;
-  if (
-    t !== 'yes_no' &&
-    t !== 'severity_scale' &&
-    t !== 'free_text' &&
-    t !== 'photo' &&
-    t !== 'video'
-  ) {
-    return null;
-  }
-  const v = o.value;
-  switch (t) {
-    case 'yes_no':
-      if (typeof v === 'boolean' || v === null) {
-        return { type: 'yes_no', value: v };
-      }
-      return null;
-    case 'severity_scale': {
-      if (v === null) {
-        return { type: 'severity_scale', value: null };
-      }
-      if (typeof v !== 'number' || !Number.isFinite(v)) {
-        return null;
-      }
-      if (Number.isInteger(v) && v >= SEVERITY_MIN && v <= SEVERITY_MAX) {
-        return { type: 'severity_scale', value: v };
-      }
-      return { type: 'severity_scale', value: null };
-    }
-    case 'free_text':
-      if (typeof v === 'string') {
-        return { type: 'free_text', value: v };
-      }
-      return null;
-    case 'photo':
-      if (v === null) {
-        return { type: 'photo', value: null };
-      }
-      return null;
-    case 'video':
-      if (v === null) {
-        return { type: 'video', value: null };
-      }
-      return null;
-    default:
-      return null;
-  }
-}
-
-/** Rejects keys that must not be assigned when copying untrusted JSON into an object. */
-function isSafeAnswerKey(key: string): boolean {
-  return key !== '__proto__' && key !== 'constructor' && key !== 'prototype';
-}
-
-function sanitizeAnswers(answers: unknown): SymptomPromptAnswers {
-  if (
-    typeof answers !== 'object' ||
-    answers === null ||
-    Array.isArray(answers)
-  ) {
-    return {};
-  }
-  const out = Object.create(null) as SymptomPromptAnswers;
-  for (const [key, val] of Object.entries(answers)) {
-    if (!isSafeAnswerKey(key)) {
-      continue;
-    }
-    const cleaned = sanitizeAnswerEntry(val);
-    if (cleaned !== null) {
-      out[key] = cleaned;
-    }
-  }
-  return out;
 }
 
 /**
@@ -139,13 +38,13 @@ export function getSymptomPromptSession(
     ) {
       return createInitialSymptomPromptSession();
     }
-    const activeIndex = sanitizeActiveIndex(parsed.activeIndex);
+    const activeIndex = sanitizeSymptomPromptActiveIndex(parsed.activeIndex);
     if (activeIndex === null) {
       return createInitialSymptomPromptSession();
     }
     return {
       activeIndex,
-      answers: sanitizeAnswers(parsed.answers),
+      answers: sanitizeSymptomPromptAnswers(parsed.answers),
     };
   } catch {
     return createInitialSymptomPromptSession();

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -88,8 +88,8 @@
 - [x] Database: migrations for (1) `episodes.health_marker_preset_id` (nullable FK to `health_marker_presets`, same-owner pattern as `symptom_preset_id`) and (2) **episode preset templates** table—each template row **requires both** `symptom_preset_id` and `health_marker_preset_id` (NOT NULL; CASCADE if either preset is deleted) + RLS; regenerate `database.types.ts` and clients per [SUPABASE_CLOUD_DEVELOPER.md](SUPABASE_CLOUD_DEVELOPER.md). Template rows must exist **before** the episode-start template picker can list choices ([PRD](PRD.md) §4, [user story](user-stories/episode-and-health-marker-flows.md))
 - [x] **Settings:** UI to create/edit **episode templates** (pair a symptom preset with a health marker preset under one name, e.g. ABS vs CVS)—done when the user is well, so episode start stays one-tap
 - [x] "I'm having an episode" button on home screen
-- [ ] Episode start: user selects **one episode template** per session; insert episode with both `symptom_preset_id` and `health_marker_preset_id` resolved from that template ([user story](user-stories/episode-and-health-marker-flows.md))
-- [ ] Prompt flow skeleton: step through symptoms one at a time, render correct input type per symptom
+- [x] Episode start: user selects **one episode template** per session; insert episode with both `symptom_preset_id` and `health_marker_preset_id` resolved from that template ([user story](user-stories/episode-and-health-marker-flows.md))
+- [x] Prompt flow skeleton: step through symptoms one at a time, render correct input type per symptom
 - [ ] Episode data wired to Supabase: plaintext columns under RLS (no client-side field encryption)
 
 **Why this week:** The first half wraps up auth (config + server-mediated MFA verification). The second half lays episode logging foundation: schema for both preset IDs **and** templates, settings to define templates, then **I'm having an episode** → template picker → prompt skeleton.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/abs-symptom-suggestions.js';
 export * from './lib/episode-template.js';
 export * from './lib/symptom-prompt-session.js';
+export * from './lib/symptom-prompt-session-sanitize.js';
 export * from './lib/types.js';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/abs-symptom-suggestions.js';
 export * from './lib/episode-template.js';
+export * from './lib/symptom-prompt-session.js';
 export * from './lib/types.js';

--- a/packages/types/src/lib/symptom-prompt-session-sanitize.spec.ts
+++ b/packages/types/src/lib/symptom-prompt-session-sanitize.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  sanitizeSymptomPromptActiveIndex,
+  sanitizeSymptomPromptAnswerEntry,
+  sanitizeSymptomPromptAnswers,
+} from './symptom-prompt-session-sanitize.js';
+
+describe('symptom-prompt-session-sanitize', () => {
+  it('sanitizeSymptomPromptActiveIndex floors and rejects non-finite', () => {
+    expect(sanitizeSymptomPromptActiveIndex(2.7)).toBe(2);
+    expect(sanitizeSymptomPromptActiveIndex(NaN)).toBeNull();
+    expect(sanitizeSymptomPromptActiveIndex('1')).toBeNull();
+  });
+
+  it('sanitizeSymptomPromptAnswerEntry keeps severity 1–5 and resets out-of-range to null value', () => {
+    expect(
+      sanitizeSymptomPromptAnswerEntry({ type: 'severity_scale', value: 3 }),
+    ).toEqual({ type: 'severity_scale', value: 3 });
+    expect(
+      sanitizeSymptomPromptAnswerEntry({ type: 'severity_scale', value: 99 }),
+    ).toEqual({ type: 'severity_scale', value: null });
+  });
+
+  it('sanitizeSymptomPromptAnswers skips unsafe keys', () => {
+    const answers = JSON.parse(
+      '{"__proto__":{"type":"yes_no","value":true},"legit":{"type":"yes_no","value":false}}',
+    );
+    expect(sanitizeSymptomPromptAnswers(answers)).toEqual({
+      legit: { type: 'yes_no', value: false },
+    });
+  });
+});

--- a/packages/types/src/lib/symptom-prompt-session-sanitize.ts
+++ b/packages/types/src/lib/symptom-prompt-session-sanitize.ts
@@ -103,7 +103,7 @@ export function sanitizeSymptomPromptAnswers(
     answers === null ||
     Array.isArray(answers)
   ) {
-    return {};
+    return Object.create(null) as SymptomPromptAnswers;
   }
   const out = Object.create(null) as SymptomPromptAnswers;
   for (const [key, val] of Object.entries(answers)) {

--- a/packages/types/src/lib/symptom-prompt-session-sanitize.ts
+++ b/packages/types/src/lib/symptom-prompt-session-sanitize.ts
@@ -1,0 +1,119 @@
+import type {
+  SymptomPromptAnswer,
+  SymptomPromptAnswers,
+} from './symptom-prompt-session.js';
+
+/** Matches severity UI (1–5 scale); integers only. */
+const SEVERITY_MIN = 1;
+const SEVERITY_MAX = 5;
+
+/**
+ * Produces a safe non-negative step index from untrusted JSON (rejects non-finite numbers and non-numbers).
+ *
+ * @param value - Parsed `activeIndex` field.
+ * @returns Integer ≥ 0, or `null` if unusable.
+ */
+export function sanitizeSymptomPromptActiveIndex(
+  value: unknown,
+): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null;
+  }
+  return Math.max(0, Math.floor(value));
+}
+
+/**
+ * Returns a single well-shaped {@link SymptomPromptAnswer} or `null` if the value cannot be represented safely.
+ *
+ * @param value - One entry from a parsed `answers` map.
+ * @returns A valid answer, or `null` to drop the entry.
+ */
+export function sanitizeSymptomPromptAnswerEntry(
+  value: unknown,
+): SymptomPromptAnswer | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const o = value as Record<string, unknown>;
+  const t = o.type;
+  if (
+    t !== 'yes_no' &&
+    t !== 'severity_scale' &&
+    t !== 'free_text' &&
+    t !== 'photo' &&
+    t !== 'video'
+  ) {
+    return null;
+  }
+  const v = o.value;
+  switch (t) {
+    case 'yes_no':
+      if (typeof v === 'boolean' || v === null) {
+        return { type: 'yes_no', value: v };
+      }
+      return null;
+    case 'severity_scale': {
+      if (v === null) {
+        return { type: 'severity_scale', value: null };
+      }
+      if (typeof v !== 'number' || !Number.isFinite(v)) {
+        return null;
+      }
+      if (Number.isInteger(v) && v >= SEVERITY_MIN && v <= SEVERITY_MAX) {
+        return { type: 'severity_scale', value: v };
+      }
+      return { type: 'severity_scale', value: null };
+    }
+    case 'free_text':
+      if (typeof v === 'string') {
+        return { type: 'free_text', value: v };
+      }
+      return null;
+    case 'photo':
+      if (v === null) {
+        return { type: 'photo', value: null };
+      }
+      return null;
+    case 'video':
+      if (v === null) {
+        return { type: 'video', value: null };
+      }
+      return null;
+    default:
+      return null;
+  }
+}
+
+/** Rejects keys that must not be assigned when copying untrusted data into an object. */
+function isSafeSymptomPromptAnswerKey(key: string): boolean {
+  return key !== '__proto__' && key !== 'constructor' && key !== 'prototype';
+}
+
+/**
+ * Builds a safe `answers` map from untrusted JSON (drops bad entries; uses a null-prototype object).
+ *
+ * @param answers - Parsed `answers` object.
+ * @returns Sanitized answers; may be empty.
+ */
+export function sanitizeSymptomPromptAnswers(
+  answers: unknown,
+): SymptomPromptAnswers {
+  if (
+    typeof answers !== 'object' ||
+    answers === null ||
+    Array.isArray(answers)
+  ) {
+    return {};
+  }
+  const out = Object.create(null) as SymptomPromptAnswers;
+  for (const [key, val] of Object.entries(answers)) {
+    if (!isSafeSymptomPromptAnswerKey(key)) {
+      continue;
+    }
+    const cleaned = sanitizeSymptomPromptAnswerEntry(val);
+    if (cleaned !== null) {
+      out[key] = cleaned;
+    }
+  }
+  return out;
+}

--- a/packages/types/src/lib/symptom-prompt-session.spec.ts
+++ b/packages/types/src/lib/symptom-prompt-session.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { createInitialSymptomPromptSession } from './symptom-prompt-session.js';
+
+describe('symptom-prompt-session', () => {
+  it('createInitialSymptomPromptSession starts at first step with no answers', () => {
+    const s = createInitialSymptomPromptSession();
+    expect(s.activeIndex).toBe(0);
+    expect(s.answers).toEqual({});
+  });
+});

--- a/packages/types/src/lib/symptom-prompt-session.ts
+++ b/packages/types/src/lib/symptom-prompt-session.ts
@@ -1,0 +1,36 @@
+import type { Uuid } from './types.js';
+
+/**
+ * One stored answer for a preset symptom line during the Week 5 traversal skeleton.
+ * Values are JSON-serializable for session persistence (web `sessionStorage`).
+ */
+export type SymptomPromptAnswer =
+  | { type: 'yes_no'; value: boolean | null }
+  | { type: 'severity_scale'; value: number | null }
+  | { type: 'free_text'; value: string }
+  | { type: 'photo'; value: null }
+  | { type: 'video'; value: null };
+
+/**
+ * Answers keyed by `preset_symptoms.id`.
+ */
+export type SymptomPromptAnswers = Record<Uuid, SymptomPromptAnswer>;
+
+/**
+ * Progress through the linear symptom list for one episode (in-memory / session scope).
+ */
+export interface SymptomPromptSessionState {
+  /** Index into the ordered preset symptom list (0-based). */
+  activeIndex: number;
+  /** Draft answers for lines the user has visited; keys are `preset_symptoms.id`. */
+  answers: SymptomPromptAnswers;
+}
+
+/**
+ * Default traversal state before any user input.
+ *
+ * @returns Initial {@link SymptomPromptSessionState}.
+ */
+export function createInitialSymptomPromptSession(): SymptomPromptSessionState {
+  return { activeIndex: 0, answers: {} };
+}


### PR DESCRIPTION
Closes #75

## Summary

Adds the Week 5 **symptom traversal skeleton**: a linear stepper over the selected preset’s symptom lines, with response-type-specific UI (yes/no, severity 1–5, free text, photo/video placeholders). Implements **web** and **mobile**; mobile is the primary impaired-use path.

## What changed

- **Episode start** creates an episode row, then **navigates** to the symptom prompt flow (no full post-symptom health-marker flow or full submission—that stays out of scope).
- **Shared types** (`@abstrack/types`): `SymptomPromptSessionState` and related answer shapes for JSON-serializable draft state.
- **Web**: route `/episode/[episodeId]/symptoms?symptomPresetId=…` with `sessionStorage` for progress within the browser session.
- **Mobile**: `SymptomPrompt` stack screen with in-memory session store keyed by `episodeId`.
- **UX**: Single-template episode start avoids flashing the template chooser or misleading “Loading templates…” copy; **PageLoading** supports an optional `message` for consistent “Preparing…” / “Starting your episode…” states.

## How to test

- Create an episode template with at least one symptom line per response type; start an episode from web and mobile.
- Confirm symptoms advance **one at a time**, **Back/Next** (and Finish) behave as expected, and **navigating away and back** (same episode URL) restores step index and drafts on web (`sessionStorage`) and mobile (in-memory store for the app session).