### PR TITLE
feat(episodes): persist symptom prompt answers to episode_symptoms via Supabase

### DIFF
--- a/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
@@ -2,7 +2,11 @@ import * as React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import { CommonActions, DefaultTheme } from '@react-navigation/native';
 import { useNavigation, useRoute } from '@react-navigation/native';
-import { listPresetSymptomsForPreset } from '@abstrack/supabase';
+import {
+  listEpisodeSymptomsForEpisode,
+  listPresetSymptomsForPreset,
+  upsertEpisodeSymptomAnswer,
+} from '@abstrack/supabase';
 import { createInitialSymptomPromptSession } from '@abstrack/types';
 import type { PresetSymptomRow } from '@abstrack/types';
 
@@ -24,10 +28,19 @@ jest.mock('@react-navigation/native', () => ({
 
 jest.mock('@abstrack/supabase', () => ({
   listPresetSymptomsForPreset: jest.fn(),
+  listEpisodeSymptomsForEpisode: jest.fn(),
+  upsertEpisodeSymptomAnswer: jest.fn(),
 }));
 
 jest.mock('../../lib/supabase-wiring', () => ({
-  getMobileSupabaseClient: jest.fn(() => ({ mockClient: true })),
+  getMobileSupabaseClient: jest.fn(() => ({
+    mockClient: true,
+    auth: {
+      getUser: jest.fn(async () => ({
+        data: { user: { id: 'test-user-1' } },
+      })),
+    },
+  })),
 }));
 
 jest.mock('../../lib/episodes/symptom-prompt-session-store', () => ({
@@ -108,6 +121,27 @@ describe('SymptomPromptScreen', () => {
     jest.mocked(listPresetSymptomsForPreset).mockResolvedValue({
       ok: true,
       data: [lineA, lineB],
+    });
+    jest.mocked(listEpisodeSymptomsForEpisode).mockResolvedValue({
+      ok: true,
+      data: [],
+    });
+    jest.mocked(upsertEpisodeSymptomAnswer).mockResolvedValue({
+      ok: true,
+      data: {
+        id: 'es-1',
+        user_id: 'test-user-1',
+        episode_id: episodeId,
+        preset_symptom_id: lineA.id,
+        symptom_name: lineA.symptom_name,
+        response_type: 'yes_no',
+        response_boolean: null,
+        response_severity: null,
+        response_text: null,
+        sort_order: 0,
+        created_at: '2020-01-01T00:00:00Z',
+        updated_at: '2020-01-01T00:00:00Z',
+      },
     });
   });
 

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import { CommonActions, DefaultTheme } from '@react-navigation/native';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import {
@@ -91,6 +91,9 @@ describe('SymptomPromptScreen', () => {
   const lineA = makeLine('line-a', 0, 'Nausea', 'yes_no');
   const lineB = makeLine('line-b', 1, 'Headache', 'severity_scale');
 
+  /** Single free-text line for debounce / flush tests. */
+  const lineFreeOnly = makeLine('line-ft', 0, 'Notes', 'free_text');
+
   beforeEach(() => {
     jest.clearAllMocks();
 
@@ -142,6 +145,123 @@ describe('SymptomPromptScreen', () => {
         created_at: '2020-01-01T00:00:00Z',
         updated_at: '2020-01-01T00:00:00Z',
       },
+    });
+  });
+
+  test('non-free-text answer triggers upsertEpisodeSymptomAnswer', async () => {
+    const screen = render(<SymptomPromptScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 1 of 2')).toBeTruthy();
+    });
+
+    jest.mocked(upsertEpisodeSymptomAnswer).mockClear();
+
+    fireEvent.press(screen.getByText('yes'));
+
+    await waitFor(() => {
+      expect(upsertEpisodeSymptomAnswer).toHaveBeenCalledTimes(1);
+    });
+
+    expect(upsertEpisodeSymptomAnswer).toHaveBeenCalledWith(
+      expect.objectContaining({ mockClient: true }),
+      expect.objectContaining({
+        userId: 'test-user-1',
+        episodeId,
+        line: lineA,
+        answer: { type: 'yes_no', value: true },
+      }),
+    );
+  });
+
+  test('free_text changes debounce to a single upsert', async () => {
+    jest.mocked(listPresetSymptomsForPreset).mockResolvedValue({
+      ok: true,
+      data: [lineFreeOnly],
+    });
+
+    const screen = render(<SymptomPromptScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 1 of 1')).toBeTruthy();
+    });
+
+    jest.mocked(upsertEpisodeSymptomAnswer).mockClear();
+
+    jest.useFakeTimers();
+    try {
+      const input = screen.getByLabelText('Notes notes');
+      fireEvent.changeText(input, 'a');
+      fireEvent.changeText(input, 'ab');
+      expect(upsertEpisodeSymptomAnswer).not.toHaveBeenCalled();
+
+      await act(async () => {
+        jest.advanceTimersByTime(300);
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(upsertEpisodeSymptomAnswer).toHaveBeenCalledTimes(1);
+      });
+
+      expect(upsertEpisodeSymptomAnswer).toHaveBeenCalledWith(
+        expect.objectContaining({ mockClient: true }),
+        expect.objectContaining({
+          userId: 'test-user-1',
+          episodeId,
+          line: lineFreeOnly,
+          answer: { type: 'free_text', value: 'ab' },
+        }),
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('free_text flush on Next runs upsert without waiting for debounce', async () => {
+    const lineAfter = makeLine('line-after', 1, 'Tired', 'yes_no');
+    jest.mocked(listPresetSymptomsForPreset).mockResolvedValue({
+      ok: true,
+      data: [lineFreeOnly, lineAfter],
+    });
+
+    const screen = render(<SymptomPromptScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 1 of 2')).toBeTruthy();
+    });
+
+    jest.mocked(upsertEpisodeSymptomAnswer).mockClear();
+
+    jest.useFakeTimers();
+    try {
+      fireEvent.changeText(screen.getByLabelText('Notes notes'), 'draft');
+      expect(upsertEpisodeSymptomAnswer).not.toHaveBeenCalled();
+
+      fireEvent.press(screen.getByLabelText('Next symptom'));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(upsertEpisodeSymptomAnswer).toHaveBeenCalledTimes(1);
+      });
+
+      expect(upsertEpisodeSymptomAnswer).toHaveBeenCalledWith(
+        expect.objectContaining({ mockClient: true }),
+        expect.objectContaining({
+          answer: { type: 'free_text', value: 'draft' },
+        }),
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 2 of 2')).toBeTruthy();
     });
   });
 

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -423,7 +423,7 @@ export function SymptomPromptScreen() {
             className={`text-sm text-amber-800 dark:text-amber-200`}
             maxFontSizeMultiplier={2}
           >
-            Could not save to the server: {persistError}
+            Could not sync with the server: {persistError}
           </Text>
         ) : null}
 

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -96,6 +96,11 @@ export function SymptomPromptScreen() {
   const userIdRef = useRef<string | null>(null);
   /** Bumps on each `load()` start and on effect cleanup so in-flight loads ignore stale results after unmount, retry, or param change. */
   const loadGenRef = useRef(0);
+  /**
+   * Latest server-persist generation. Incremented per {@link executeServerPersist} attempt and
+   * before flush on episode change / unmount so older in-flight writes cannot update {@link persistError}.
+   */
+  const serverPersistGenerationRef = useRef(0);
 
   /**
    * Caches the auth user id on {@link userIdRef}. Called from {@link load} before `ready`, and
@@ -126,11 +131,20 @@ export function SymptomPromptScreen() {
     activeIndexRef.current = activeIndex;
   }, [activeIndex]);
 
+  /**
+   * Each call bumps {@link serverPersistGenerationRef}; after each `await`, if the captured
+   * generation no longer matches the ref, this attempt is stale and must not update
+   * {@link persistError} (avoids out-of-order failures/successes).
+   */
   const executeServerPersist = useCallback(
     (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
+      const generation = ++serverPersistGenerationRef.current;
       void (async () => {
         const supabase = getMobileSupabaseClient();
         const uid = await resolveSessionUserId(supabase);
+        if (generation !== serverPersistGenerationRef.current) {
+          return;
+        }
         if (!uid) {
           setPersistError(
             'Your session could not be verified. Try signing in again.',
@@ -143,6 +157,9 @@ export function SymptomPromptScreen() {
           line,
           answer,
         });
+        if (generation !== serverPersistGenerationRef.current) {
+          return;
+        }
         if (!r.ok) {
           setPersistError(r.error.message);
         } else {
@@ -204,6 +221,7 @@ export function SymptomPromptScreen() {
 
   useEffect(() => {
     return () => {
+      serverPersistGenerationRef.current += 1;
       flushPendingServerPersist();
     };
   }, [flushPendingServerPersist]);
@@ -296,6 +314,7 @@ export function SymptomPromptScreen() {
   }, [load]);
 
   useLayoutEffect(() => {
+    serverPersistGenerationRef.current += 1;
     flushPendingServerPersist();
     episodeIdRef.current = episodeId;
     const s = getSymptomPromptSession(episodeId);

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -84,12 +84,39 @@ export function SymptomPromptScreen() {
   );
   const answersRef = useRef(answers);
   const activeIndexRef = useRef(activeIndex);
+  const episodeIdRef = useRef(episodeId);
   const serverPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  /** Latest debounced free-text payload for Supabase; read in {@link flushPendingServerPersist}. */
+  const pendingServerFreeTextPersistRef = useRef<{
+    line: PresetSymptomRow;
+    answer: SymptomPromptAnswer;
+  } | null>(null);
   const userIdRef = useRef<string | null>(null);
   /** Bumps on each `load()` start and on effect cleanup so in-flight loads ignore stale results after unmount, retry, or param change. */
   const loadGenRef = useRef(0);
+
+  /**
+   * Caches the auth user id on {@link userIdRef}. Called from {@link load} before `ready`, and
+   * from {@link executeServerPersist} so writes never depend on a separate mount-only `getUser()`.
+   */
+  const resolveSessionUserId = useCallback(
+    async (
+      supabase: ReturnType<typeof getMobileSupabaseClient>,
+    ): Promise<string | null> => {
+      if (userIdRef.current) {
+        return userIdRef.current;
+      }
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      const id = user?.id ?? null;
+      userIdRef.current = id;
+      return id;
+    },
+    [],
+  );
 
   useEffect(() => {
     answersRef.current = answers;
@@ -99,31 +126,87 @@ export function SymptomPromptScreen() {
     activeIndexRef.current = activeIndex;
   }, [activeIndex]);
 
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      const supabase = getMobileSupabaseClient();
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (!cancelled) {
-        userIdRef.current = user?.id ?? null;
+  const executeServerPersist = useCallback(
+    (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
+      void (async () => {
+        const supabase = getMobileSupabaseClient();
+        const uid = await resolveSessionUserId(supabase);
+        if (!uid) {
+          setPersistError(
+            'Your session could not be verified. Try signing in again.',
+          );
+          return;
+        }
+        const r = await upsertEpisodeSymptomAnswer(supabase, {
+          userId: uid,
+          episodeId: episodeIdRef.current,
+          line,
+          answer,
+        });
+        if (!r.ok) {
+          setPersistError(r.error.message);
+        } else {
+          setPersistError(null);
+        }
+      })();
+    },
+    [resolveSessionUserId],
+  );
+
+  /**
+   * Cancels the debounced server timer, then **immediately** persists the latest free-text
+   * `{ line, answer }` from {@link pendingServerFreeTextPersistRef} (if any). Call from
+   * Next/Back, `useLayoutEffect` (episode change), and unmount so the last keystrokes are not lost.
+   */
+  const flushPendingServerPersist = useCallback(() => {
+    if (serverPersistTimerRef.current !== null) {
+      clearTimeout(serverPersistTimerRef.current);
+      serverPersistTimerRef.current = null;
+    }
+    const pending = pendingServerFreeTextPersistRef.current;
+    pendingServerFreeTextPersistRef.current = null;
+    if (!pending) {
+      return;
+    }
+    executeServerPersist(pending.line, pending.answer);
+  }, [executeServerPersist]);
+
+  /**
+   * Schedules or runs a server upsert. User id is **not** read here: {@link executeServerPersist}
+   * always calls {@link resolveSessionUserId} so the first answer after load cannot silently skip.
+   */
+  const schedulePersistToSupabase = useCallback(
+    (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
+      if (answer.type === 'free_text') {
+        pendingServerFreeTextPersistRef.current = { line, answer };
+        if (serverPersistTimerRef.current !== null) {
+          clearTimeout(serverPersistTimerRef.current);
+        }
+        serverPersistTimerRef.current = setTimeout(() => {
+          serverPersistTimerRef.current = null;
+          const pending = pendingServerFreeTextPersistRef.current;
+          pendingServerFreeTextPersistRef.current = null;
+          if (pending) {
+            executeServerPersist(pending.line, pending.answer);
+          }
+        }, SERVER_SYMPTOM_PERSIST_DEBOUNCE_MS);
+      } else {
+        pendingServerFreeTextPersistRef.current = null;
+        if (serverPersistTimerRef.current !== null) {
+          clearTimeout(serverPersistTimerRef.current);
+          serverPersistTimerRef.current = null;
+        }
+        executeServerPersist(line, answer);
       }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+    },
+    [executeServerPersist],
+  );
 
   useEffect(() => {
     return () => {
-      if (serverPersistTimerRef.current === null) {
-        return;
-      }
-      clearTimeout(serverPersistTimerRef.current);
-      serverPersistTimerRef.current = null;
+      flushPendingServerPersist();
     };
-  }, []);
+  }, [flushPendingServerPersist]);
 
   const persist = useCallback(
     (nextIndex: number, nextAnswers: typeof answers) => {
@@ -131,51 +214,6 @@ export function SymptomPromptScreen() {
         activeIndex: nextIndex,
         answers: nextAnswers,
       });
-    },
-    [episodeId],
-  );
-
-  const flushPendingServerPersist = useCallback(() => {
-    if (serverPersistTimerRef.current === null) {
-      return;
-    }
-    clearTimeout(serverPersistTimerRef.current);
-    serverPersistTimerRef.current = null;
-  }, []);
-
-  const schedulePersistToSupabase = useCallback(
-    (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
-      const uid = userIdRef.current;
-      if (!uid) {
-        return;
-      }
-      const run = () => {
-        void (async () => {
-          const supabase = getMobileSupabaseClient();
-          const r = await upsertEpisodeSymptomAnswer(supabase, {
-            userId: uid,
-            episodeId,
-            line,
-            answer,
-          });
-          if (!r.ok) {
-            setPersistError(r.error.message);
-          } else {
-            setPersistError(null);
-          }
-        })();
-      };
-      if (answer.type === 'free_text') {
-        if (serverPersistTimerRef.current !== null) {
-          clearTimeout(serverPersistTimerRef.current);
-        }
-        serverPersistTimerRef.current = setTimeout(() => {
-          serverPersistTimerRef.current = null;
-          run();
-        }, SERVER_SYMPTOM_PERSIST_DEBOUNCE_MS);
-      } else {
-        run();
-      }
     },
     [episodeId],
   );
@@ -190,6 +228,17 @@ export function SymptomPromptScreen() {
     setPhase('prompting');
     try {
       const supabase = getMobileSupabaseClient();
+      const uid = await resolveSessionUserId(supabase);
+      if (stale()) {
+        return;
+      }
+      if (!uid) {
+        setErrorMessage(
+          'You must be signed in to save symptom answers. Try signing in again.',
+        );
+        setStatus('error');
+        return;
+      }
       const result = await listPresetSymptomsForPreset(
         supabase,
         symptomPresetId,
@@ -237,7 +286,7 @@ export function SymptomPromptScreen() {
       setErrorMessage(message);
       setStatus('error');
     }
-  }, [episodeId, symptomPresetId]);
+  }, [episodeId, symptomPresetId, resolveSessionUserId]);
 
   useEffect(() => {
     void load();
@@ -247,10 +296,8 @@ export function SymptomPromptScreen() {
   }, [load]);
 
   useLayoutEffect(() => {
-    if (serverPersistTimerRef.current !== null) {
-      clearTimeout(serverPersistTimerRef.current);
-      serverPersistTimerRef.current = null;
-    }
+    flushPendingServerPersist();
+    episodeIdRef.current = episodeId;
     const s = getSymptomPromptSession(episodeId);
     activeIndexRef.current = s.activeIndex;
     setActiveIndex(s.activeIndex);
@@ -261,7 +308,7 @@ export function SymptomPromptScreen() {
     setErrorMessage(null);
     setPersistError(null);
     setLines([]);
-  }, [episodeId, symptomPresetId]);
+  }, [episodeId, symptomPresetId, flushPendingServerPersist]);
 
   const currentLine = lines[activeIndex] ?? null;
   const stepLabel =

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -289,7 +289,8 @@ export function SymptomPromptScreen() {
         ? episodeSymptomRowsToAnswersMap(fromServer.data)
         : {};
       const session = getSymptomPromptSession(episodeId);
-      const mergedAnswers = { ...session.answers, ...serverAnswers };
+      // Session overlays server so local drafts survive hydrate (debounced/offline/failed sync).
+      const mergedAnswers = { ...serverAnswers, ...session.answers };
       const idx = clampIndex(session.activeIndex, result.data.length);
       activeIndexRef.current = idx;
       setActiveIndex(idx);

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -99,6 +99,8 @@ export function SymptomPromptScreen() {
   /**
    * Latest server-persist generation. Incremented per {@link executeServerPersist} attempt and
    * before flush on episode change / unmount so older in-flight writes cannot update {@link persistError}.
+   * Each attempt also captures the episode id at call time so a flushed write after navigation cannot
+   * surface errors for the wrong episode ({@link executeServerPersist}).
    */
   const serverPersistGenerationRef = useRef(0);
 
@@ -132,12 +134,13 @@ export function SymptomPromptScreen() {
   }, [activeIndex]);
 
   /**
-   * Each call bumps {@link serverPersistGenerationRef}; after each `await`, if the captured
-   * generation no longer matches the ref, this attempt is stale and must not update
-   * {@link persistError} (avoids out-of-order failures/successes).
+   * Each call bumps {@link serverPersistGenerationRef} and captures the current episode id so flushes
+   * during navigation still write to the correct episode and do not update {@link persistError} for
+   * the wrong screen after the route has advanced.
    */
   const executeServerPersist = useCallback(
     (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
+      const targetEpisodeId = episodeIdRef.current;
       const generation = ++serverPersistGenerationRef.current;
       void (async () => {
         const supabase = getMobileSupabaseClient();
@@ -146,18 +149,23 @@ export function SymptomPromptScreen() {
           return;
         }
         if (!uid) {
-          setPersistError(
-            'Your session could not be verified. Try signing in again.',
-          );
+          if (episodeIdRef.current === targetEpisodeId) {
+            setPersistError(
+              'Your session could not be verified. Try signing in again.',
+            );
+          }
           return;
         }
         const r = await upsertEpisodeSymptomAnswer(supabase, {
           userId: uid,
-          episodeId: episodeIdRef.current,
+          episodeId: targetEpisodeId,
           line,
           answer,
         });
         if (generation !== serverPersistGenerationRef.current) {
+          return;
+        }
+        if (episodeIdRef.current !== targetEpisodeId) {
           return;
         }
         if (!r.ok) {

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -18,7 +18,12 @@ import type {
   SymptomPromptAnswer,
   SymptomPromptAnswers,
 } from '@abstrack/types';
-import { listPresetSymptomsForPreset } from '@abstrack/supabase';
+import { episodeSymptomRowsToAnswersMap } from '@abstrack/types';
+import {
+  listEpisodeSymptomsForEpisode,
+  listPresetSymptomsForPreset,
+  upsertEpisodeSymptomAnswer,
+} from '@abstrack/supabase';
 import { announce } from '@abstrack/ui/native';
 import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
@@ -50,6 +55,9 @@ function clampIndex(index: number, length: number): number {
   return Math.max(0, Math.min(i, length - 1));
 }
 
+/** Debounce Supabase writes for free-text answers (matches web episode flow). */
+const SERVER_SYMPTOM_PERSIST_DEBOUNCE_MS = 300;
+
 /**
  * Linear symptom stepper for the active episode’s selected preset (Week 5 skeleton).
  *
@@ -64,6 +72,7 @@ export function SymptomPromptScreen() {
     'loading',
   );
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [persistError, setPersistError] = useState<string | null>(null);
   const [lines, setLines] = useState<PresetSymptomRow[]>([]);
   const [phase, setPhase] = useState<'prompting' | 'complete'>('prompting');
 
@@ -75,6 +84,10 @@ export function SymptomPromptScreen() {
   );
   const answersRef = useRef(answers);
   const activeIndexRef = useRef(activeIndex);
+  const serverPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const userIdRef = useRef<string | null>(null);
   /** Bumps on each `load()` start and on effect cleanup so in-flight loads ignore stale results after unmount, retry, or param change. */
   const loadGenRef = useRef(0);
 
@@ -86,6 +99,32 @@ export function SymptomPromptScreen() {
     activeIndexRef.current = activeIndex;
   }, [activeIndex]);
 
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const supabase = getMobileSupabaseClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!cancelled) {
+        userIdRef.current = user?.id ?? null;
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (serverPersistTimerRef.current === null) {
+        return;
+      }
+      clearTimeout(serverPersistTimerRef.current);
+      serverPersistTimerRef.current = null;
+    };
+  }, []);
+
   const persist = useCallback(
     (nextIndex: number, nextAnswers: typeof answers) => {
       setSymptomPromptSession(episodeId, {
@@ -96,12 +135,58 @@ export function SymptomPromptScreen() {
     [episodeId],
   );
 
+  const flushPendingServerPersist = useCallback(() => {
+    if (serverPersistTimerRef.current === null) {
+      return;
+    }
+    clearTimeout(serverPersistTimerRef.current);
+    serverPersistTimerRef.current = null;
+  }, []);
+
+  const schedulePersistToSupabase = useCallback(
+    (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
+      const uid = userIdRef.current;
+      if (!uid) {
+        return;
+      }
+      const run = () => {
+        void (async () => {
+          const supabase = getMobileSupabaseClient();
+          const r = await upsertEpisodeSymptomAnswer(supabase, {
+            userId: uid,
+            episodeId,
+            line,
+            answer,
+          });
+          if (!r.ok) {
+            setPersistError(r.error.message);
+          } else {
+            setPersistError(null);
+          }
+        })();
+      };
+      if (answer.type === 'free_text') {
+        if (serverPersistTimerRef.current !== null) {
+          clearTimeout(serverPersistTimerRef.current);
+        }
+        serverPersistTimerRef.current = setTimeout(() => {
+          serverPersistTimerRef.current = null;
+          run();
+        }, SERVER_SYMPTOM_PERSIST_DEBOUNCE_MS);
+      } else {
+        run();
+      }
+    },
+    [episodeId],
+  );
+
   const load = useCallback(async () => {
     const myGen = ++loadGenRef.current;
     const stale = () => myGen !== loadGenRef.current;
 
     setStatus('loading');
     setErrorMessage(null);
+    setPersistError(null);
     setPhase('prompting');
     try {
       const supabase = getMobileSupabaseClient();
@@ -118,16 +203,30 @@ export function SymptomPromptScreen() {
         return;
       }
       setLines(result.data);
+      const fromServer = await listEpisodeSymptomsForEpisode(
+        supabase,
+        episodeId,
+      );
+      if (stale()) {
+        return;
+      }
+      const serverAnswers = fromServer.ok
+        ? episodeSymptomRowsToAnswersMap(fromServer.data)
+        : {};
       const session = getSymptomPromptSession(episodeId);
+      const mergedAnswers = { ...session.answers, ...serverAnswers };
       const idx = clampIndex(session.activeIndex, result.data.length);
       activeIndexRef.current = idx;
       setActiveIndex(idx);
-      setAnswers(session.answers);
-      answersRef.current = session.answers;
+      setAnswers(mergedAnswers);
+      answersRef.current = mergedAnswers;
       setSymptomPromptSession(episodeId, {
         activeIndex: idx,
-        answers: session.answers,
+        answers: mergedAnswers,
       });
+      if (!fromServer.ok) {
+        setPersistError(fromServer.error.message);
+      }
       setStatus('ready');
     } catch (caught: unknown) {
       if (stale()) {
@@ -148,6 +247,10 @@ export function SymptomPromptScreen() {
   }, [load]);
 
   useLayoutEffect(() => {
+    if (serverPersistTimerRef.current !== null) {
+      clearTimeout(serverPersistTimerRef.current);
+      serverPersistTimerRef.current = null;
+    }
     const s = getSymptomPromptSession(episodeId);
     activeIndexRef.current = s.activeIndex;
     setActiveIndex(s.activeIndex);
@@ -156,6 +259,7 @@ export function SymptomPromptScreen() {
     setPhase('prompting');
     setStatus('loading');
     setErrorMessage(null);
+    setPersistError(null);
     setLines([]);
   }, [episodeId, symptomPresetId]);
 
@@ -183,9 +287,11 @@ export function SymptomPromptScreen() {
     answersRef.current = merged;
     setAnswers(merged);
     persist(activeIndexRef.current, merged);
+    schedulePersistToSupabase(currentLine, next);
   };
 
   const goBackStep = () => {
+    flushPendingServerPersist();
     const idx = activeIndexRef.current;
     if (idx > 0) {
       const next = idx - 1;
@@ -199,6 +305,7 @@ export function SymptomPromptScreen() {
   };
 
   const goNext = () => {
+    flushPendingServerPersist();
     if (lines.length === 0) {
       setPhase('complete');
       return;
@@ -235,6 +342,15 @@ export function SymptomPromptScreen() {
         >
           Episode symptoms
         </Text>
+        {persistError ? (
+          <Text
+            accessibilityLiveRegion="polite"
+            className={`text-sm text-amber-800 dark:text-amber-200`}
+            maxFontSizeMultiplier={2}
+          >
+            Could not save to the server: {persistError}
+          </Text>
+        ) : null}
 
         {phase === 'complete' ? (
           <View className="gap-4" accessibilityLiveRegion="polite">

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -531,7 +531,7 @@ export function SymptomPromptFlow({
             className="mt-2 text-sm text-amber-800 dark:text-amber-200"
             role="status"
           >
-            Could not save to the server: {persistError}
+            Could not sync with the server: {persistError}
           </p>
         ) : null}
       </div>

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -100,6 +100,11 @@ export function SymptomPromptFlow({
   const userIdRef = useRef<string | null>(null);
   /** Bumps on each `load()` start and on effect cleanup so in-flight loads ignore stale results after unmount, retry, or param change. */
   const loadGenRef = useRef(0);
+  /**
+   * Monotonic id for `executeServerPersist` attempts; bumped on each new persist and on episode
+   * change so out-of-order async completions do not clobber {@link persistError}.
+   */
+  const serverPersistGenerationRef = useRef(0);
 
   /**
    * Resolves the signed-in user id for RLS writes, caching on {@link userIdRef}.
@@ -132,9 +137,13 @@ export function SymptomPromptFlow({
 
   const executeServerPersist = useCallback(
     (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
+      const generation = ++serverPersistGenerationRef.current;
       void (async () => {
         const supabase = createBrowserClient();
         const uid = await resolveSessionUserId(supabase);
+        if (generation !== serverPersistGenerationRef.current) {
+          return;
+        }
         if (!uid) {
           setPersistError(
             'Your session could not be verified. Try signing in again.',
@@ -147,6 +156,9 @@ export function SymptomPromptFlow({
           line,
           answer,
         });
+        if (generation !== serverPersistGenerationRef.current) {
+          return;
+        }
         if (!r.ok) {
           setPersistError(r.error.message);
         } else {
@@ -211,6 +223,7 @@ export function SymptomPromptFlow({
         answers: answersRef.current,
       });
     }
+    serverPersistGenerationRef.current += 1;
     flushPendingServerPersist();
     episodeIdRef.current = episodeId;
     const s = getSymptomPromptSession(episodeId);
@@ -253,6 +266,7 @@ export function SymptomPromptFlow({
 
   useEffect(() => {
     return () => {
+      serverPersistGenerationRef.current += 1;
       flushPendingServerPersist();
     };
   }, [flushPendingServerPersist]);

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -14,8 +14,15 @@ import type {
   SymptomPromptAnswer,
   SymptomPromptAnswers,
 } from '@abstrack/types';
-import { createInitialSymptomPromptSession } from '@abstrack/types';
-import { listPresetSymptomsForPreset } from '@abstrack/supabase';
+import {
+  createInitialSymptomPromptSession,
+  episodeSymptomRowsToAnswersMap,
+} from '@abstrack/types';
+import {
+  listEpisodeSymptomsForEpisode,
+  listPresetSymptomsForPreset,
+  upsertEpisodeSymptomAnswer,
+} from '@abstrack/supabase';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import {
@@ -34,6 +41,9 @@ export type SymptomPromptFlowProps = {
 
 /** Delay before writing free-text drafts to `sessionStorage` (keystrokes stay snappy in React state). */
 const FREE_TEXT_PERSIST_DEBOUNCE_MS = 300;
+
+/** Same debounce for Supabase `episode_symptoms` writes (plaintext columns under RLS). */
+const SERVER_SYMPTOM_PERSIST_DEBOUNCE_MS = 300;
 
 function clampIndex(index: number, length: number): number {
   if (length <= 0) {
@@ -64,6 +74,7 @@ export function SymptomPromptFlow({
     'loading',
   );
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [persistError, setPersistError] = useState<string | null>(null);
   const [lines, setLines] = useState<PresetSymptomRow[]>([]);
   const [phase, setPhase] = useState<'prompting' | 'complete'>('prompting');
 
@@ -78,8 +89,28 @@ export function SymptomPromptFlow({
   const textPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  const serverPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const userIdRef = useRef<string | null>(null);
   /** Bumps on each `load()` start and on effect cleanup so in-flight loads ignore stale results after unmount, retry, or param change. */
   const loadGenRef = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const supabase = createBrowserClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!cancelled) {
+        userIdRef.current = user?.id ?? null;
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     activeIndexRef.current = activeIndex;
@@ -98,6 +129,10 @@ export function SymptomPromptFlow({
         activeIndex: activeIndexRef.current,
         answers: answersRef.current,
       });
+    }
+    if (serverPersistTimerRef.current !== null) {
+      clearTimeout(serverPersistTimerRef.current);
+      serverPersistTimerRef.current = null;
     }
     episodeIdRef.current = episodeId;
     const s = getSymptomPromptSession(episodeId);
@@ -138,6 +173,16 @@ export function SymptomPromptFlow({
     };
   }, []);
 
+  useEffect(() => {
+    return () => {
+      if (serverPersistTimerRef.current === null) {
+        return;
+      }
+      clearTimeout(serverPersistTimerRef.current);
+      serverPersistTimerRef.current = null;
+    };
+  }, []);
+
   const persistImmediate = useCallback(
     (nextIndex: number, nextAnswers: typeof answers) => {
       setSymptomPromptSession(episodeIdRef.current, {
@@ -148,12 +193,58 @@ export function SymptomPromptFlow({
     [],
   );
 
+  const flushPendingServerPersist = useCallback(() => {
+    if (serverPersistTimerRef.current === null) {
+      return;
+    }
+    clearTimeout(serverPersistTimerRef.current);
+    serverPersistTimerRef.current = null;
+  }, []);
+
+  const schedulePersistToSupabase = useCallback(
+    (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
+      const uid = userIdRef.current;
+      if (!uid) {
+        return;
+      }
+      const run = () => {
+        void (async () => {
+          const supabase = createBrowserClient();
+          const r = await upsertEpisodeSymptomAnswer(supabase, {
+            userId: uid,
+            episodeId: episodeIdRef.current,
+            line,
+            answer,
+          });
+          if (!r.ok) {
+            setPersistError(r.error.message);
+          } else {
+            setPersistError(null);
+          }
+        })();
+      };
+      if (answer.type === 'free_text') {
+        if (serverPersistTimerRef.current !== null) {
+          clearTimeout(serverPersistTimerRef.current);
+        }
+        serverPersistTimerRef.current = setTimeout(() => {
+          serverPersistTimerRef.current = null;
+          run();
+        }, SERVER_SYMPTOM_PERSIST_DEBOUNCE_MS);
+      } else {
+        run();
+      }
+    },
+    [],
+  );
+
   const load = useCallback(async () => {
     const myGen = ++loadGenRef.current;
     const stale = () => myGen !== loadGenRef.current;
 
     setStatus('loading');
     setErrorMessage(null);
+    setPersistError(null);
     setPhase('prompting');
     const supabase = createBrowserClient();
     const result = await listPresetSymptomsForPreset(supabase, symptomPresetId);
@@ -166,16 +257,27 @@ export function SymptomPromptFlow({
       return;
     }
     setLines(result.data);
+    const fromServer = await listEpisodeSymptomsForEpisode(supabase, episodeId);
+    if (stale()) {
+      return;
+    }
+    const serverAnswers = fromServer.ok
+      ? episodeSymptomRowsToAnswersMap(fromServer.data)
+      : {};
     const session = getSymptomPromptSession(episodeId);
+    const mergedAnswers = { ...session.answers, ...serverAnswers };
     const idx = clampIndex(session.activeIndex, result.data.length);
     setActiveIndex(idx);
-    setAnswers(session.answers);
-    answersRef.current = session.answers;
+    setAnswers(mergedAnswers);
+    answersRef.current = mergedAnswers;
     activeIndexRef.current = idx;
     setSymptomPromptSession(episodeId, {
       activeIndex: idx,
-      answers: session.answers,
+      answers: mergedAnswers,
     });
+    if (!fromServer.ok) {
+      setPersistError(fromServer.error.message);
+    }
     setStatus('ready');
   }, [episodeId, symptomPresetId]);
 
@@ -219,6 +321,7 @@ export function SymptomPromptFlow({
     };
     answersRef.current = merged;
     setAnswers(merged);
+    schedulePersistToSupabase(currentLine, next);
 
     if (next.type === 'free_text') {
       if (textPersistTimerRef.current !== null) {
@@ -245,6 +348,7 @@ export function SymptomPromptFlow({
 
   const goBackStep = () => {
     flushPendingTextPersist();
+    flushPendingServerPersist();
     const idx = activeIndexRef.current;
     if (idx > 0) {
       const next = idx - 1;
@@ -261,6 +365,7 @@ export function SymptomPromptFlow({
 
   const goNext = () => {
     flushPendingTextPersist();
+    flushPendingServerPersist();
     if (lines.length === 0) {
       setPhase('complete');
       return;
@@ -358,6 +463,14 @@ export function SymptomPromptFlow({
         <h1 className="mt-4 text-2xl font-bold tracking-tight text-app-ink">
           Episode symptoms
         </h1>
+        {persistError ? (
+          <p
+            className="mt-2 text-sm text-amber-800 dark:text-amber-200"
+            role="status"
+          >
+            Could not save to the server: {persistError}
+          </p>
+        ) : null}
       </div>
 
       <p className="text-base font-medium text-app-muted">{stepLabel}</p>

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -92,25 +92,35 @@ export function SymptomPromptFlow({
   const serverPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  /** Latest debounced free-text payload; cleared when the write runs or is flushed. */
+  const pendingServerFreeTextPersistRef = useRef<{
+    line: PresetSymptomRow;
+    answer: SymptomPromptAnswer;
+  } | null>(null);
   const userIdRef = useRef<string | null>(null);
   /** Bumps on each `load()` start and on effect cleanup so in-flight loads ignore stale results after unmount, retry, or param change. */
   const loadGenRef = useRef(0);
 
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      const supabase = createBrowserClient();
+  /**
+   * Resolves the signed-in user id for RLS writes, caching on {@link userIdRef}.
+   * Used by `load()` (before inputs enable) and as a fallback in {@link executeServerPersist}.
+   */
+  const resolveSessionUserId = useCallback(
+    async (
+      supabase: ReturnType<typeof createBrowserClient>,
+    ): Promise<string | null> => {
+      if (userIdRef.current) {
+        return userIdRef.current;
+      }
       const {
         data: { user },
       } = await supabase.auth.getUser();
-      if (!cancelled) {
-        userIdRef.current = user?.id ?? null;
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+      const id = user?.id ?? null;
+      userIdRef.current = id;
+      return id;
+    },
+    [],
+  );
 
   useEffect(() => {
     activeIndexRef.current = activeIndex;
@@ -119,6 +129,77 @@ export function SymptomPromptFlow({
   useEffect(() => {
     answersRef.current = answers;
   }, [answers]);
+
+  const executeServerPersist = useCallback(
+    (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
+      void (async () => {
+        const supabase = createBrowserClient();
+        const uid = await resolveSessionUserId(supabase);
+        if (!uid) {
+          setPersistError(
+            'Your session could not be verified. Try signing in again.',
+          );
+          return;
+        }
+        const r = await upsertEpisodeSymptomAnswer(supabase, {
+          userId: uid,
+          episodeId: episodeIdRef.current,
+          line,
+          answer,
+        });
+        if (!r.ok) {
+          setPersistError(r.error.message);
+        } else {
+          setPersistError(null);
+        }
+      })();
+    },
+    [resolveSessionUserId],
+  );
+
+  /**
+   * Clears the debounced server timer and immediately persists the latest free-text
+   * payload (if any). Call before navigation / unmount so the last keystrokes are not lost.
+   */
+  const flushPendingServerPersist = useCallback(() => {
+    if (serverPersistTimerRef.current !== null) {
+      clearTimeout(serverPersistTimerRef.current);
+      serverPersistTimerRef.current = null;
+    }
+    const pending = pendingServerFreeTextPersistRef.current;
+    pendingServerFreeTextPersistRef.current = null;
+    if (!pending) {
+      return;
+    }
+    executeServerPersist(pending.line, pending.answer);
+  }, [executeServerPersist]);
+
+  const schedulePersistToSupabase = useCallback(
+    (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
+      if (answer.type === 'free_text') {
+        pendingServerFreeTextPersistRef.current = { line, answer };
+        if (serverPersistTimerRef.current !== null) {
+          clearTimeout(serverPersistTimerRef.current);
+        }
+        serverPersistTimerRef.current = setTimeout(() => {
+          serverPersistTimerRef.current = null;
+          const pending = pendingServerFreeTextPersistRef.current;
+          pendingServerFreeTextPersistRef.current = null;
+          if (pending) {
+            executeServerPersist(pending.line, pending.answer);
+          }
+        }, SERVER_SYMPTOM_PERSIST_DEBOUNCE_MS);
+      } else {
+        pendingServerFreeTextPersistRef.current = null;
+        if (serverPersistTimerRef.current !== null) {
+          clearTimeout(serverPersistTimerRef.current);
+          serverPersistTimerRef.current = null;
+        }
+        executeServerPersist(line, answer);
+      }
+    },
+    [executeServerPersist],
+  );
 
   useLayoutEffect(() => {
     const outgoingEpisodeId = episodeIdRef.current;
@@ -130,10 +211,7 @@ export function SymptomPromptFlow({
         answers: answersRef.current,
       });
     }
-    if (serverPersistTimerRef.current !== null) {
-      clearTimeout(serverPersistTimerRef.current);
-      serverPersistTimerRef.current = null;
-    }
+    flushPendingServerPersist();
     episodeIdRef.current = episodeId;
     const s = getSymptomPromptSession(episodeId);
     setActiveIndex(s.activeIndex);
@@ -145,7 +223,7 @@ export function SymptomPromptFlow({
     setErrorMessage(null);
     setLines([]);
     setHydrated(true);
-  }, [episodeId, symptomPresetId]);
+  }, [episodeId, symptomPresetId, flushPendingServerPersist]);
 
   const flushPendingTextPersist = useCallback(() => {
     if (textPersistTimerRef.current === null) {
@@ -175,13 +253,9 @@ export function SymptomPromptFlow({
 
   useEffect(() => {
     return () => {
-      if (serverPersistTimerRef.current === null) {
-        return;
-      }
-      clearTimeout(serverPersistTimerRef.current);
-      serverPersistTimerRef.current = null;
+      flushPendingServerPersist();
     };
-  }, []);
+  }, [flushPendingServerPersist]);
 
   const persistImmediate = useCallback(
     (nextIndex: number, nextAnswers: typeof answers) => {
@@ -189,51 +263,6 @@ export function SymptomPromptFlow({
         activeIndex: nextIndex,
         answers: nextAnswers,
       });
-    },
-    [],
-  );
-
-  const flushPendingServerPersist = useCallback(() => {
-    if (serverPersistTimerRef.current === null) {
-      return;
-    }
-    clearTimeout(serverPersistTimerRef.current);
-    serverPersistTimerRef.current = null;
-  }, []);
-
-  const schedulePersistToSupabase = useCallback(
-    (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
-      const uid = userIdRef.current;
-      if (!uid) {
-        return;
-      }
-      const run = () => {
-        void (async () => {
-          const supabase = createBrowserClient();
-          const r = await upsertEpisodeSymptomAnswer(supabase, {
-            userId: uid,
-            episodeId: episodeIdRef.current,
-            line,
-            answer,
-          });
-          if (!r.ok) {
-            setPersistError(r.error.message);
-          } else {
-            setPersistError(null);
-          }
-        })();
-      };
-      if (answer.type === 'free_text') {
-        if (serverPersistTimerRef.current !== null) {
-          clearTimeout(serverPersistTimerRef.current);
-        }
-        serverPersistTimerRef.current = setTimeout(() => {
-          serverPersistTimerRef.current = null;
-          run();
-        }, SERVER_SYMPTOM_PERSIST_DEBOUNCE_MS);
-      } else {
-        run();
-      }
     },
     [],
   );
@@ -247,6 +276,17 @@ export function SymptomPromptFlow({
     setPersistError(null);
     setPhase('prompting');
     const supabase = createBrowserClient();
+    const uid = await resolveSessionUserId(supabase);
+    if (stale()) {
+      return;
+    }
+    if (!uid) {
+      setErrorMessage(
+        'You must be signed in to save symptom answers. Try signing in again.',
+      );
+      setStatus('error');
+      return;
+    }
     const result = await listPresetSymptomsForPreset(supabase, symptomPresetId);
     if (stale()) {
       return;
@@ -279,7 +319,7 @@ export function SymptomPromptFlow({
       setPersistError(fromServer.error.message);
     }
     setStatus('ready');
-  }, [episodeId, symptomPresetId]);
+  }, [episodeId, symptomPresetId, resolveSessionUserId]);
 
   useEffect(() => {
     void load();

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -102,7 +102,8 @@ export function SymptomPromptFlow({
   const loadGenRef = useRef(0);
   /**
    * Monotonic id for `executeServerPersist` attempts; bumped on each new persist and on episode
-   * change so out-of-order async completions do not clobber {@link persistError}.
+   * change so out-of-order async completions do not clobber {@link persistError}. Episode id is
+   * captured per attempt so flushes during navigation cannot attach errors to the wrong episode.
    */
   const serverPersistGenerationRef = useRef(0);
 
@@ -137,6 +138,7 @@ export function SymptomPromptFlow({
 
   const executeServerPersist = useCallback(
     (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
+      const targetEpisodeId = episodeIdRef.current;
       const generation = ++serverPersistGenerationRef.current;
       void (async () => {
         const supabase = createBrowserClient();
@@ -145,18 +147,23 @@ export function SymptomPromptFlow({
           return;
         }
         if (!uid) {
-          setPersistError(
-            'Your session could not be verified. Try signing in again.',
-          );
+          if (episodeIdRef.current === targetEpisodeId) {
+            setPersistError(
+              'Your session could not be verified. Try signing in again.',
+            );
+          }
           return;
         }
         const r = await upsertEpisodeSymptomAnswer(supabase, {
           userId: uid,
-          episodeId: episodeIdRef.current,
+          episodeId: targetEpisodeId,
           line,
           answer,
         });
         if (generation !== serverPersistGenerationRef.current) {
+          return;
+        }
+        if (episodeIdRef.current !== targetEpisodeId) {
           return;
         }
         if (!r.ok) {

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -107,6 +108,8 @@ export function SymptomPromptFlow({
    */
   const serverPersistGenerationRef = useRef(0);
 
+  const supabase = useMemo(() => createBrowserClient(), []);
+
   /**
    * Resolves the signed-in user id for RLS writes, caching on {@link userIdRef}.
    * Used by `load()` (before inputs enable) and as a fallback in {@link executeServerPersist}.
@@ -141,7 +144,6 @@ export function SymptomPromptFlow({
       const targetEpisodeId = episodeIdRef.current;
       const generation = ++serverPersistGenerationRef.current;
       void (async () => {
-        const supabase = createBrowserClient();
         const uid = await resolveSessionUserId(supabase);
         if (generation !== serverPersistGenerationRef.current) {
           return;
@@ -173,7 +175,7 @@ export function SymptomPromptFlow({
         }
       })();
     },
-    [resolveSessionUserId],
+    [resolveSessionUserId, supabase],
   );
 
   /**
@@ -296,7 +298,6 @@ export function SymptomPromptFlow({
     setErrorMessage(null);
     setPersistError(null);
     setPhase('prompting');
-    const supabase = createBrowserClient();
     const uid = await resolveSessionUserId(supabase);
     if (stale()) {
       return;
@@ -326,7 +327,8 @@ export function SymptomPromptFlow({
       ? episodeSymptomRowsToAnswersMap(fromServer.data)
       : {};
     const session = getSymptomPromptSession(episodeId);
-    const mergedAnswers = { ...session.answers, ...serverAnswers };
+    // Session overlays server so local drafts survive hydrate (debounced/offline/failed sync).
+    const mergedAnswers = { ...serverAnswers, ...session.answers };
     const idx = clampIndex(session.activeIndex, result.data.length);
     setActiveIndex(idx);
     setAnswers(mergedAnswers);
@@ -340,7 +342,7 @@ export function SymptomPromptFlow({
       setPersistError(fromServer.error.message);
     }
     setStatus('ready');
-  }, [episodeId, symptomPresetId, resolveSessionUserId]);
+  }, [episodeId, symptomPresetId, resolveSessionUserId, supabase]);
 
   useEffect(() => {
     void load();

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -72,7 +72,7 @@
 
 ---
 
-## Week 5: April 13-19 -- Auth Completion and Episode Logging Foundation
+## Week 5: April 13-19 -- Auth Completion and Episode Logging Foundation (COMPLETE)
 
 **Goal:** Round out authentication for all roles and lay the groundwork for the core episode logging feature.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -90,7 +90,7 @@
 - [x] "I'm having an episode" button on home screen
 - [x] Episode start: user selects **one episode template** per session; insert episode with both `symptom_preset_id` and `health_marker_preset_id` resolved from that template ([user story](user-stories/episode-and-health-marker-flows.md))
 - [x] Prompt flow skeleton: step through symptoms one at a time, render correct input type per symptom
-- [ ] Episode data wired to Supabase: plaintext columns under RLS (no client-side field encryption)
+- [x] Episode data wired to Supabase: plaintext columns under RLS (no client-side field encryption)
 
 **Why this week:** The first half wraps up auth (config + server-mediated MFA verification). The second half lays episode logging foundation: schema for both preset IDs **and** templates, settings to define templates, then **I'm having an episode** → template picker → prompt skeleton.
 

--- a/packages/supabase/src/episode-foundation.integration.spec.ts
+++ b/packages/supabase/src/episode-foundation.integration.spec.ts
@@ -1,6 +1,7 @@
 /**
  * Episode row + `episode_symptoms` persistence against **Supabase Cloud** with RLS (patient session).
  * Skips without `SUPABASE_SECRET_KEY` and public URL/key — see **docs/SUPABASE_CLOUD_DEVELOPER.md**.
+ * Disposable user emails/ids are logged only when `ABSTRACK_PRESET_INTEGRATION_LOG=1` (avoids PII in CI).
  */
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { PresetSymptomRow } from '@abstrack/types';
@@ -132,12 +133,14 @@ describe.skipIf(!episodeFoundationReady)(
         throw signB.error;
       }
 
-      console.info('[episode-foundation.integration] Disposable users', {
-        emailA,
-        emailB,
-        userAId,
-        userBId,
-      });
+      if (process.env.ABSTRACK_PRESET_INTEGRATION_LOG === '1') {
+        console.info('[episode-foundation.integration] Disposable users', {
+          emailA,
+          emailB,
+          userAId,
+          userBId,
+        });
+      }
     }, 120_000);
 
     afterAll(async () => {

--- a/packages/supabase/src/episode-foundation.integration.spec.ts
+++ b/packages/supabase/src/episode-foundation.integration.spec.ts
@@ -1,0 +1,355 @@
+/**
+ * Episode row + `episode_symptoms` persistence against **Supabase Cloud** with RLS (patient session).
+ * Skips without `SUPABASE_SECRET_KEY` and public URL/key — see **docs/SUPABASE_CLOUD_DEVELOPER.md**.
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { PresetSymptomRow } from '@abstrack/types';
+import { createClient } from '@supabase/supabase-js';
+import type { Database } from './lib/database.types.js';
+import { getSupabasePublishableKey, getSupabaseUrl } from './lib/env-public.js';
+import type { AbstrackSupabaseClient } from './lib/supabase-client-type.js';
+import { getSupabaseAdminClient } from './admin.js';
+import { createEpisode, getEpisodeById } from './lib/episode-data.js';
+import {
+  listEpisodeSymptomsForEpisode,
+  upsertEpisodeSymptomAnswer,
+} from './lib/episode-symptom-data.js';
+import {
+  createHealthMarkerPreset,
+  createPresetSymptom,
+  createSymptomPreset,
+  deleteHealthMarkerPreset,
+  deleteSymptomPreset,
+} from './lib/preset-data.js';
+
+function episodeFoundationEnvReady(): boolean {
+  if (!process.env.SUPABASE_SECRET_KEY?.length) {
+    return false;
+  }
+  try {
+    getSupabaseUrl();
+    getSupabasePublishableKey();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const episodeFoundationReady = episodeFoundationEnvReady();
+if (
+  !episodeFoundationReady &&
+  process.env.ABSTRACK_PRESET_INTEGRATION_LOG === '1'
+) {
+  console.info(
+    '[episode-foundation.integration] Skipped: need SUPABASE_SECRET_KEY plus URL and publishable key (see docs/SUPABASE_CLOUD_DEVELOPER.md).',
+  );
+}
+
+async function deleteDisposableAuthUsers(
+  admin: ReturnType<typeof getSupabaseAdminClient>,
+  users: ReadonlyArray<{ id: string; label: string; email: string }>,
+): Promise<void> {
+  const failures: string[] = [];
+  for (const { id, label, email } of users) {
+    const { error } = await admin.auth.admin.deleteUser(id);
+    if (error) {
+      failures.push(`${label} id=${id} (${email}): ${error.message}`);
+    }
+  }
+  if (failures.length > 0) {
+    throw new Error(
+      `[episode-foundation.integration] auth.admin.deleteUser failed:\n${failures.join('\n')}`,
+    );
+  }
+}
+
+describe.skipIf(!episodeFoundationReady)(
+  'episode foundation — RLS integration (Supabase Cloud)',
+  () => {
+    vi.setConfig({ hookTimeout: 120_000, testTimeout: 120_000 });
+
+    const password = 'EpisodeFound!234567';
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    const emailA = `ep-found-a-${suffix}@example.com`;
+    const emailB = `ep-found-b-${suffix}@example.com`;
+
+    let admin: ReturnType<typeof getSupabaseAdminClient>;
+    let url: string;
+    let anonKey: string;
+    let userAId: string;
+    let userBId: string;
+    let clientA: AbstrackSupabaseClient;
+    let clientB: AbstrackSupabaseClient;
+
+    beforeAll(async () => {
+      url = getSupabaseUrl();
+      anonKey = getSupabasePublishableKey();
+      admin = getSupabaseAdminClient();
+
+      const { data: createdA, error: errA } = await admin.auth.admin.createUser(
+        {
+          email: emailA,
+          password,
+          email_confirm: true,
+        },
+      );
+      if (errA || !createdA.user) {
+        throw errA ?? new Error('createUser A failed');
+      }
+      userAId = createdA.user.id;
+
+      const { data: createdB, error: errB } = await admin.auth.admin.createUser(
+        {
+          email: emailB,
+          password,
+          email_confirm: true,
+        },
+      );
+      if (errB || !createdB.user) {
+        throw errB ?? new Error('createUser B failed');
+      }
+      userBId = createdB.user.id;
+
+      clientA = createClient<Database>(url, anonKey, {
+        auth: { persistSession: false, autoRefreshToken: false },
+      }) as unknown as AbstrackSupabaseClient;
+      clientB = createClient<Database>(url, anonKey, {
+        auth: { persistSession: false, autoRefreshToken: false },
+      }) as unknown as AbstrackSupabaseClient;
+
+      const signA = await clientA.auth.signInWithPassword({
+        email: emailA,
+        password,
+      });
+      if (signA.error) {
+        throw signA.error;
+      }
+      const signB = await clientB.auth.signInWithPassword({
+        email: emailB,
+        password,
+      });
+      if (signB.error) {
+        throw signB.error;
+      }
+
+      console.info('[episode-foundation.integration] Disposable users', {
+        emailA,
+        emailB,
+        userAId,
+        userBId,
+      });
+    }, 120_000);
+
+    afterAll(async () => {
+      await clientA?.auth.signOut();
+      await clientB?.auth.signOut();
+      if (!admin) {
+        return;
+      }
+      const disposable: { id: string; label: string; email: string }[] = [];
+      if (userAId) {
+        disposable.push({ id: userAId, label: 'userA', email: emailA });
+      }
+      if (userBId) {
+        disposable.push({ id: userBId, label: 'userB', email: emailB });
+      }
+      if (disposable.length > 0) {
+        await deleteDisposableAuthUsers(admin, disposable);
+      }
+    }, 120_000);
+
+    describe.sequential('owner session — create / read', () => {
+      let symptomPresetId: string;
+      let healthMarkerPresetId: string;
+      let presetLineRow: PresetSymptomRow;
+      let episodeId: string;
+
+      beforeAll(async () => {
+        const sp = await createSymptomPreset(clientA, {
+          user_id: userAId,
+          name: `Ep foundation sx ${suffix}`,
+        });
+        if (!sp.ok) {
+          throw new Error(sp.error.message);
+        }
+        symptomPresetId = sp.data.id;
+
+        const line = await createPresetSymptom(clientA, {
+          preset_id: symptomPresetId,
+          sort_order: 0,
+          symptom_name: 'Nausea level',
+          response_type: 'free_text',
+        });
+        if (!line.ok) {
+          throw new Error(line.error.message);
+        }
+        presetLineRow = line.data;
+
+        const hp = await createHealthMarkerPreset(clientA, {
+          user_id: userAId,
+          name: `Ep foundation hm ${suffix}`,
+        });
+        if (!hp.ok) {
+          throw new Error(hp.error.message);
+        }
+        healthMarkerPresetId = hp.data.id;
+
+        const ep = await createEpisode(clientA, {
+          user_id: userAId,
+          started_at: new Date().toISOString(),
+          symptom_preset_id: symptomPresetId,
+          health_marker_preset_id: healthMarkerPresetId,
+        });
+        if (!ep.ok) {
+          throw new Error(ep.error.message);
+        }
+        episodeId = ep.data.id;
+      });
+
+      afterAll(async () => {
+        if (episodeId) {
+          await clientA.from('episodes').delete().eq('id', episodeId);
+        }
+        if (symptomPresetId) {
+          await deleteSymptomPreset(clientA, symptomPresetId);
+        }
+        if (healthMarkerPresetId) {
+          await deleteHealthMarkerPreset(clientA, healthMarkerPresetId);
+        }
+      });
+
+      it('writes episode_symptoms and reads plaintext under the same session', async () => {
+        const upsert = await upsertEpisodeSymptomAnswer(clientA, {
+          userId: userAId,
+          episodeId,
+          line: presetLineRow,
+          answer: { type: 'free_text', value: 'mild cramping' },
+        });
+        expect(upsert.ok).toBe(true);
+        if (!upsert.ok) {
+          return;
+        }
+        expect(upsert.data.response_text).toBe('mild cramping');
+
+        const list = await listEpisodeSymptomsForEpisode(clientA, episodeId);
+        expect(list.ok).toBe(true);
+        if (!list.ok) {
+          return;
+        }
+        expect(list.data).toHaveLength(1);
+        expect(list.data[0]?.response_text).toBe('mild cramping');
+
+        const got = await getEpisodeById(clientA, episodeId);
+        expect(got.ok).toBe(true);
+        if (got.ok) {
+          expect(got.data?.id).toBe(episodeId);
+          expect(got.data?.user_id).toBe(userAId);
+        }
+      });
+
+      it('stores plaintext PHI at rest; service role can read the same value', async () => {
+        const { data, error } = await admin
+          .from('episode_symptoms')
+          .select('response_text')
+          .eq('episode_id', episodeId)
+          .maybeSingle();
+        expect(error).toBeNull();
+        expect(data?.response_text).toBe('mild cramping');
+      });
+    });
+
+    describe('cross-user denial', () => {
+      let victimEpisodeId: string;
+      let victimSymptomPresetId: string;
+      let victimHealthMarkerPresetId: string;
+      let victimPresetLine: PresetSymptomRow;
+
+      beforeAll(async () => {
+        const sp = await createSymptomPreset(clientA, {
+          user_id: userAId,
+          name: `Victim ep sx ${suffix}`,
+        });
+        expect(sp.ok).toBe(true);
+        if (!sp.ok) {
+          throw new Error(sp.error.message);
+        }
+        victimSymptomPresetId = sp.data.id;
+
+        const line = await createPresetSymptom(clientA, {
+          preset_id: victimSymptomPresetId,
+          sort_order: 0,
+          symptom_name: 'Pain',
+          response_type: 'yes_no',
+        });
+        expect(line.ok).toBe(true);
+        if (!line.ok) {
+          throw new Error(line.error.message);
+        }
+        victimPresetLine = line.data;
+
+        const hp = await createHealthMarkerPreset(clientA, {
+          user_id: userAId,
+          name: `Victim ep hm ${suffix}`,
+        });
+        expect(hp.ok).toBe(true);
+        if (!hp.ok) {
+          throw new Error(hp.error.message);
+        }
+        victimHealthMarkerPresetId = hp.data.id;
+
+        const ep = await createEpisode(clientA, {
+          user_id: userAId,
+          started_at: new Date().toISOString(),
+          symptom_preset_id: victimSymptomPresetId,
+          health_marker_preset_id: victimHealthMarkerPresetId,
+        });
+        expect(ep.ok).toBe(true);
+        if (!ep.ok) {
+          throw new Error(ep.error.message);
+        }
+        victimEpisodeId = ep.data.id;
+
+        const up = await upsertEpisodeSymptomAnswer(clientA, {
+          userId: userAId,
+          episodeId: victimEpisodeId,
+          line: victimPresetLine,
+          answer: { type: 'yes_no', value: true },
+        });
+        expect(up.ok).toBe(true);
+      });
+
+      afterAll(async () => {
+        if (victimEpisodeId) {
+          await clientA.from('episodes').delete().eq('id', victimEpisodeId);
+        }
+        if (victimSymptomPresetId) {
+          await deleteSymptomPreset(clientA, victimSymptomPresetId);
+        }
+        if (victimHealthMarkerPresetId) {
+          await deleteHealthMarkerPreset(clientA, victimHealthMarkerPresetId);
+        }
+      });
+
+      it('hides other user episode_symptoms rows', async () => {
+        const list = await listEpisodeSymptomsForEpisode(
+          clientB,
+          victimEpisodeId,
+        );
+        expect(list.ok).toBe(true);
+        if (!list.ok) {
+          return;
+        }
+        expect(list.data).toHaveLength(0);
+      });
+
+      it('hides other user episode row from getEpisodeById', async () => {
+        const got = await getEpisodeById(clientB, victimEpisodeId);
+        expect(got.ok).toBe(true);
+        if (!got.ok) {
+          return;
+        }
+        expect(got.data).toBeNull();
+      });
+    });
+  },
+);

--- a/packages/supabase/src/episode-foundation.integration.spec.ts
+++ b/packages/supabase/src/episode-foundation.integration.spec.ts
@@ -2,6 +2,7 @@
  * Episode row + `episode_symptoms` persistence against **Supabase Cloud** with RLS (patient session).
  * Skips without `SUPABASE_SECRET_KEY` and public URL/key — see **docs/SUPABASE_CLOUD_DEVELOPER.md**.
  * Disposable user emails/ids are logged only when `ABSTRACK_PRESET_INTEGRATION_LOG=1` (avoids PII in CI).
+ * `auth.admin.deleteUser` failure lines omit emails unless that flag is set.
  */
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { PresetSymptomRow } from '@abstrack/types';
@@ -50,11 +51,15 @@ async function deleteDisposableAuthUsers(
   admin: ReturnType<typeof getSupabaseAdminClient>,
   users: ReadonlyArray<{ id: string; label: string; email: string }>,
 ): Promise<void> {
+  const logPii = process.env.ABSTRACK_PRESET_INTEGRATION_LOG === '1';
   const failures: string[] = [];
   for (const { id, label, email } of users) {
     const { error } = await admin.auth.admin.deleteUser(id);
     if (error) {
-      failures.push(`${label} id=${id} (${email}): ${error.message}`);
+      const line = logPii
+        ? `${label} id=${id} (${email}): ${error.message}`
+        : `${label} id=${id}: ${error.message}`;
+      failures.push(line);
     }
   }
   if (failures.length > 0) {

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -75,4 +75,8 @@ export {
   listEpisodeTemplates,
   updateEpisodeTemplate,
 } from './lib/episode-template-data.js';
-export { createEpisode } from './lib/episode-data.js';
+export { createEpisode, getEpisodeById } from './lib/episode-data.js';
+export {
+  listEpisodeSymptomsForEpisode,
+  upsertEpisodeSymptomAnswer,
+} from './lib/episode-symptom-data.js';

--- a/packages/supabase/src/lib/episode-data.spec.ts
+++ b/packages/supabase/src/lib/episode-data.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { EpisodeInsert, EpisodeRow } from '@abstrack/types';
-import { createEpisode } from './episode-data.js';
+import { createEpisode, getEpisodeById } from './episode-data.js';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
 
 describe('createEpisode', () => {
@@ -46,5 +46,43 @@ describe('createEpisode', () => {
       expect(result.data.health_marker_preset_id).toBe('hm-1');
     }
     expect(client.from).toHaveBeenCalledWith('episodes');
+  });
+});
+
+describe('getEpisodeById', () => {
+  it('returns the row when present', async () => {
+    const row: EpisodeRow = {
+      id: 'ep-1',
+      user_id: 'user-1',
+      symptom_preset_id: 'sym-1',
+      health_marker_preset_id: 'hm-1',
+      episode_type: 'Other',
+      episode_label: null,
+      note: null,
+      started_at: '2026-04-18T12:00:00.000Z',
+      ended_at: null,
+      created_at: '2026-04-18T12:00:00.000Z',
+      updated_at: '2026-04-18T12:00:00.000Z',
+    };
+    const maybeSingle = vi.fn(async () => ({
+      data: row,
+      error: null,
+    }));
+    const client = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle,
+          })),
+        })),
+      })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await getEpisodeById(client, 'ep-1');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data?.id).toBe('ep-1');
+    }
   });
 });

--- a/packages/supabase/src/lib/episode-data.ts
+++ b/packages/supabase/src/lib/episode-data.ts
@@ -1,4 +1,5 @@
-import type { EpisodeInsert, EpisodeRow } from '@abstrack/types';
+import type { EpisodeInsert, EpisodeRow, Uuid } from '@abstrack/types';
+import { toPresetDataError } from './preset-data-error.js';
 import type { PresetDataResult } from './preset-data.js';
 import { wrap } from './preset-data.js';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
@@ -20,4 +21,30 @@ export async function createEpisode(
       error: r.error,
     };
   });
+}
+
+/**
+ * Fetches one episode by id when RLS allows (typically the owner’s row).
+ *
+ * @param client - Supabase client (RLS applies).
+ * @param episodeId - `episodes.id`.
+ * @returns The row, or `null` if not found / not visible.
+ */
+export async function getEpisodeById(
+  client: AbstrackSupabaseClient,
+  episodeId: Uuid,
+): Promise<PresetDataResult<EpisodeRow | null>> {
+  try {
+    const { data, error } = await client
+      .from('episodes')
+      .select('*')
+      .eq('id', episodeId)
+      .maybeSingle();
+    if (error) {
+      return { ok: false, error: toPresetDataError(error) };
+    }
+    return { ok: true, data: data as EpisodeRow | null };
+  } catch (caught) {
+    return { ok: false, error: toPresetDataError(caught) };
+  }
 }

--- a/packages/supabase/src/lib/episode-symptom-data.spec.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.spec.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { PresetSymptomRow } from '@abstrack/types';
+import { upsertEpisodeSymptomAnswer } from './episode-symptom-data.js';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+
+const line: PresetSymptomRow = {
+  id: 'ps-line-1',
+  preset_id: 'preset-1',
+  sort_order: 0,
+  symptom_name: 'Nausea',
+  response_type: 'yes_no',
+  prompt_instruction: null,
+  created_at: '2026-04-18T12:00:00.000Z',
+  updated_at: '2026-04-18T12:00:00.000Z',
+};
+
+describe('upsertEpisodeSymptomAnswer', () => {
+  it('inserts when no existing row', async () => {
+    const inserted = {
+      id: 'es-1',
+      user_id: 'u1',
+      episode_id: 'ep-1',
+      preset_symptom_id: line.id,
+      symptom_name: line.symptom_name,
+      response_type: 'yes_no',
+      response_boolean: true,
+      response_severity: null,
+      response_text: null,
+      sort_order: 0,
+      created_at: '2026-04-18T12:00:00.000Z',
+      updated_at: '2026-04-18T12:00:00.000Z',
+    };
+    let fromCalls = 0;
+    const client = {
+      from: vi.fn(() => {
+        fromCalls += 1;
+        if (fromCalls === 1) {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  limit: vi.fn(async () => ({
+                    data: [],
+                    error: null,
+                  })),
+                })),
+              })),
+            })),
+          };
+        }
+        return {
+          insert: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn(async () => ({
+                data: inserted,
+                error: null,
+              })),
+            })),
+          })),
+        };
+      }),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await upsertEpisodeSymptomAnswer(client, {
+      userId: 'u1',
+      episodeId: 'ep-1',
+      line,
+      answer: { type: 'yes_no', value: true },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.response_boolean).toBe(true);
+    }
+    expect(fromCalls).toBe(2);
+  });
+
+  it('updates when a row exists', async () => {
+    const existingId = 'existing-es';
+    const updated = {
+      id: existingId,
+      user_id: 'u1',
+      episode_id: 'ep-1',
+      preset_symptom_id: line.id,
+      symptom_name: line.symptom_name,
+      response_type: 'yes_no',
+      response_boolean: false,
+      response_severity: null,
+      response_text: null,
+      sort_order: 0,
+      created_at: '2026-04-18T12:00:00.000Z',
+      updated_at: '2026-04-18T12:01:00.000Z',
+    };
+    let fromCalls = 0;
+    const client = {
+      from: vi.fn(() => {
+        fromCalls += 1;
+        if (fromCalls === 1) {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  limit: vi.fn(async () => ({
+                    data: [
+                      {
+                        id: existingId,
+                        user_id: 'u1',
+                        episode_id: 'ep-1',
+                        preset_symptom_id: line.id,
+                      },
+                    ],
+                    error: null,
+                  })),
+                })),
+              })),
+            })),
+          };
+        }
+        return {
+          update: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              select: vi.fn(() => ({
+                single: vi.fn(async () => ({
+                  data: updated,
+                  error: null,
+                })),
+              })),
+            })),
+          })),
+        };
+      }),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await upsertEpisodeSymptomAnswer(client, {
+      userId: 'u1',
+      episodeId: 'ep-1',
+      line,
+      answer: { type: 'yes_no', value: false },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.response_boolean).toBe(false);
+    }
+    expect(fromCalls).toBe(2);
+  });
+});

--- a/packages/supabase/src/lib/episode-symptom-data.spec.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.spec.ts
@@ -218,9 +218,10 @@ describe('upsertEpisodeSymptomAnswer', () => {
     };
     let fromCalls = 0;
     const client = {
-      from: vi.fn(() => {
+      from: vi.fn((table: string) => {
         fromCalls += 1;
         if (fromCalls === 1) {
+          expect(table).toBe('episode_symptoms');
           return chainSelectEpisodeLine([
             {
               id: newestId,
@@ -239,6 +240,20 @@ describe('upsertEpisodeSymptomAnswer', () => {
           ]);
         }
         if (fromCalls === 2) {
+          expect(table).toBe('episode_media');
+          return {
+            update: vi.fn((payload: { episode_symptom_id: string }) => {
+              expect(payload).toEqual({ episode_symptom_id: newestId });
+              return {
+                eq: vi.fn(() => ({
+                  in: vi.fn(async () => ({ error: null })),
+                })),
+              };
+            }),
+          };
+        }
+        if (fromCalls === 3) {
+          expect(table).toBe('episode_symptoms');
           return {
             delete: vi.fn(() => ({
               in: vi.fn(async () => ({ error: null })),
@@ -271,7 +286,7 @@ describe('upsertEpisodeSymptomAnswer', () => {
     if (result.ok) {
       expect(result.data.id).toBe(newestId);
     }
-    expect(fromCalls).toBe(3);
+    expect(fromCalls).toBe(4);
   });
 
   it('on insert unique violation (23505), refetches and updates the concurrent row', async () => {

--- a/packages/supabase/src/lib/episode-symptom-data.spec.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.spec.ts
@@ -214,4 +214,80 @@ describe('upsertEpisodeSymptomAnswer', () => {
     }
     expect(fromCalls).toBe(3);
   });
+
+  it('on insert unique violation (23505), refetches and updates the concurrent row', async () => {
+    const raceRowId = 'es-concurrent';
+    const afterUpdate = {
+      id: raceRowId,
+      user_id: 'u1',
+      episode_id: 'ep-1',
+      preset_symptom_id: line.id,
+      symptom_name: line.symptom_name,
+      response_type: 'yes_no' as const,
+      response_boolean: true,
+      response_severity: null,
+      response_text: null,
+      sort_order: 0,
+      created_at: '2026-04-18T12:00:00.000Z',
+      updated_at: '2026-04-18T12:00:01.000Z',
+    };
+    let fromCalls = 0;
+    const client = {
+      from: vi.fn(() => {
+        fromCalls += 1;
+        if (fromCalls === 1) {
+          return chainSelectEpisodeLine([]);
+        }
+        if (fromCalls === 2) {
+          return {
+            insert: vi.fn(() => ({
+              select: vi.fn(() => ({
+                single: vi.fn(async () => ({
+                  data: null,
+                  error: { code: '23505', message: 'duplicate key value' },
+                })),
+              })),
+            })),
+          };
+        }
+        if (fromCalls === 3) {
+          return chainSelectEpisodeLine([
+            {
+              id: raceRowId,
+              user_id: 'u1',
+              episode_id: 'ep-1',
+              preset_symptom_id: line.id,
+              created_at: '2026-04-18T12:00:00.000Z',
+            },
+          ]);
+        }
+        return {
+          update: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              select: vi.fn(() => ({
+                single: vi.fn(async () => ({
+                  data: afterUpdate,
+                  error: null,
+                })),
+              })),
+            })),
+          })),
+        };
+      }),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await upsertEpisodeSymptomAnswer(client, {
+      userId: 'u1',
+      episodeId: 'ep-1',
+      line,
+      answer: { type: 'yes_no', value: true },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.id).toBe(raceRowId);
+      expect(result.data.response_boolean).toBe(true);
+    }
+    expect(fromCalls).toBe(4);
+  });
 });

--- a/packages/supabase/src/lib/episode-symptom-data.spec.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.spec.ts
@@ -14,6 +14,21 @@ const line: PresetSymptomRow = {
   updated_at: '2026-04-18T12:00:00.000Z',
 };
 
+/** Matches `.select().eq().eq().order().order()` from `fetchEpisodeSymptomRowsForLine`. */
+function chainSelectEpisodeLine(data: unknown): Record<string, unknown> {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          order: vi.fn(() => ({
+            order: vi.fn(async () => ({ data, error: null })),
+          })),
+        })),
+      })),
+    })),
+  };
+}
+
 describe('upsertEpisodeSymptomAnswer', () => {
   it('inserts when no existing row', async () => {
     const inserted = {
@@ -32,21 +47,11 @@ describe('upsertEpisodeSymptomAnswer', () => {
     };
     let fromCalls = 0;
     const client = {
-      from: vi.fn(() => {
+      from: vi.fn((table: string) => {
         fromCalls += 1;
         if (fromCalls === 1) {
-          return {
-            select: vi.fn(() => ({
-              eq: vi.fn(() => ({
-                eq: vi.fn(() => ({
-                  limit: vi.fn(async () => ({
-                    data: [],
-                    error: null,
-                  })),
-                })),
-              })),
-            })),
-          };
+          expect(table).toBe('episode_symptoms');
+          return chainSelectEpisodeLine([]);
         }
         return {
           insert: vi.fn(() => ({
@@ -96,25 +101,15 @@ describe('upsertEpisodeSymptomAnswer', () => {
       from: vi.fn(() => {
         fromCalls += 1;
         if (fromCalls === 1) {
-          return {
-            select: vi.fn(() => ({
-              eq: vi.fn(() => ({
-                eq: vi.fn(() => ({
-                  limit: vi.fn(async () => ({
-                    data: [
-                      {
-                        id: existingId,
-                        user_id: 'u1',
-                        episode_id: 'ep-1',
-                        preset_symptom_id: line.id,
-                      },
-                    ],
-                    error: null,
-                  })),
-                })),
-              })),
-            })),
-          };
+          return chainSelectEpisodeLine([
+            {
+              id: existingId,
+              user_id: 'u1',
+              episode_id: 'ep-1',
+              preset_symptom_id: line.id,
+              created_at: '2026-04-18T12:00:00.000Z',
+            },
+          ]);
         }
         return {
           update: vi.fn(() => ({
@@ -143,5 +138,80 @@ describe('upsertEpisodeSymptomAnswer', () => {
       expect(result.data.response_boolean).toBe(false);
     }
     expect(fromCalls).toBe(2);
+  });
+
+  it('deletes duplicate rows then updates the oldest', async () => {
+    const keepId = 'es-keep';
+    const dropId = 'es-drop';
+    const updated = {
+      id: keepId,
+      user_id: 'u1',
+      episode_id: 'ep-1',
+      preset_symptom_id: line.id,
+      symptom_name: line.symptom_name,
+      response_type: 'yes_no',
+      response_boolean: true,
+      response_severity: null,
+      response_text: null,
+      sort_order: 0,
+      created_at: '2026-04-18T12:00:00.000Z',
+      updated_at: '2026-04-18T12:02:00.000Z',
+    };
+    let fromCalls = 0;
+    const client = {
+      from: vi.fn(() => {
+        fromCalls += 1;
+        if (fromCalls === 1) {
+          return chainSelectEpisodeLine([
+            {
+              id: keepId,
+              user_id: 'u1',
+              episode_id: 'ep-1',
+              preset_symptom_id: line.id,
+              created_at: '2026-04-18T12:00:00.000Z',
+            },
+            {
+              id: dropId,
+              user_id: 'u1',
+              episode_id: 'ep-1',
+              preset_symptom_id: line.id,
+              created_at: '2026-04-18T12:00:01.000Z',
+            },
+          ]);
+        }
+        if (fromCalls === 2) {
+          return {
+            delete: vi.fn(() => ({
+              in: vi.fn(async () => ({ error: null })),
+            })),
+          };
+        }
+        return {
+          update: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              select: vi.fn(() => ({
+                single: vi.fn(async () => ({
+                  data: updated,
+                  error: null,
+                })),
+              })),
+            })),
+          })),
+        };
+      }),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await upsertEpisodeSymptomAnswer(client, {
+      userId: 'u1',
+      episodeId: 'ep-1',
+      line,
+      answer: { type: 'yes_no', value: true },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.id).toBe(keepId);
+    }
+    expect(fromCalls).toBe(3);
   });
 });

--- a/packages/supabase/src/lib/episode-symptom-data.spec.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.spec.ts
@@ -14,7 +14,7 @@ const line: PresetSymptomRow = {
   updated_at: '2026-04-18T12:00:00.000Z',
 };
 
-/** Matches `.select().eq().eq().order().order()` from `fetchEpisodeSymptomRowsForLine`. */
+/** Matches `.select().eq().eq().order(created_at desc).order(id desc)` from `fetchEpisodeSymptomRowsForLine`. */
 function chainSelectEpisodeLine(data: unknown): Record<string, unknown> {
   return {
     select: vi.fn(() => ({
@@ -140,11 +140,11 @@ describe('upsertEpisodeSymptomAnswer', () => {
     expect(fromCalls).toBe(2);
   });
 
-  it('deletes duplicate rows then updates the oldest', async () => {
-    const keepId = 'es-keep';
-    const dropId = 'es-drop';
+  it('deletes duplicate rows then updates the newest', async () => {
+    const newestId = 'es-newest';
+    const olderId = 'es-older';
     const updated = {
-      id: keepId,
+      id: newestId,
       user_id: 'u1',
       episode_id: 'ep-1',
       preset_symptom_id: line.id,
@@ -164,18 +164,18 @@ describe('upsertEpisodeSymptomAnswer', () => {
         if (fromCalls === 1) {
           return chainSelectEpisodeLine([
             {
-              id: keepId,
-              user_id: 'u1',
-              episode_id: 'ep-1',
-              preset_symptom_id: line.id,
-              created_at: '2026-04-18T12:00:00.000Z',
-            },
-            {
-              id: dropId,
+              id: newestId,
               user_id: 'u1',
               episode_id: 'ep-1',
               preset_symptom_id: line.id,
               created_at: '2026-04-18T12:00:01.000Z',
+            },
+            {
+              id: olderId,
+              user_id: 'u1',
+              episode_id: 'ep-1',
+              preset_symptom_id: line.id,
+              created_at: '2026-04-18T12:00:00.000Z',
             },
           ]);
         }
@@ -210,7 +210,7 @@ describe('upsertEpisodeSymptomAnswer', () => {
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.data.id).toBe(keepId);
+      expect(result.data.id).toBe(newestId);
     }
     expect(fromCalls).toBe(3);
   });

--- a/packages/supabase/src/lib/episode-symptom-data.spec.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { PresetSymptomRow } from '@abstrack/types';
-import { upsertEpisodeSymptomAnswer } from './episode-symptom-data.js';
+import {
+  listEpisodeSymptomsForEpisode,
+  upsertEpisodeSymptomAnswer,
+} from './episode-symptom-data.js';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
 
 const line: PresetSymptomRow = {
@@ -29,7 +32,63 @@ function chainSelectEpisodeLine(data: unknown): Record<string, unknown> {
   };
 }
 
+describe('listEpisodeSymptomsForEpisode', () => {
+  it('orders by sort_order asc, then created_at desc, then id desc', async () => {
+    const orderCalls: { column: string; ascending: boolean }[] = [];
+    const orderFn = vi.fn((column: string, opts?: { ascending?: boolean }) => {
+      orderCalls.push({
+        column,
+        ascending: opts?.ascending ?? true,
+      });
+      if (orderCalls.length < 3) {
+        return { order: orderFn };
+      }
+      return Promise.resolve({ data: [], error: null });
+    });
+    const client = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            order: orderFn,
+          })),
+        })),
+      })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await listEpisodeSymptomsForEpisode(client, 'ep-1');
+
+    expect(result.ok).toBe(true);
+    expect(orderCalls).toEqual([
+      { column: 'sort_order', ascending: true },
+      { column: 'created_at', ascending: false },
+      { column: 'id', ascending: false },
+    ]);
+  });
+});
+
 describe('upsertEpisodeSymptomAnswer', () => {
+  it('returns validation_error when answer.type does not match line.response_type', async () => {
+    const client = {
+      from: vi.fn(() => {
+        throw new Error('should not query');
+      }),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await upsertEpisodeSymptomAnswer(client, {
+      userId: 'u1',
+      episodeId: 'ep-1',
+      line: { ...line, response_type: 'free_text' },
+      answer: { type: 'yes_no', value: true },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('validation_error');
+      expect(result.error.message).toContain('symptom line');
+    }
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
   it('inserts when no existing row', async () => {
     const inserted = {
       id: 'es-1',

--- a/packages/supabase/src/lib/episode-symptom-data.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.ts
@@ -43,6 +43,34 @@ async function fetchEpisodeSymptomRowsForLine(
 }
 
 /**
+ * Moves `episode_media` rows off duplicate `episode_symptoms` ids before those rows are deleted.
+ * `episode_media_symptom_step_fk` is `ON DELETE CASCADE`; without this, storage metadata would be
+ * dropped with the duplicate symptom row.
+ *
+ * @internal
+ */
+async function reassignEpisodeMediaToCanonicalSymptomRow(
+  client: AbstrackSupabaseClient,
+  args: {
+    episodeId: Uuid;
+    canonicalEpisodeSymptomId: Uuid;
+    duplicateEpisodeSymptomIds: Uuid[];
+  },
+): Promise<{ error: unknown }> {
+  const { episodeId, canonicalEpisodeSymptomId, duplicateEpisodeSymptomIds } =
+    args;
+  if (duplicateEpisodeSymptomIds.length === 0) {
+    return { error: null };
+  }
+  const r = await client
+    .from('episode_media')
+    .update({ episode_symptom_id: canonicalEpisodeSymptomId })
+    .eq('episode_id', episodeId)
+    .in('episode_symptom_id', duplicateEpisodeSymptomIds);
+  return { error: r.error };
+}
+
+/**
  * Deletes duplicate rows by id (keeps the canonical row outside this call).
  *
  * @internal
@@ -55,6 +83,63 @@ async function deleteEpisodeSymptomRowsByIds(
     return { error: null };
   }
   return client.from('episode_symptoms').delete().in('id', ids);
+}
+
+/** User-facing copy when dedupe fails on the initial fetch path. */
+const DUPLICATE_SYMPTOM_CONFLICT_FIX =
+  'Could not fix duplicate symptom entries. Try again or contact support.';
+
+/** User-facing copy when dedupe fails after a unique race on insert. */
+const DUPLICATE_SYMPTOM_CONFLICT_SAVE =
+  'Could not save this symptom answer. Try again.';
+
+/**
+ * If `rows` has more than one line for the same preset step (newest first), repoints
+ * `episode_media`, deletes duplicate `episode_symptoms` rows, and returns `[canonical]`.
+ * Otherwise returns `rows` unchanged.
+ *
+ * @internal
+ */
+async function dedupeEpisodeSymptomRowsForLine(
+  client: AbstrackSupabaseClient,
+  episodeId: Uuid,
+  rows: EpisodeSymptomRow[],
+  conflictMessage: string,
+): Promise<
+  | { ok: true; rows: EpisodeSymptomRow[] }
+  | { ok: false; error: PresetDataError }
+> {
+  if (rows.length <= 1) {
+    return { ok: true, rows };
+  }
+  const canonicalId = rows[0].id;
+  const duplicateIds = rows.slice(1).map((r) => r.id);
+
+  const { error: mediaError } = await reassignEpisodeMediaToCanonicalSymptomRow(
+    client,
+    {
+      episodeId,
+      canonicalEpisodeSymptomId: canonicalId,
+      duplicateEpisodeSymptomIds: duplicateIds,
+    },
+  );
+  if (mediaError) {
+    return {
+      ok: false,
+      error: new PresetDataError('conflict', conflictMessage, mediaError),
+    };
+  }
+  const { error: delError } = await deleteEpisodeSymptomRowsByIds(
+    client,
+    duplicateIds,
+  );
+  if (delError) {
+    return {
+      ok: false,
+      error: new PresetDataError('conflict', conflictMessage, delError),
+    };
+  }
+  return { ok: true, rows: [rows[0]] };
 }
 
 /**
@@ -88,7 +173,8 @@ export async function listEpisodeSymptomsForEpisode(
 /**
  * Inserts or updates one `episode_symptoms` row for a preset line (one row per episode + preset line).
  * If multiple rows exist for the same pair (legacy data or pre-migration races), keeps the newest row
- * by `created_at` / `id` and deletes the rest before updating. Values are plaintext columns under RLS.
+ * by `created_at` / `id`, repoints `episode_media` off duplicate ids (CASCADE), deletes the rest,
+ * then updates. Values are plaintext columns under RLS.
  *
  * @param client - Supabase client (RLS applies).
  * @param args.userId - Must match the episode owner (`episodes.user_id`) for patient-owned episodes.
@@ -140,24 +226,16 @@ export async function upsertEpisodeSymptomAnswer(
 
     let rows = fetched.data;
 
-    if (rows.length > 1) {
-      const duplicateIds = rows.slice(1).map((r) => r.id);
-      const { error: delError } = await deleteEpisodeSymptomRowsByIds(
-        client,
-        duplicateIds,
-      );
-      if (delError) {
-        return {
-          data: null,
-          error: new PresetDataError(
-            'conflict',
-            'Could not fix duplicate symptom entries. Try again or contact support.',
-            delError,
-          ),
-        };
-      }
-      rows = [rows[0]];
+    const initialDedupe = await dedupeEpisodeSymptomRowsForLine(
+      client,
+      episodeId,
+      rows,
+      DUPLICATE_SYMPTOM_CONFLICT_FIX,
+    );
+    if (!initialDedupe.ok) {
+      return { data: null, error: initialDedupe.error };
     }
+    rows = initialDedupe.rows;
 
     if (rows.length === 1) {
       const upd = await client
@@ -193,24 +271,16 @@ export async function upsertEpisodeSymptomAnswer(
         return { data: null, error: afterRace.error };
       }
       let r2 = afterRace.data;
-      if (r2.length > 1) {
-        const duplicateIds = r2.slice(1).map((r) => r.id);
-        const { error: delError } = await deleteEpisodeSymptomRowsByIds(
-          client,
-          duplicateIds,
-        );
-        if (delError) {
-          return {
-            data: null,
-            error: new PresetDataError(
-              'conflict',
-              'Could not save this symptom answer. Try again.',
-              delError,
-            ),
-          };
-        }
-        r2 = [r2[0]];
+      const raceDedupe = await dedupeEpisodeSymptomRowsForLine(
+        client,
+        episodeId,
+        r2,
+        DUPLICATE_SYMPTOM_CONFLICT_SAVE,
+      );
+      if (!raceDedupe.ok) {
+        return { data: null, error: raceDedupe.error };
       }
+      r2 = raceDedupe.rows;
       if (r2.length === 0) {
         return { data: null, error: ins.error };
       }

--- a/packages/supabase/src/lib/episode-symptom-data.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.ts
@@ -20,7 +20,7 @@ function isPostgresUniqueViolation(error: unknown): boolean {
 }
 
 /**
- * Loads all `episode_symptoms` rows for one episode step, oldest first (canonical row is first).
+ * Loads all `episode_symptoms` rows for one episode step, newest first (canonical row is first).
  *
  * @internal
  */
@@ -34,8 +34,8 @@ async function fetchEpisodeSymptomRowsForLine(
     .select('*')
     .eq('episode_id', episodeId)
     .eq('preset_symptom_id', presetSymptomId)
-    .order('created_at', { ascending: true })
-    .order('id', { ascending: true });
+    .order('created_at', { ascending: false })
+    .order('id', { ascending: false });
   return {
     data: (r.data ?? []) as EpisodeSymptomRow[],
     error: r.error,
@@ -83,7 +83,7 @@ export async function listEpisodeSymptomsForEpisode(
 
 /**
  * Inserts or updates one `episode_symptoms` row for a preset line (one row per episode + preset line).
- * If multiple rows exist for the same pair (legacy data or pre-migration races), keeps the oldest row
+ * If multiple rows exist for the same pair (legacy data or pre-migration races), keeps the newest row
  * by `created_at` / `id` and deletes the rest before updating. Values are plaintext columns under RLS.
  *
  * @param client - Supabase client (RLS applies).

--- a/packages/supabase/src/lib/episode-symptom-data.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.ts
@@ -5,9 +5,57 @@ import type {
   Uuid,
 } from '@abstrack/types';
 import { symptomPromptAnswerToResponseColumns } from '@abstrack/types';
+import { PresetDataError } from './preset-data-error.js';
 import type { PresetDataResult } from './preset-data.js';
 import { wrap } from './preset-data.js';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+
+function isPostgresUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: string }).code === '23505'
+  );
+}
+
+/**
+ * Loads all `episode_symptoms` rows for one episode step, oldest first (canonical row is first).
+ *
+ * @internal
+ */
+async function fetchEpisodeSymptomRowsForLine(
+  client: AbstrackSupabaseClient,
+  episodeId: Uuid,
+  presetSymptomId: Uuid,
+): Promise<{ data: EpisodeSymptomRow[]; error: unknown }> {
+  const r = await client
+    .from('episode_symptoms')
+    .select('*')
+    .eq('episode_id', episodeId)
+    .eq('preset_symptom_id', presetSymptomId)
+    .order('created_at', { ascending: true })
+    .order('id', { ascending: true });
+  return {
+    data: (r.data ?? []) as EpisodeSymptomRow[],
+    error: r.error,
+  };
+}
+
+/**
+ * Deletes duplicate rows by id (keeps the canonical row outside this call).
+ *
+ * @internal
+ */
+async function deleteEpisodeSymptomRowsByIds(
+  client: AbstrackSupabaseClient,
+  ids: Uuid[],
+): Promise<{ error: unknown }> {
+  if (ids.length === 0) {
+    return { error: null };
+  }
+  return client.from('episode_symptoms').delete().in('id', ids);
+}
 
 /**
  * Lists logged symptom rows for one episode (ordered like the preset).
@@ -35,7 +83,8 @@ export async function listEpisodeSymptomsForEpisode(
 
 /**
  * Inserts or updates one `episode_symptoms` row for a preset line (one row per episode + preset line).
- * Values are stored as plaintext columns under RLS (no client-side encryption).
+ * If multiple rows exist for the same pair (legacy data or pre-migration races), keeps the oldest row
+ * by `created_at` / `id` and deletes the rest before updating. Values are plaintext columns under RLS.
  *
  * @param client - Supabase client (RLS applies).
  * @param args.userId - Must match the episode owner (`episodes.user_id`) for patient-owned episodes.
@@ -55,36 +104,57 @@ export async function upsertEpisodeSymptomAnswer(
   const { userId, episodeId, line, answer } = args;
   const response = symptomPromptAnswerToResponseColumns(answer);
 
-  return wrap(async () => {
-    const existing = await client
-      .from('episode_symptoms')
-      .select('*')
-      .eq('episode_id', episodeId)
-      .eq('preset_symptom_id', line.id)
-      .limit(2);
+  const responsePayload = {
+    symptom_name: line.symptom_name,
+    sort_order: line.sort_order,
+    response_type: response.response_type,
+    response_boolean: response.response_boolean,
+    response_severity: response.response_severity,
+    response_text: response.response_text,
+  };
 
-    if (existing.error) {
-      return { data: null, error: existing.error };
+  return wrap(async () => {
+    const fetched = await fetchEpisodeSymptomRowsForLine(
+      client,
+      episodeId,
+      line.id,
+    );
+    if (fetched.error) {
+      return { data: null, error: fetched.error };
     }
 
-    const rows = (existing.data ?? []) as EpisodeSymptomRow[];
-    const first = rows[0];
+    let rows = fetched.data;
 
-    if (first) {
+    if (rows.length > 1) {
+      const duplicateIds = rows.slice(1).map((r) => r.id);
+      const { error: delError } = await deleteEpisodeSymptomRowsByIds(
+        client,
+        duplicateIds,
+      );
+      if (delError) {
+        return {
+          data: null,
+          error: new PresetDataError(
+            'conflict',
+            'Could not fix duplicate symptom entries. Try again or contact support.',
+            delError,
+          ),
+        };
+      }
+      rows = [rows[0]];
+    }
+
+    if (rows.length === 1) {
       const upd = await client
         .from('episode_symptoms')
-        .update({
-          symptom_name: line.symptom_name,
-          sort_order: line.sort_order,
-          response_type: response.response_type,
-          response_boolean: response.response_boolean,
-          response_severity: response.response_severity,
-          response_text: response.response_text,
-        })
-        .eq('id', first.id)
+        .update(responsePayload)
+        .eq('id', rows[0].id)
         .select('*')
         .single();
-      return { data: upd.data as EpisodeSymptomRow | null, error: upd.error };
+      return {
+        data: upd.data as EpisodeSymptomRow | null,
+        error: upd.error,
+      };
     }
 
     const ins = await client
@@ -93,15 +163,57 @@ export async function upsertEpisodeSymptomAnswer(
         user_id: userId,
         episode_id: episodeId,
         preset_symptom_id: line.id,
-        symptom_name: line.symptom_name,
-        sort_order: line.sort_order,
-        response_type: response.response_type,
-        response_boolean: response.response_boolean,
-        response_severity: response.response_severity,
-        response_text: response.response_text,
+        ...responsePayload,
       })
       .select('*')
       .single();
-    return { data: ins.data as EpisodeSymptomRow | null, error: ins.error };
+
+    if (ins.error && isPostgresUniqueViolation(ins.error)) {
+      const afterRace = await fetchEpisodeSymptomRowsForLine(
+        client,
+        episodeId,
+        line.id,
+      );
+      if (afterRace.error) {
+        return { data: null, error: afterRace.error };
+      }
+      let r2 = afterRace.data;
+      if (r2.length > 1) {
+        const duplicateIds = r2.slice(1).map((r) => r.id);
+        const { error: delError } = await deleteEpisodeSymptomRowsByIds(
+          client,
+          duplicateIds,
+        );
+        if (delError) {
+          return {
+            data: null,
+            error: new PresetDataError(
+              'conflict',
+              'Could not save this symptom answer. Try again.',
+              delError,
+            ),
+          };
+        }
+        r2 = [r2[0]];
+      }
+      if (r2.length === 0) {
+        return { data: null, error: ins.error };
+      }
+      const upd = await client
+        .from('episode_symptoms')
+        .update(responsePayload)
+        .eq('id', r2[0].id)
+        .select('*')
+        .single();
+      return {
+        data: upd.data as EpisodeSymptomRow | null,
+        error: upd.error,
+      };
+    }
+
+    return {
+      data: ins.data as EpisodeSymptomRow | null,
+      error: ins.error,
+    };
   });
 }

--- a/packages/supabase/src/lib/episode-symptom-data.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.ts
@@ -58,7 +58,10 @@ async function deleteEpisodeSymptomRowsByIds(
 }
 
 /**
- * Lists logged symptom rows for one episode (ordered like the preset).
+ * Lists logged symptom rows for one episode (preset order, then stable duplicate ordering).
+ *
+ * Orders by `sort_order` ASC, then `created_at` DESC, then `id` DESC so legacy duplicate rows for the
+ * same preset line list the canonical row first (same tie-break as upsert / migration / client map).
  *
  * @param client - Supabase client (RLS applies).
  * @param episodeId - `episodes.id`.
@@ -73,7 +76,8 @@ export async function listEpisodeSymptomsForEpisode(
       .select('*')
       .eq('episode_id', episodeId)
       .order('sort_order', { ascending: true })
-      .order('id', { ascending: true });
+      .order('created_at', { ascending: false })
+      .order('id', { ascending: false });
     return {
       data: (r.data ?? []) as EpisodeSymptomRow[],
       error: r.error,
@@ -90,7 +94,7 @@ export async function listEpisodeSymptomsForEpisode(
  * @param args.userId - Must match the episode owner (`episodes.user_id`) for patient-owned episodes.
  * @param args.episodeId - `episodes.id`.
  * @param args.line - Active preset symptom line (defines `preset_symptom_id`, name, sort order).
- * @param args.answer - Current answer for that line.
+ * @param args.answer - Current answer for that line (`answer.type` must match `line.response_type`).
  */
 export async function upsertEpisodeSymptomAnswer(
   client: AbstrackSupabaseClient,
@@ -102,6 +106,17 @@ export async function upsertEpisodeSymptomAnswer(
   },
 ): Promise<PresetDataResult<EpisodeSymptomRow>> {
   const { userId, episodeId, line, answer } = args;
+
+  if (answer.type !== line.response_type) {
+    return {
+      ok: false,
+      error: new PresetDataError(
+        'validation_error',
+        'Answer type does not match this symptom line.',
+      ),
+    };
+  }
+
   const response = symptomPromptAnswerToResponseColumns(answer);
 
   const responsePayload = {

--- a/packages/supabase/src/lib/episode-symptom-data.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.ts
@@ -1,0 +1,107 @@
+import type {
+  EpisodeSymptomRow,
+  PresetSymptomRow,
+  SymptomPromptAnswer,
+  Uuid,
+} from '@abstrack/types';
+import { symptomPromptAnswerToResponseColumns } from '@abstrack/types';
+import type { PresetDataResult } from './preset-data.js';
+import { wrap } from './preset-data.js';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+
+/**
+ * Lists logged symptom rows for one episode (ordered like the preset).
+ *
+ * @param client - Supabase client (RLS applies).
+ * @param episodeId - `episodes.id`.
+ */
+export async function listEpisodeSymptomsForEpisode(
+  client: AbstrackSupabaseClient,
+  episodeId: Uuid,
+): Promise<PresetDataResult<EpisodeSymptomRow[]>> {
+  return wrap(async () => {
+    const r = await client
+      .from('episode_symptoms')
+      .select('*')
+      .eq('episode_id', episodeId)
+      .order('sort_order', { ascending: true })
+      .order('id', { ascending: true });
+    return {
+      data: (r.data ?? []) as EpisodeSymptomRow[],
+      error: r.error,
+    };
+  });
+}
+
+/**
+ * Inserts or updates one `episode_symptoms` row for a preset line (one row per episode + preset line).
+ * Values are stored as plaintext columns under RLS (no client-side encryption).
+ *
+ * @param client - Supabase client (RLS applies).
+ * @param args.userId - Must match the episode owner (`episodes.user_id`) for patient-owned episodes.
+ * @param args.episodeId - `episodes.id`.
+ * @param args.line - Active preset symptom line (defines `preset_symptom_id`, name, sort order).
+ * @param args.answer - Current answer for that line.
+ */
+export async function upsertEpisodeSymptomAnswer(
+  client: AbstrackSupabaseClient,
+  args: {
+    userId: Uuid;
+    episodeId: Uuid;
+    line: PresetSymptomRow;
+    answer: SymptomPromptAnswer;
+  },
+): Promise<PresetDataResult<EpisodeSymptomRow>> {
+  const { userId, episodeId, line, answer } = args;
+  const response = symptomPromptAnswerToResponseColumns(answer);
+
+  return wrap(async () => {
+    const existing = await client
+      .from('episode_symptoms')
+      .select('*')
+      .eq('episode_id', episodeId)
+      .eq('preset_symptom_id', line.id)
+      .limit(2);
+
+    if (existing.error) {
+      return { data: null, error: existing.error };
+    }
+
+    const rows = (existing.data ?? []) as EpisodeSymptomRow[];
+    const first = rows[0];
+
+    if (first) {
+      const upd = await client
+        .from('episode_symptoms')
+        .update({
+          symptom_name: line.symptom_name,
+          sort_order: line.sort_order,
+          response_type: response.response_type,
+          response_boolean: response.response_boolean,
+          response_severity: response.response_severity,
+          response_text: response.response_text,
+        })
+        .eq('id', first.id)
+        .select('*')
+        .single();
+      return { data: upd.data as EpisodeSymptomRow | null, error: upd.error };
+    }
+
+    const ins = await client
+      .from('episode_symptoms')
+      .insert({
+        user_id: userId,
+        episode_id: episodeId,
+        preset_symptom_id: line.id,
+        symptom_name: line.symptom_name,
+        sort_order: line.sort_order,
+        response_type: response.response_type,
+        response_boolean: response.response_boolean,
+        response_severity: response.response_severity,
+        response_text: response.response_text,
+      })
+      .select('*')
+      .single();
+    return { data: ins.data as EpisodeSymptomRow | null, error: ins.error };
+  });
+}

--- a/packages/supabase/src/preset-flows.integration.spec.ts
+++ b/packages/supabase/src/preset-flows.integration.spec.ts
@@ -76,16 +76,21 @@ if (
 /**
  * Deletes disposable Auth users and surfaces `auth.admin.deleteUser` failures (rate limits,
  * network, etc.) so the suite does not silently leak users.
+ * Failure lines omit emails unless `ABSTRACK_PRESET_INTEGRATION_LOG=1` (reduces PII in CI logs).
  */
 async function deleteDisposableAuthUsers(
   adminClient: ReturnType<typeof getSupabaseAdminClient>,
   users: ReadonlyArray<{ id: string; label: string; email: string }>,
 ): Promise<void> {
+  const logPii = process.env.ABSTRACK_PRESET_INTEGRATION_LOG === '1';
   const failures: string[] = [];
   for (const { id, label, email } of users) {
     const { error } = await adminClient.auth.admin.deleteUser(id);
     if (error) {
-      failures.push(`${label} id=${id} (${email}): ${error.message}`);
+      const line = logPii
+        ? `${label} id=${id} (${email}): ${error.message}`
+        : `${label} id=${id}: ${error.message}`;
+      failures.push(line);
     }
   }
   if (failures.length > 0) {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,4 +2,5 @@ export * from './lib/abs-symptom-suggestions.js';
 export * from './lib/episode-template.js';
 export * from './lib/symptom-prompt-session.js';
 export * from './lib/symptom-prompt-session-sanitize.js';
+export * from './lib/episode-symptom-mapping.js';
 export * from './lib/types.js';

--- a/packages/types/src/lib/episode-symptom-mapping.spec.ts
+++ b/packages/types/src/lib/episode-symptom-mapping.spec.ts
@@ -83,4 +83,66 @@ describe('episode-symptom mapping', () => {
     ]);
     expect(map['ps-1']).toEqual({ type: 'yes_no', value: true });
   });
+
+  it('episodeSymptomRowsToAnswersMap keeps newest duplicate per preset_symptom_id', () => {
+    const older = {
+      ...baseRow,
+      id: '00000000-0000-4000-8000-000000000001',
+      preset_symptom_id: 'ps-1',
+      created_at: '2026-04-18T12:00:00.000Z',
+      response_type: 'yes_no' as const,
+      response_boolean: false,
+      response_severity: null,
+      response_text: null,
+    } as EpisodeSymptomRow;
+    const newer = {
+      ...baseRow,
+      id: '00000000-0000-4000-8000-000000000002',
+      preset_symptom_id: 'ps-1',
+      created_at: '2026-04-18T12:00:01.000Z',
+      response_type: 'yes_no' as const,
+      response_boolean: true,
+      response_severity: null,
+      response_text: null,
+    } as EpisodeSymptomRow;
+
+    expect(episodeSymptomRowsToAnswersMap([older, newer])['ps-1']).toEqual({
+      type: 'yes_no',
+      value: true,
+    });
+    expect(episodeSymptomRowsToAnswersMap([newer, older])['ps-1']).toEqual({
+      type: 'yes_no',
+      value: true,
+    });
+  });
+
+  it('episodeSymptomRowsToAnswersMap breaks created_at ties with id DESC', () => {
+    const lowerId = {
+      ...baseRow,
+      id: '00000000-0000-4000-8000-000000000001',
+      preset_symptom_id: 'ps-1',
+      created_at: '2026-04-18T12:00:00.000Z',
+      response_type: 'yes_no' as const,
+      response_boolean: false,
+      response_severity: null,
+      response_text: null,
+    } as EpisodeSymptomRow;
+    const higherId = {
+      ...baseRow,
+      id: '00000000-0000-4000-8000-000000000002',
+      preset_symptom_id: 'ps-1',
+      created_at: '2026-04-18T12:00:00.000Z',
+      response_type: 'yes_no' as const,
+      response_boolean: true,
+      response_severity: null,
+      response_text: null,
+    } as EpisodeSymptomRow;
+
+    expect(episodeSymptomRowsToAnswersMap([lowerId, higherId])['ps-1']).toEqual(
+      {
+        type: 'yes_no',
+        value: true,
+      },
+    );
+  });
 });

--- a/packages/types/src/lib/episode-symptom-mapping.spec.ts
+++ b/packages/types/src/lib/episode-symptom-mapping.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import type { EpisodeSymptomRow } from './types.js';
+import {
+  episodeSymptomRowToPromptAnswer,
+  episodeSymptomRowsToAnswersMap,
+  symptomPromptAnswerToResponseColumns,
+} from './episode-symptom-mapping.js';
+
+const baseRow = {
+  id: 'es-1',
+  user_id: 'u1',
+  episode_id: 'ep-1',
+  preset_symptom_id: 'ps-1',
+  symptom_name: 'Nausea',
+  created_at: '2026-04-18T12:00:00.000Z',
+  updated_at: '2026-04-18T12:00:00.000Z',
+  sort_order: 0,
+} satisfies Partial<EpisodeSymptomRow>;
+
+describe('episode-symptom mapping', () => {
+  it('episodeSymptomRowToPromptAnswer maps yes_no / severity / free_text', () => {
+    expect(
+      episodeSymptomRowToPromptAnswer({
+        ...baseRow,
+        response_type: 'yes_no',
+        response_boolean: true,
+        response_severity: null,
+        response_text: null,
+      } as EpisodeSymptomRow),
+    ).toEqual({ type: 'yes_no', value: true });
+
+    expect(
+      episodeSymptomRowToPromptAnswer({
+        ...baseRow,
+        response_type: 'severity_scale',
+        response_boolean: null,
+        response_severity: 3,
+        response_text: null,
+      } as EpisodeSymptomRow),
+    ).toEqual({ type: 'severity_scale', value: 3 });
+
+    expect(
+      episodeSymptomRowToPromptAnswer({
+        ...baseRow,
+        response_type: 'free_text',
+        response_boolean: null,
+        response_severity: null,
+        response_text: 'hello',
+      } as EpisodeSymptomRow),
+    ).toEqual({ type: 'free_text', value: 'hello' });
+  });
+
+  it('symptomPromptAnswerToResponseColumns satisfies CHECK shape', () => {
+    expect(
+      symptomPromptAnswerToResponseColumns({ type: 'yes_no', value: false }),
+    ).toEqual({
+      response_type: 'yes_no',
+      response_boolean: false,
+      response_severity: null,
+      response_text: null,
+    });
+    expect(
+      symptomPromptAnswerToResponseColumns({ type: 'free_text', value: 'x' }),
+    ).toEqual({
+      response_type: 'free_text',
+      response_boolean: null,
+      response_severity: null,
+      response_text: 'x',
+    });
+  });
+
+  it('episodeSymptomRowsToAnswersMap keys by preset_symptom_id', () => {
+    const map = episodeSymptomRowsToAnswersMap([
+      {
+        ...baseRow,
+        id: 'a',
+        preset_symptom_id: 'ps-1',
+        response_type: 'yes_no',
+        response_boolean: true,
+        response_severity: null,
+        response_text: null,
+      } as EpisodeSymptomRow,
+    ]);
+    expect(map['ps-1']).toEqual({ type: 'yes_no', value: true });
+  });
+});

--- a/packages/types/src/lib/episode-symptom-mapping.ts
+++ b/packages/types/src/lib/episode-symptom-mapping.ts
@@ -1,0 +1,97 @@
+import type { EpisodeSymptomRow, SymptomResponseType } from './types.js';
+import type {
+  SymptomPromptAnswer,
+  SymptomPromptAnswers,
+} from './symptom-prompt-session.js';
+
+/**
+ * Maps a stored `episode_symptoms` row to the in-memory prompt answer shape (Week 5+ flows).
+ *
+ * @param row - Row returned from Postgres (plaintext columns under RLS).
+ * @returns Serializable answer for UI state and session overlays.
+ */
+export function episodeSymptomRowToPromptAnswer(
+  row: EpisodeSymptomRow,
+): SymptomPromptAnswer {
+  switch (row.response_type) {
+    case 'yes_no':
+      return { type: 'yes_no', value: row.response_boolean };
+    case 'severity_scale':
+      return { type: 'severity_scale', value: row.response_severity };
+    case 'free_text':
+      return { type: 'free_text', value: row.response_text ?? '' };
+    case 'photo':
+      return { type: 'photo', value: null };
+    case 'video':
+      return { type: 'video', value: null };
+  }
+}
+
+/**
+ * Converts a prompt answer into `episode_symptoms` response columns (CHECK-aligned).
+ *
+ * @param answer - Current draft from the prompt UI.
+ */
+export function symptomPromptAnswerToResponseColumns(
+  answer: SymptomPromptAnswer,
+): {
+  response_type: SymptomResponseType;
+  response_boolean: boolean | null;
+  response_severity: number | null;
+  response_text: string | null;
+} {
+  switch (answer.type) {
+    case 'yes_no':
+      return {
+        response_type: 'yes_no',
+        response_boolean: answer.value,
+        response_severity: null,
+        response_text: null,
+      };
+    case 'severity_scale':
+      return {
+        response_type: 'severity_scale',
+        response_boolean: null,
+        response_severity: answer.value,
+        response_text: null,
+      };
+    case 'free_text':
+      return {
+        response_type: 'free_text',
+        response_boolean: null,
+        response_severity: null,
+        response_text: answer.value,
+      };
+    case 'photo':
+      return {
+        response_type: 'photo',
+        response_boolean: null,
+        response_severity: null,
+        response_text: null,
+      };
+    case 'video':
+      return {
+        response_type: 'video',
+        response_boolean: null,
+        response_severity: null,
+        response_text: null,
+      };
+  }
+}
+
+/**
+ * Builds {@link SymptomPromptAnswers} from persisted episode symptom rows (keyed by `preset_symptoms.id`).
+ *
+ * @param rows - Rows for one episode (same owner as the episode under RLS).
+ */
+export function episodeSymptomRowsToAnswersMap(
+  rows: EpisodeSymptomRow[],
+): SymptomPromptAnswers {
+  const out: SymptomPromptAnswers = {};
+  for (const row of rows) {
+    if (row.preset_symptom_id) {
+      out[row.preset_symptom_id] = episodeSymptomRowToPromptAnswer(row);
+    }
+  }
+  return out;
+}

--- a/packages/types/src/lib/episode-symptom-mapping.ts
+++ b/packages/types/src/lib/episode-symptom-mapping.ts
@@ -80,18 +80,47 @@ export function symptomPromptAnswerToResponseColumns(
 }
 
 /**
+ * Prefer `a` over `b` when both rows are for the same preset line — matches upsert/dedupe
+ * (`created_at` DESC, `id` DESC) so hydration agrees with the canonical DB row.
+ */
+function episodeSymptomRowIsCanonicalOver(
+  a: EpisodeSymptomRow,
+  b: EpisodeSymptomRow,
+): boolean {
+  const ta = new Date(a.created_at).getTime();
+  const tb = new Date(b.created_at).getTime();
+  if (ta !== tb) {
+    return ta > tb;
+  }
+  return a.id > b.id;
+}
+
+/**
  * Builds {@link SymptomPromptAnswers} from persisted episode symptom rows (keyed by `preset_symptoms.id`).
+ *
+ * If multiple rows share a `preset_symptom_id` (legacy duplicates), keeps the same canonical row as
+ * server upsert / the unique-index migration: newest `created_at`, then `id` DESC.
  *
  * @param rows - Rows for one episode (same owner as the episode under RLS).
  */
 export function episodeSymptomRowsToAnswersMap(
   rows: EpisodeSymptomRow[],
 ): SymptomPromptAnswers {
-  const out: SymptomPromptAnswers = {};
+  const canonicalByPreset: Record<string, EpisodeSymptomRow> = {};
   for (const row of rows) {
-    if (row.preset_symptom_id) {
-      out[row.preset_symptom_id] = episodeSymptomRowToPromptAnswer(row);
+    if (!row.preset_symptom_id) {
+      continue;
     }
+    const key = row.preset_symptom_id;
+    const prev = canonicalByPreset[key];
+    if (!prev || episodeSymptomRowIsCanonicalOver(row, prev)) {
+      canonicalByPreset[key] = row;
+    }
+  }
+
+  const out: SymptomPromptAnswers = {};
+  for (const [presetId, row] of Object.entries(canonicalByPreset)) {
+    out[presetId] = episodeSymptomRowToPromptAnswer(row);
   }
   return out;
 }

--- a/supabase/migrations/20260419120000_episode_symptoms_episode_preset_unique.sql
+++ b/supabase/migrations/20260419120000_episode_symptoms_episode_preset_unique.sql
@@ -2,8 +2,12 @@
 -- Partial index: only rows tied to an episode (episode_id IS NOT NULL) with a preset line id.
 -- Ad-hoc / NULL episode_id rows are out of scope for this uniqueness rule.
 
--- Hold an exclusive lock for the whole migration transaction so no concurrent writer can insert a
--- duplicate (episode_id, preset_symptom_id) between the DELETE and CREATE UNIQUE INDEX.
+-- Explicit transaction: LOCK TABLE requires a transaction block (SQLSTATE 25P01 if applied
+-- statement-by-statement). Local `supabase db reset` can run migrations outside an outer txn.
+BEGIN;
+
+-- Hold an exclusive lock for this transaction so no concurrent writer can insert a duplicate
+-- (episode_id, preset_symptom_id) between the DELETE and CREATE UNIQUE INDEX.
 LOCK TABLE public.episode_symptoms IN EXCLUSIVE MODE;
 
 -- Remove duplicate (episode_id, preset_symptom_id) rows if any exist before creating the index.
@@ -35,3 +39,5 @@ CREATE UNIQUE INDEX IF NOT EXISTS episode_symptoms_episode_id_preset_symptom_id_
     AND preset_symptom_id IS NOT NULL;
 
 COMMENT ON INDEX public.episode_symptoms_episode_id_preset_symptom_id_uidx IS 'At most one logged answer per preset symptom step per episode (episode_symptoms upsert).';
+
+COMMIT;

--- a/supabase/migrations/20260419120000_episode_symptoms_episode_preset_unique.sql
+++ b/supabase/migrations/20260419120000_episode_symptoms_episode_preset_unique.sql
@@ -12,6 +12,44 @@ LOCK TABLE public.episode_symptoms IN EXCLUSIVE MODE;
 
 -- Remove duplicate (episode_id, preset_symptom_id) rows if any exist before creating the index.
 -- Keep the newest row per pair so we do not discard the latest user-entered answer (older rows are races/legacy).
+-- Repoint episode_media first: FK episode_media_symptom_step_fk is ON DELETE CASCADE on episode_symptoms.id.
+WITH ranked AS (
+  SELECT
+    id,
+    episode_id,
+    preset_symptom_id,
+    ROW_NUMBER() OVER (
+      PARTITION BY episode_id, preset_symptom_id
+      ORDER BY
+        created_at DESC,
+        id DESC
+    ) AS rn
+  FROM public.episode_symptoms
+  WHERE
+    episode_id IS NOT NULL
+    AND preset_symptom_id IS NOT NULL
+),
+canonical AS (
+  SELECT
+    episode_id,
+    preset_symptom_id,
+    id AS canonical_id
+  FROM ranked
+  WHERE
+    rn = 1
+)
+UPDATE public.episode_media em
+SET
+  episode_symptom_id = c.canonical_id
+FROM ranked r
+INNER JOIN canonical c
+  ON c.episode_id = r.episode_id
+  AND c.preset_symptom_id = r.preset_symptom_id
+WHERE
+  em.episode_id = r.episode_id
+  AND em.episode_symptom_id = r.id
+  AND r.rn > 1;
+
 WITH ranked AS (
   SELECT
     id,

--- a/supabase/migrations/20260419120000_episode_symptoms_episode_preset_unique.sql
+++ b/supabase/migrations/20260419120000_episode_symptoms_episode_preset_unique.sql
@@ -2,6 +2,10 @@
 -- Partial index: only rows tied to an episode (episode_id IS NOT NULL) with a preset line id.
 -- Ad-hoc / NULL episode_id rows are out of scope for this uniqueness rule.
 
+-- Hold an exclusive lock for the whole migration transaction so no concurrent writer can insert a
+-- duplicate (episode_id, preset_symptom_id) between the DELETE and CREATE UNIQUE INDEX.
+LOCK TABLE public.episode_symptoms IN EXCLUSIVE MODE;
+
 -- Remove duplicate (episode_id, preset_symptom_id) rows if any exist before creating the index.
 -- Keep the newest row per pair so we do not discard the latest user-entered answer (older rows are races/legacy).
 WITH ranked AS (

--- a/supabase/migrations/20260419120000_episode_symptoms_episode_preset_unique.sql
+++ b/supabase/migrations/20260419120000_episode_symptoms_episode_preset_unique.sql
@@ -3,14 +3,15 @@
 -- Ad-hoc / NULL episode_id rows are out of scope for this uniqueness rule.
 
 -- Remove duplicate (episode_id, preset_symptom_id) rows if any exist before creating the index.
+-- Keep the newest row per pair so we do not discard the latest user-entered answer (older rows are races/legacy).
 WITH ranked AS (
   SELECT
     id,
     ROW_NUMBER() OVER (
       PARTITION BY episode_id, preset_symptom_id
       ORDER BY
-        created_at ASC,
-        id ASC
+        created_at DESC,
+        id DESC
     ) AS rn
   FROM public.episode_symptoms
   WHERE

--- a/supabase/migrations/20260419120000_episode_symptoms_episode_preset_unique.sql
+++ b/supabase/migrations/20260419120000_episode_symptoms_episode_preset_unique.sql
@@ -1,0 +1,32 @@
+-- One answer row per preset symptom line within an episode (prevents duplicates and races).
+-- Partial index: only rows tied to an episode (episode_id IS NOT NULL) with a preset line id.
+-- Ad-hoc / NULL episode_id rows are out of scope for this uniqueness rule.
+
+-- Remove duplicate (episode_id, preset_symptom_id) rows if any exist before creating the index.
+WITH ranked AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY episode_id, preset_symptom_id
+      ORDER BY
+        created_at ASC,
+        id ASC
+    ) AS rn
+  FROM public.episode_symptoms
+  WHERE
+    episode_id IS NOT NULL
+    AND preset_symptom_id IS NOT NULL
+)
+DELETE FROM public.episode_symptoms es
+USING ranked r
+WHERE
+  es.id = r.id
+  AND r.rn > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS episode_symptoms_episode_id_preset_symptom_id_uidx
+  ON public.episode_symptoms (episode_id, preset_symptom_id)
+  WHERE
+    episode_id IS NOT NULL
+    AND preset_symptom_id IS NOT NULL;
+
+COMMENT ON INDEX public.episode_symptoms_episode_id_preset_symptom_id_uidx IS 'At most one logged answer per preset symptom step per episode (episode_symptoms upsert).';


### PR DESCRIPTION
Closes #76

## Summary

Wires the Week 5 symptom prompt flow to **Supabase** so answers are stored as **plaintext columns** on `episode_symptoms` under **RLS** (no client-side field encryption), aligned with the PRD security model.

## What changed

- **`@abstrack/types`**: Mapping helpers between `episode_symptoms` rows and `SymptomPromptAnswer` / `SymptomPromptAnswers`.
- **`@abstrack/supabase`**: `listEpisodeSymptomsForEpisode`, `upsertEpisodeSymptomAnswer`, and `getEpisodeById`; unit tests for upsert/read helpers. Upsert logic handles duplicate rows safely; insert races covered where applicable.
- **Web & mobile**: Symptom stepper loads server-backed answers (merged over local session), persists on change (debounced for free text); surfaces a non-blocking message if sync fails. Session user id resolved before `ready` and on each persist so early answers are not skipped.
- **Database**: Migration `20260419120000_episode_symptoms_episode_preset_unique.sql` — one-time dedupe of existing duplicate `(episode_id, preset_symptom_id)` rows (keeps **newest** by `created_at` / `id`), then partial **unique index** on `(episode_id, preset_symptom_id)` where both are non-null. Apply with your usual Supabase workflow (`db push` + `gen types --linked` per **docs/SUPABASE_CLOUD_DEVELOPER.md**).
- **Integration tests** (`episode-foundation.integration.spec.ts`): Owner create/read path and cross-user denial (same env pattern as preset RLS tests — requires `SUPABASE_SECRET_KEY` + public URL/key locally/CI). Disposable user emails/ids logged only when `ABSTRACK_PRESET_INTEGRATION_LOG=1`.
- **`docs/ROADMAP.md`**: Week 5 “episode data wired to Supabase” item marked complete.

## How to verify

- Start an episode, answer a symptom (e.g. severity). Confirm rows in **`episode_symptoms`** for that `episode_id` with expected `response_*` values.
- After applying the migration: confirm at most one row per `(episode_id, preset_symptom_id)` for episode-bound rows.
- Optional: run `pnpm exec nx test @abstrack/supabase` with integration env vars so `episode-foundation.integration.spec.ts` is not skipped.

## Notes

- **Migrations** are included for this PR; commit `supabase/migrations/*.sql` and regenerate **`packages/supabase/src/lib/database.types.ts`** after `db push` + `gen types --linked` (see **SUPABASE_CLOUD_DEVELOPER.md**).
- Photo/video lines may not persist meaningful rows until capture flows land (Week 6 scope).