### PR TITLE
feat(episode-flow): complete preset symptom inputs on web/mobile with accessible skip controls, non-media persistence, and honest media placeholders

### DIFF
--- a/apps/mobile/src/app/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/mobile/src/app/components/episode-flow/SymptomPromptResponseField.tsx
@@ -69,7 +69,10 @@ export function SymptomPromptResponseField({
                 accessibilityState={{ selected, disabled }}
                 disabled={disabled}
                 onPress={() => {
-                  onChange({ type: 'yes_no', value: boolVal });
+                  onChange({
+                    type: 'yes_no',
+                    value: selected ? null : boolVal,
+                  });
                 }}
                 style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
                 className={`items-center justify-center rounded-xl border-2 px-4 py-4 active:opacity-90 ${
@@ -108,7 +111,10 @@ export function SymptomPromptResponseField({
                 accessibilityState={{ selected, disabled }}
                 disabled={disabled}
                 onPress={() => {
-                  onChange({ type: 'severity_scale', value: n });
+                  onChange({
+                    type: 'severity_scale',
+                    value: selected ? null : n,
+                  });
                 }}
                 style={{
                   minWidth: COMFORTABLE_TOUCH_TARGET_DP,
@@ -160,8 +166,8 @@ export function SymptomPromptResponseField({
             className={`text-center text-base leading-relaxed ${nw.textInk}`}
             maxFontSizeMultiplier={2}
           >
-            Photo capture will open here during an episode. This step is a
-            placeholder for now.
+            Photo symptom capture is coming in a later update. For now, use Next
+            or Skip to continue this episode flow.
           </Text>
         </View>
       );
@@ -175,8 +181,8 @@ export function SymptomPromptResponseField({
             className={`text-center text-base leading-relaxed ${nw.textInk}`}
             maxFontSizeMultiplier={2}
           >
-            Video capture will open here during an episode. This step is a
-            placeholder for now.
+            Video symptom capture is coming in a later update. For now, use Next
+            or Skip to continue this episode flow.
           </Text>
         </View>
       );

--- a/apps/mobile/src/app/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/mobile/src/app/components/episode-flow/SymptomPromptResponseField.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { Pressable, Text, TextInput, View } from 'react-native';
-import type {
-  PresetSymptomRow,
-  SymptomPromptAnswer,
-  SymptomResponseType,
-} from '@abstrack/types';
+import type { PresetSymptomRow, SymptomPromptAnswer } from '@abstrack/types';
+import { createDefaultSymptomPromptAnswer } from '@abstrack/types';
 import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
 import { useAppTheme } from '../../theme/AppThemeContext';
 import { nw } from '../../theme/app-nativewind-classes';
@@ -15,25 +12,6 @@ export type SymptomPromptResponseFieldProps = {
   onChange: (next: SymptomPromptAnswer) => void;
   disabled: boolean;
 };
-
-function defaultAnswerForType(type: SymptomResponseType): SymptomPromptAnswer {
-  switch (type) {
-    case 'yes_no':
-      return { type: 'yes_no', value: null };
-    case 'severity_scale':
-      return { type: 'severity_scale', value: null };
-    case 'free_text':
-      return { type: 'free_text', value: '' };
-    case 'photo':
-      return { type: 'photo', value: null };
-    case 'video':
-      return { type: 'video', value: null };
-    default: {
-      const _exhaustive: never = type;
-      return _exhaustive;
-    }
-  }
-}
 
 /**
  * Renders the capture UI for one preset symptom line (Week 5 skeleton: no media pipeline).
@@ -48,7 +26,8 @@ export function SymptomPromptResponseField({
   disabled,
 }: SymptomPromptResponseFieldProps) {
   const { colors } = useAppTheme();
-  const effective = answer ?? defaultAnswerForType(line.response_type);
+  const effective =
+    answer ?? createDefaultSymptomPromptAnswer(line.response_type);
 
   switch (line.response_type) {
     case 'yes_no': {

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
@@ -94,6 +94,7 @@ describe('SymptomPromptScreen', () => {
 
   const lineA = makeLine('line-a', 0, 'Nausea', 'yes_no');
   const lineB = makeLine('line-b', 1, 'Headache', 'severity_scale');
+  const lineSeverityOnly = makeLine('line-sev', 0, 'Pain', 'severity_scale');
 
   /** Single free-text line for debounce / flush tests. */
   const lineFreeOnly = makeLine('line-ft', 0, 'Notes', 'free_text');
@@ -181,6 +182,44 @@ describe('SymptomPromptScreen', () => {
         answer: { type: 'yes_no', value: true },
       }),
     );
+  });
+
+  test('deselecting severity clears server row via delete (no null upsert)', async () => {
+    jest.mocked(listPresetSymptomsForPreset).mockResolvedValue({
+      ok: true,
+      data: [lineSeverityOnly],
+    });
+    const screen = render(<SymptomPromptScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 1 of 1')).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByLabelText('Severity 3'));
+    await waitFor(() => {
+      expect(upsertEpisodeSymptomAnswer).toHaveBeenCalledWith(
+        expect.objectContaining({ mockClient: true }),
+        expect.objectContaining({
+          line: lineSeverityOnly,
+          answer: { type: 'severity_scale', value: 3 },
+        }),
+      );
+    });
+
+    jest.mocked(upsertEpisodeSymptomAnswer).mockClear();
+    jest.mocked(deleteEpisodeSymptomAnswer).mockClear();
+    fireEvent.press(screen.getByLabelText('Severity 3'));
+
+    await waitFor(() => {
+      expect(deleteEpisodeSymptomAnswer).toHaveBeenCalledWith(
+        expect.objectContaining({ mockClient: true }),
+        expect.objectContaining({
+          episodeId,
+          presetSymptomId: lineSeverityOnly.id,
+        }),
+      );
+    });
+    expect(upsertEpisodeSymptomAnswer).not.toHaveBeenCalled();
   });
 
   test('free_text changes debounce to a single upsert', async () => {

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
+import { Alert } from 'react-native';
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import { CommonActions, DefaultTheme } from '@react-navigation/native';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import {
+  deleteEpisodeSymptomAnswer,
   listEpisodeSymptomsForEpisode,
   listPresetSymptomsForPreset,
   upsertEpisodeSymptomAnswer,
@@ -27,6 +29,7 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 jest.mock('@abstrack/supabase', () => ({
+  deleteEpisodeSymptomAnswer: jest.fn(),
   listPresetSymptomsForPreset: jest.fn(),
   listEpisodeSymptomsForEpisode: jest.fn(),
   upsertEpisodeSymptomAnswer: jest.fn(),
@@ -87,6 +90,7 @@ function makeLine(
 describe('SymptomPromptScreen', () => {
   const mockGoBack = jest.fn();
   const mockDispatch = jest.fn();
+  const mockAddListener = jest.fn(() => jest.fn());
 
   const lineA = makeLine('line-a', 0, 'Nausea', 'yes_no');
   const lineB = makeLine('line-b', 1, 'Headache', 'severity_scale');
@@ -106,6 +110,7 @@ describe('SymptomPromptScreen', () => {
     jest.mocked(useNavigation).mockReturnValue({
       goBack: mockGoBack,
       dispatch: mockDispatch,
+      addListener: mockAddListener,
     } as never);
 
     jest.mocked(useAppTheme).mockReturnValue({
@@ -145,6 +150,10 @@ describe('SymptomPromptScreen', () => {
         created_at: '2020-01-01T00:00:00Z',
         updated_at: '2020-01-01T00:00:00Z',
       },
+    });
+    jest.mocked(deleteEpisodeSymptomAnswer).mockResolvedValue({
+      ok: true,
+      data: true,
     });
   });
 
@@ -287,6 +296,7 @@ describe('SymptomPromptScreen', () => {
       expect(screen.getByText('Step 1 of 2')).toBeTruthy();
     });
 
+    fireEvent.press(screen.getByText('yes'));
     fireEvent.press(screen.getByLabelText('Next symptom'));
 
     await waitFor(() => {
@@ -294,9 +304,70 @@ describe('SymptomPromptScreen', () => {
     });
 
     expect(screen.getByText('Headache')).toBeTruthy();
-    expect(setSymptomPromptSession).toHaveBeenCalledWith(episodeId, {
+    expect(setSymptomPromptSession).toHaveBeenLastCalledWith(episodeId, {
       activeIndex: 1,
-      answers: {},
+      answers: { [lineA.id]: { type: 'yes_no', value: true } },
+    });
+  });
+
+  test('only one of Skip and Next is enabled based on answer presence', async () => {
+    const screen = render(<SymptomPromptScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 1 of 2')).toBeTruthy();
+    });
+
+    expect(
+      screen.getByLabelText('Skip this symptom').props.accessibilityState,
+    ).toEqual({
+      disabled: false,
+    });
+    expect(
+      screen.getByLabelText('Next symptom').props.accessibilityState,
+    ).toEqual({
+      disabled: true,
+    });
+
+    fireEvent.press(screen.getByText('yes'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('Skip this symptom').props.accessibilityState,
+      ).toEqual({
+        disabled: true,
+      });
+    });
+    expect(
+      screen.getByLabelText('Next symptom').props.accessibilityState,
+    ).toEqual({
+      disabled: false,
+    });
+  });
+
+  test('Skip advances step and clears persisted answer for current symptom', async () => {
+    const screen = render(<SymptomPromptScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 1 of 2')).toBeTruthy();
+    });
+
+    jest.mocked(deleteEpisodeSymptomAnswer).mockClear();
+    fireEvent.press(screen.getByLabelText('Skip this symptom'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 2 of 2')).toBeTruthy();
+    });
+
+    expect(deleteEpisodeSymptomAnswer).toHaveBeenCalledWith(
+      expect.objectContaining({ mockClient: true }),
+      expect.objectContaining({
+        episodeId,
+        presetSymptomId: lineA.id,
+      }),
+    );
+    expect(setSymptomPromptSession).toHaveBeenCalledWith(episodeId, {
+      activeIndex: 0,
+      answers: { [lineA.id]: { type: 'yes_no', value: null } },
     });
   });
 
@@ -315,16 +386,59 @@ describe('SymptomPromptScreen', () => {
     expect(screen.getByText('Headache')).toBeTruthy();
   });
 
-  test('Back on step 0 calls navigation.goBack', async () => {
+  test('Skip on free-text flushes immediately after answer is cleared', async () => {
+    const lineAfter = makeLine('line-after', 1, 'Headache', 'severity_scale');
+    jest.mocked(listPresetSymptomsForPreset).mockResolvedValue({
+      ok: true,
+      data: [lineFreeOnly, lineAfter],
+    });
     const screen = render(<SymptomPromptScreen />);
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Go back to previous screen')).toBeTruthy();
+      expect(screen.getByText('Step 1 of 2')).toBeTruthy();
     });
 
-    fireEvent.press(screen.getByLabelText('Go back to previous screen'));
+    fireEvent.changeText(screen.getByLabelText('Notes notes'), 'draft text');
+    jest.mocked(deleteEpisodeSymptomAnswer).mockClear();
 
-    expect(mockGoBack).toHaveBeenCalled();
+    const skipButton = screen.getByLabelText('Skip this symptom');
+    expect(skipButton.props.accessibilityState).toEqual({ disabled: true });
+
+    fireEvent.changeText(screen.getByLabelText('Notes notes'), '');
+    fireEvent.press(screen.getByLabelText('Skip this symptom'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 2 of 2')).toBeTruthy();
+    });
+
+    expect(deleteEpisodeSymptomAnswer).toHaveBeenCalledWith(
+      expect.objectContaining({ mockClient: true }),
+      expect.objectContaining({
+        episodeId,
+        presetSymptomId: lineFreeOnly.id,
+      }),
+    );
+  });
+
+  test('Exit symptom flow asks for confirmation before leaving', async () => {
+    const screen = render(<SymptomPromptScreen />);
+    const alertSpy = jest
+      .spyOn(Alert, 'alert')
+      .mockImplementation(() => undefined);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Exit symptom flow')).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByLabelText('Exit symptom flow'));
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Exit symptom flow?',
+      'If you exit now, you will return home. Starting again creates a new episode.',
+      expect.any(Array),
+    );
+    expect(mockGoBack).not.toHaveBeenCalled();
+    alertSpy.mockRestore();
   });
 
   test('changing symptomPresetId after completion shows prompting again for new lines', async () => {
@@ -342,10 +456,12 @@ describe('SymptomPromptScreen', () => {
       expect(screen.getByText('Step 1 of 2')).toBeTruthy();
     });
 
+    fireEvent.press(screen.getByText('yes'));
     fireEvent.press(screen.getByLabelText('Next symptom'));
     await waitFor(() => {
       expect(screen.getByLabelText('Finish symptom list')).toBeTruthy();
     });
+    fireEvent.press(screen.getByLabelText('Severity 1'));
     fireEvent.press(screen.getByLabelText('Finish symptom list'));
 
     await waitFor(() => {
@@ -386,12 +502,14 @@ describe('SymptomPromptScreen', () => {
       expect(screen.getByText('Step 1 of 2')).toBeTruthy();
     });
 
+    fireEvent.press(screen.getByText('yes'));
     fireEvent.press(screen.getByLabelText('Next symptom'));
 
     await waitFor(() => {
       expect(screen.getByLabelText('Finish symptom list')).toBeTruthy();
     });
 
+    fireEvent.press(screen.getByLabelText('Severity 1'));
     fireEvent.press(screen.getByLabelText('Finish symptom list'));
 
     await waitFor(() => {

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -259,6 +259,11 @@ export function SymptomPromptScreen() {
    */
   const schedulePersistToSupabase = useCallback(
     (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
+      if (!symptomPromptAnswerHasValue(answer)) {
+        cancelPendingServerPersist();
+        executeServerDelete(line);
+        return;
+      }
       if (answer.type === 'free_text') {
         pendingServerFreeTextPersistRef.current = { line, answer };
         if (serverPersistTimerRef.current !== null) {
@@ -281,7 +286,7 @@ export function SymptomPromptScreen() {
         executeServerPersist(line, answer);
       }
     },
-    [executeServerPersist],
+    [cancelPendingServerPersist, executeServerDelete, executeServerPersist],
   );
 
   useEffect(() => {
@@ -456,10 +461,11 @@ export function SymptomPromptScreen() {
 
   const requestExitToPreviousScreen = useCallback(() => {
     confirmExitFlow(() => {
+      flushPendingServerPersist();
       allowRemovalRef.current = true;
       navigation.goBack();
     });
-  }, [confirmExitFlow, navigation]);
+  }, [confirmExitFlow, flushPendingServerPersist, navigation]);
 
   useEffect(() => {
     const unsub = navigation.addListener('beforeRemove', (e) => {
@@ -469,12 +475,13 @@ export function SymptomPromptScreen() {
       }
       e.preventDefault();
       confirmExitFlow(() => {
+        flushPendingServerPersist();
         allowRemovalRef.current = true;
         navigation.dispatch(e.data.action);
       });
     });
     return unsub;
-  }, [confirmExitFlow, navigation, phase]);
+  }, [confirmExitFlow, flushPendingServerPersist, navigation, phase]);
 
   const onExitFlowPress = () => {
     requestExitToPreviousScreen();

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -104,12 +104,11 @@ export function SymptomPromptScreen() {
   /** Bumps on each `load()` start and on effect cleanup so in-flight loads ignore stale results after unmount, retry, or param change. */
   const loadGenRef = useRef(0);
   /**
-   * Latest server-persist generation. Incremented per {@link executeServerPersist} attempt and
-   * before flush on episode change / unmount so older in-flight writes cannot update {@link persistError}.
-   * Each attempt also captures the episode id at call time so a flushed write after navigation cannot
-   * surface errors for the wrong episode ({@link executeServerPersist}).
+   * Bumped on episode change, unmount, and {@link cancelPendingServerPersist}. Each write captures
+   * the epoch at enqueue time (not per write) so parallel writes to different lines still report
+   * their own completion/errors.
    */
-  const serverPersistGenerationRef = useRef(0);
+  const serverPersistEpochRef = useRef(0);
   const allowRemovalRef = useRef(false);
 
   /**
@@ -141,11 +140,6 @@ export function SymptomPromptScreen() {
     activeIndexRef.current = activeIndex;
   }, [activeIndex]);
 
-  /**
-   * Each call bumps {@link serverPersistGenerationRef} and captures the current episode id so flushes
-   * during navigation still write to the correct episode and do not update {@link persistError} for
-   * the wrong screen after the route has advanced.
-   */
   const executeServerPersist = useCallback(
     (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
       const queues = lineWriteQueueRef.current;
@@ -156,10 +150,10 @@ export function SymptomPromptScreen() {
         })
         .then(async () => {
           const targetEpisodeId = episodeIdRef.current;
-          const generation = ++serverPersistGenerationRef.current;
+          const epochAtStart = serverPersistEpochRef.current;
           const supabase = getMobileSupabaseClient();
           const uid = await resolveSessionUserId(supabase);
-          if (generation !== serverPersistGenerationRef.current) {
+          if (epochAtStart !== serverPersistEpochRef.current) {
             return;
           }
           if (!uid) {
@@ -176,7 +170,7 @@ export function SymptomPromptScreen() {
             line,
             answer,
           });
-          if (generation !== serverPersistGenerationRef.current) {
+          if (epochAtStart !== serverPersistEpochRef.current) {
             return;
           }
           if (episodeIdRef.current !== targetEpisodeId) {
@@ -208,10 +202,10 @@ export function SymptomPromptScreen() {
         })
         .then(async () => {
           const targetEpisodeId = episodeIdRef.current;
-          const generation = ++serverPersistGenerationRef.current;
+          const epochAtStart = serverPersistEpochRef.current;
           const supabase = getMobileSupabaseClient();
           const uid = await resolveSessionUserId(supabase);
-          if (generation !== serverPersistGenerationRef.current) {
+          if (epochAtStart !== serverPersistEpochRef.current) {
             return;
           }
           if (!uid) {
@@ -226,7 +220,7 @@ export function SymptomPromptScreen() {
             episodeId: targetEpisodeId,
             presetSymptomId: line.id,
           });
-          if (generation !== serverPersistGenerationRef.current) {
+          if (epochAtStart !== serverPersistEpochRef.current) {
             return;
           }
           if (episodeIdRef.current !== targetEpisodeId) {
@@ -276,7 +270,7 @@ export function SymptomPromptScreen() {
       serverPersistTimerRef.current = null;
     }
     pendingServerFreeTextPersistRef.current = null;
-    serverPersistGenerationRef.current += 1;
+    serverPersistEpochRef.current += 1;
   }, []);
 
   /**
@@ -317,7 +311,7 @@ export function SymptomPromptScreen() {
 
   useEffect(() => {
     return () => {
-      serverPersistGenerationRef.current += 1;
+      serverPersistEpochRef.current += 1;
       flushPendingServerPersist();
     };
   }, [flushPendingServerPersist]);
@@ -411,7 +405,7 @@ export function SymptomPromptScreen() {
   }, [load]);
 
   useLayoutEffect(() => {
-    serverPersistGenerationRef.current += 1;
+    serverPersistEpochRef.current += 1;
     flushPendingServerPersist();
     episodeIdRef.current = episodeId;
     const s = getSymptomPromptSession(episodeId);

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -241,6 +241,19 @@ export function SymptomPromptScreen() {
   }, [executeServerPersist]);
 
   /**
+   * Cancels pending debounced free-text upserts and invalidates older in-flight persists.
+   * Used on skip/delete so delayed upserts cannot recreate deleted symptom rows.
+   */
+  const cancelPendingServerPersist = useCallback(() => {
+    if (serverPersistTimerRef.current !== null) {
+      clearTimeout(serverPersistTimerRef.current);
+      serverPersistTimerRef.current = null;
+    }
+    pendingServerFreeTextPersistRef.current = null;
+    serverPersistGenerationRef.current += 1;
+  }, []);
+
+  /**
    * Schedules or runs a server upsert. User id is **not** read here: {@link executeServerPersist}
    * always calls {@link resolveSessionUserId} so the first answer after load cannot silently skip.
    */
@@ -493,7 +506,7 @@ export function SymptomPromptScreen() {
     if (!currentLine) {
       return;
     }
-    flushPendingServerPersist();
+    cancelPendingServerPersist();
     const skippedAnswer = createDefaultSymptomPromptAnswer(
       currentLine.response_type,
     );

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -142,6 +142,9 @@ export function SymptomPromptScreen() {
 
   const executeServerPersist = useCallback(
     (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
+      const enqueueEpisodeId = episodeIdRef.current;
+      const enqueueEpoch = serverPersistEpochRef.current;
+
       const queues = lineWriteQueueRef.current;
       const previous = queues.get(line.id) ?? Promise.resolve();
       const next = previous
@@ -149,15 +152,20 @@ export function SymptomPromptScreen() {
           // Keep the chain alive so later writes still run.
         })
         .then(async () => {
-          const targetEpisodeId = episodeIdRef.current;
-          const epochAtStart = serverPersistEpochRef.current;
+          if (enqueueEpoch !== serverPersistEpochRef.current) {
+            return;
+          }
+          const targetEpisodeId = enqueueEpisodeId;
           const supabase = getMobileSupabaseClient();
           const uid = await resolveSessionUserId(supabase);
-          if (epochAtStart !== serverPersistEpochRef.current) {
+          if (enqueueEpoch !== serverPersistEpochRef.current) {
             return;
           }
           if (!uid) {
-            if (episodeIdRef.current === targetEpisodeId) {
+            if (
+              episodeIdRef.current === enqueueEpisodeId &&
+              enqueueEpoch === serverPersistEpochRef.current
+            ) {
               setPersistError(
                 'Your session could not be verified. Try signing in again.',
               );
@@ -170,10 +178,10 @@ export function SymptomPromptScreen() {
             line,
             answer,
           });
-          if (epochAtStart !== serverPersistEpochRef.current) {
+          if (enqueueEpoch !== serverPersistEpochRef.current) {
             return;
           }
-          if (episodeIdRef.current !== targetEpisodeId) {
+          if (episodeIdRef.current !== enqueueEpisodeId) {
             return;
           }
           if (!r.ok) {
@@ -194,6 +202,9 @@ export function SymptomPromptScreen() {
 
   const executeServerDelete = useCallback(
     (line: PresetSymptomRow) => {
+      const enqueueEpisodeId = episodeIdRef.current;
+      const enqueueEpoch = serverPersistEpochRef.current;
+
       const queues = lineWriteQueueRef.current;
       const previous = queues.get(line.id) ?? Promise.resolve();
       const next = previous
@@ -201,15 +212,20 @@ export function SymptomPromptScreen() {
           // Keep the chain alive so later writes still run.
         })
         .then(async () => {
-          const targetEpisodeId = episodeIdRef.current;
-          const epochAtStart = serverPersistEpochRef.current;
+          if (enqueueEpoch !== serverPersistEpochRef.current) {
+            return;
+          }
+          const targetEpisodeId = enqueueEpisodeId;
           const supabase = getMobileSupabaseClient();
           const uid = await resolveSessionUserId(supabase);
-          if (epochAtStart !== serverPersistEpochRef.current) {
+          if (enqueueEpoch !== serverPersistEpochRef.current) {
             return;
           }
           if (!uid) {
-            if (episodeIdRef.current === targetEpisodeId) {
+            if (
+              episodeIdRef.current === enqueueEpisodeId &&
+              enqueueEpoch === serverPersistEpochRef.current
+            ) {
               setPersistError(
                 'Your session could not be verified. Try signing in again.',
               );
@@ -220,10 +236,10 @@ export function SymptomPromptScreen() {
             episodeId: targetEpisodeId,
             presetSymptomId: line.id,
           });
-          if (epochAtStart !== serverPersistEpochRef.current) {
+          if (enqueueEpoch !== serverPersistEpochRef.current) {
             return;
           }
-          if (episodeIdRef.current !== targetEpisodeId) {
+          if (episodeIdRef.current !== enqueueEpisodeId) {
             return;
           }
           if (!r.ok) {

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -104,11 +104,12 @@ export function SymptomPromptScreen() {
   /** Bumps on each `load()` start and on effect cleanup so in-flight loads ignore stale results after unmount, retry, or param change. */
   const loadGenRef = useRef(0);
   /**
-   * Bumped on episode change, unmount, and {@link cancelPendingServerPersist}. Each write captures
-   * the epoch at enqueue time (not per write) so parallel writes to different lines still report
-   * their own completion/errors.
+   * Bumped only by {@link cancelPendingServerPersist}. Gates {@link setPersistError} when a cancel
+   * invalidates UI feedback; queued writes still run for the episode id captured at enqueue time.
    */
   const serverPersistEpochRef = useRef(0);
+  /** Suppresses {@link setPersistError} after unmount. */
+  const isMountedRef = useRef(true);
   const allowRemovalRef = useRef(false);
 
   /**
@@ -140,6 +141,13 @@ export function SymptomPromptScreen() {
     activeIndexRef.current = activeIndex;
   }, [activeIndex]);
 
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
   const executeServerPersist = useCallback(
     (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
       const enqueueEpisodeId = episodeIdRef.current;
@@ -152,17 +160,12 @@ export function SymptomPromptScreen() {
           // Keep the chain alive so later writes still run.
         })
         .then(async () => {
-          if (enqueueEpoch !== serverPersistEpochRef.current) {
-            return;
-          }
           const targetEpisodeId = enqueueEpisodeId;
           const supabase = getMobileSupabaseClient();
           const uid = await resolveSessionUserId(supabase);
-          if (enqueueEpoch !== serverPersistEpochRef.current) {
-            return;
-          }
           if (!uid) {
             if (
+              isMountedRef.current &&
               episodeIdRef.current === enqueueEpisodeId &&
               enqueueEpoch === serverPersistEpochRef.current
             ) {
@@ -179,6 +182,9 @@ export function SymptomPromptScreen() {
             answer,
           });
           if (enqueueEpoch !== serverPersistEpochRef.current) {
+            return;
+          }
+          if (!isMountedRef.current) {
             return;
           }
           if (episodeIdRef.current !== enqueueEpisodeId) {
@@ -212,17 +218,12 @@ export function SymptomPromptScreen() {
           // Keep the chain alive so later writes still run.
         })
         .then(async () => {
-          if (enqueueEpoch !== serverPersistEpochRef.current) {
-            return;
-          }
           const targetEpisodeId = enqueueEpisodeId;
           const supabase = getMobileSupabaseClient();
           const uid = await resolveSessionUserId(supabase);
-          if (enqueueEpoch !== serverPersistEpochRef.current) {
-            return;
-          }
           if (!uid) {
             if (
+              isMountedRef.current &&
               episodeIdRef.current === enqueueEpisodeId &&
               enqueueEpoch === serverPersistEpochRef.current
             ) {
@@ -237,6 +238,9 @@ export function SymptomPromptScreen() {
             presetSymptomId: line.id,
           });
           if (enqueueEpoch !== serverPersistEpochRef.current) {
+            return;
+          }
+          if (!isMountedRef.current) {
             return;
           }
           if (episodeIdRef.current !== enqueueEpisodeId) {
@@ -327,7 +331,8 @@ export function SymptomPromptScreen() {
 
   useEffect(() => {
     return () => {
-      serverPersistEpochRef.current += 1;
+      // Do not bump serverPersistEpochRef here — queued per-line writes should still reach Supabase;
+      // isMountedRef gates setPersistError after unmount.
       flushPendingServerPersist();
     };
   }, [flushPendingServerPersist]);
@@ -421,7 +426,6 @@ export function SymptomPromptScreen() {
   }, [load]);
 
   useLayoutEffect(() => {
-    serverPersistEpochRef.current += 1;
     flushPendingServerPersist();
     episodeIdRef.current = episodeId;
     const s = getSymptomPromptSession(episodeId);

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -495,13 +495,24 @@ export function SymptomPromptScreen() {
     );
   }, []);
 
-  const requestExitToPreviousScreen = useCallback(() => {
+  /** Matches {@link onFinishToHome}: reset stack to MainTabs so copy matches behavior (not `goBack`). */
+  const exitSymptomFlowToHome = useCallback(() => {
+    flushPendingServerPersist();
+    clearSymptomPromptSession(episodeId);
+    allowRemovalRef.current = true;
+    navigation.dispatch(
+      CommonActions.reset({
+        index: 0,
+        routes: [{ name: 'MainTabs' }],
+      }),
+    );
+  }, [episodeId, flushPendingServerPersist, navigation]);
+
+  const requestExitToHome = useCallback(() => {
     confirmExitFlow(() => {
-      flushPendingServerPersist();
-      allowRemovalRef.current = true;
-      navigation.goBack();
+      exitSymptomFlowToHome();
     });
-  }, [confirmExitFlow, flushPendingServerPersist, navigation]);
+  }, [confirmExitFlow, exitSymptomFlowToHome]);
 
   useEffect(() => {
     const unsub = navigation.addListener('beforeRemove', (e) => {
@@ -511,16 +522,14 @@ export function SymptomPromptScreen() {
       }
       e.preventDefault();
       confirmExitFlow(() => {
-        flushPendingServerPersist();
-        allowRemovalRef.current = true;
-        navigation.dispatch(e.data.action);
+        exitSymptomFlowToHome();
       });
     });
     return unsub;
-  }, [confirmExitFlow, flushPendingServerPersist, navigation, phase]);
+  }, [confirmExitFlow, exitSymptomFlowToHome, navigation, phase]);
 
   const onExitFlowPress = () => {
-    requestExitToPreviousScreen();
+    requestExitToHome();
   };
 
   const advanceToNextStep = () => {
@@ -675,24 +684,22 @@ export function SymptomPromptScreen() {
                 ) : null}
 
                 <View className="mt-6 gap-3">
-                  <Pressable
-                    accessibilityRole="button"
-                    accessibilityLabel="Previous symptom"
-                    accessibilityState={{ disabled: activeIndex === 0 }}
-                    disabled={activeIndex === 0}
-                    onPress={goBackStep}
-                    style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                    className={`w-full items-center justify-center rounded-xl border-2 border-app-border bg-app-bg px-3 py-4 dark:border-app-border-dark dark:bg-app-bg-dark ${
-                      activeIndex === 0 ? 'opacity-50' : 'active:opacity-90'
-                    }`}
-                  >
-                    <Text
-                      className={`text-center text-[17px] font-semibold ${nw.textInk}`}
-                      maxFontSizeMultiplier={2}
+                  {activeIndex > 0 ? (
+                    <Pressable
+                      accessibilityRole="button"
+                      accessibilityLabel="Previous symptom"
+                      onPress={goBackStep}
+                      style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                      className="w-full items-center justify-center rounded-xl border-2 border-app-border bg-app-bg px-3 py-4 active:opacity-90 dark:border-app-border-dark dark:bg-app-bg-dark"
                     >
-                      Back
-                    </Text>
-                  </Pressable>
+                      <Text
+                        className={`text-center text-[17px] font-semibold ${nw.textInk}`}
+                        maxFontSizeMultiplier={2}
+                      >
+                        Back
+                      </Text>
+                    </Pressable>
+                  ) : null}
                   {currentLine ? (
                     <Pressable
                       accessibilityRole="button"

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -17,9 +17,12 @@ import type {
   PresetSymptomRow,
   SymptomPromptAnswer,
   SymptomPromptAnswers,
-  SymptomResponseType,
 } from '@abstrack/types';
-import { episodeSymptomRowsToAnswersMap } from '@abstrack/types';
+import {
+  createDefaultSymptomPromptAnswer,
+  episodeSymptomRowsToAnswersMap,
+  symptomPromptAnswerHasValue,
+} from '@abstrack/types';
 import {
   deleteEpisodeSymptomAnswer,
   listEpisodeSymptomsForEpisode,
@@ -55,46 +58,6 @@ function clampIndex(index: number, length: number): number {
   }
   const i = Math.trunc(index);
   return Math.max(0, Math.min(i, length - 1));
-}
-
-function defaultAnswerForType(type: SymptomResponseType): SymptomPromptAnswer {
-  switch (type) {
-    case 'yes_no':
-      return { type: 'yes_no', value: null };
-    case 'severity_scale':
-      return { type: 'severity_scale', value: null };
-    case 'free_text':
-      return { type: 'free_text', value: '' };
-    case 'photo':
-      return { type: 'photo', value: null };
-    case 'video':
-      return { type: 'video', value: null };
-    default: {
-      const _exhaustive: never = type;
-      return _exhaustive;
-    }
-  }
-}
-
-function hasAnswerValue(answer: SymptomPromptAnswer | undefined): boolean {
-  if (!answer) {
-    return false;
-  }
-  switch (answer.type) {
-    case 'yes_no':
-      return answer.value !== null;
-    case 'severity_scale':
-      return answer.value !== null;
-    case 'free_text':
-      return answer.value.trim().length > 0;
-    case 'photo':
-    case 'video':
-      return false;
-    default: {
-      const _exhaustive: never = answer;
-      return _exhaustive;
-    }
-  }
 }
 
 /** Debounce Supabase writes for free-text answers (matches web episode flow). */
@@ -421,7 +384,7 @@ export function SymptomPromptScreen() {
 
   const currentLine = lines[activeIndex] ?? null;
   const currentAnswer = currentLine ? answers[currentLine.id] : undefined;
-  const currentLineAnswered = hasAnswerValue(currentAnswer);
+  const currentLineAnswered = symptomPromptAnswerHasValue(currentAnswer);
   const canProceedWithNext = !currentLine || currentLineAnswered;
   const canSkipCurrentLine = Boolean(currentLine) && !currentLineAnswered;
   const stepLabel =
@@ -531,7 +494,9 @@ export function SymptomPromptScreen() {
       return;
     }
     flushPendingServerPersist();
-    const skippedAnswer = defaultAnswerForType(currentLine.response_type);
+    const skippedAnswer = createDefaultSymptomPromptAnswer(
+      currentLine.response_type,
+    );
     const merged: SymptomPromptAnswers = {
       ...answersRef.current,
       [currentLine.id]: skippedAnswer,

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -98,6 +98,8 @@ export function SymptomPromptScreen() {
     line: PresetSymptomRow;
     answer: SymptomPromptAnswer;
   } | null>(null);
+  /** Per-line write queue so upsert/delete requests execute in user action order. */
+  const lineWriteQueueRef = useRef<Map<string, Promise<void>>>(new Map());
   const userIdRef = useRef<string | null>(null);
   /** Bumps on each `load()` start and on effect cleanup so in-flight loads ignore stale results after unmount, retry, or param change. */
   const loadGenRef = useRef(0);
@@ -146,78 +148,102 @@ export function SymptomPromptScreen() {
    */
   const executeServerPersist = useCallback(
     (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
-      const targetEpisodeId = episodeIdRef.current;
-      const generation = ++serverPersistGenerationRef.current;
-      void (async () => {
-        const supabase = getMobileSupabaseClient();
-        const uid = await resolveSessionUserId(supabase);
-        if (generation !== serverPersistGenerationRef.current) {
-          return;
-        }
-        if (!uid) {
-          if (episodeIdRef.current === targetEpisodeId) {
-            setPersistError(
-              'Your session could not be verified. Try signing in again.',
-            );
+      const queues = lineWriteQueueRef.current;
+      const previous = queues.get(line.id) ?? Promise.resolve();
+      const next = previous
+        .catch(() => {
+          // Keep the chain alive so later writes still run.
+        })
+        .then(async () => {
+          const targetEpisodeId = episodeIdRef.current;
+          const generation = ++serverPersistGenerationRef.current;
+          const supabase = getMobileSupabaseClient();
+          const uid = await resolveSessionUserId(supabase);
+          if (generation !== serverPersistGenerationRef.current) {
+            return;
           }
-          return;
-        }
-        const r = await upsertEpisodeSymptomAnswer(supabase, {
-          userId: uid,
-          episodeId: targetEpisodeId,
-          line,
-          answer,
+          if (!uid) {
+            if (episodeIdRef.current === targetEpisodeId) {
+              setPersistError(
+                'Your session could not be verified. Try signing in again.',
+              );
+            }
+            return;
+          }
+          const r = await upsertEpisodeSymptomAnswer(supabase, {
+            userId: uid,
+            episodeId: targetEpisodeId,
+            line,
+            answer,
+          });
+          if (generation !== serverPersistGenerationRef.current) {
+            return;
+          }
+          if (episodeIdRef.current !== targetEpisodeId) {
+            return;
+          }
+          if (!r.ok) {
+            setPersistError(r.error.message);
+          } else {
+            setPersistError(null);
+          }
         });
-        if (generation !== serverPersistGenerationRef.current) {
-          return;
+      queues.set(line.id, next);
+      void next.finally(() => {
+        if (queues.get(line.id) === next) {
+          queues.delete(line.id);
         }
-        if (episodeIdRef.current !== targetEpisodeId) {
-          return;
-        }
-        if (!r.ok) {
-          setPersistError(r.error.message);
-        } else {
-          setPersistError(null);
-        }
-      })();
+      });
     },
     [resolveSessionUserId],
   );
 
   const executeServerDelete = useCallback(
     (line: PresetSymptomRow) => {
-      const targetEpisodeId = episodeIdRef.current;
-      const generation = ++serverPersistGenerationRef.current;
-      void (async () => {
-        const supabase = getMobileSupabaseClient();
-        const uid = await resolveSessionUserId(supabase);
-        if (generation !== serverPersistGenerationRef.current) {
-          return;
-        }
-        if (!uid) {
-          if (episodeIdRef.current === targetEpisodeId) {
-            setPersistError(
-              'Your session could not be verified. Try signing in again.',
-            );
+      const queues = lineWriteQueueRef.current;
+      const previous = queues.get(line.id) ?? Promise.resolve();
+      const next = previous
+        .catch(() => {
+          // Keep the chain alive so later writes still run.
+        })
+        .then(async () => {
+          const targetEpisodeId = episodeIdRef.current;
+          const generation = ++serverPersistGenerationRef.current;
+          const supabase = getMobileSupabaseClient();
+          const uid = await resolveSessionUserId(supabase);
+          if (generation !== serverPersistGenerationRef.current) {
+            return;
           }
-          return;
-        }
-        const r = await deleteEpisodeSymptomAnswer(supabase, {
-          episodeId: targetEpisodeId,
-          presetSymptomId: line.id,
+          if (!uid) {
+            if (episodeIdRef.current === targetEpisodeId) {
+              setPersistError(
+                'Your session could not be verified. Try signing in again.',
+              );
+            }
+            return;
+          }
+          const r = await deleteEpisodeSymptomAnswer(supabase, {
+            episodeId: targetEpisodeId,
+            presetSymptomId: line.id,
+          });
+          if (generation !== serverPersistGenerationRef.current) {
+            return;
+          }
+          if (episodeIdRef.current !== targetEpisodeId) {
+            return;
+          }
+          if (!r.ok) {
+            setPersistError(r.error.message);
+          } else {
+            setPersistError(null);
+          }
         });
-        if (generation !== serverPersistGenerationRef.current) {
-          return;
+      queues.set(line.id, next);
+      void next.finally(() => {
+        if (queues.get(line.id) === next) {
+          queues.delete(line.id);
         }
-        if (episodeIdRef.current !== targetEpisodeId) {
-          return;
-        }
-        if (!r.ok) {
-          setPersistError(r.error.message);
-        } else {
-          setPersistError(null);
-        }
-      })();
+      });
     },
     [resolveSessionUserId],
   );

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { Pressable, ScrollView, Text, View } from 'react-native';
+import { Alert, Pressable, ScrollView, Text, View } from 'react-native';
 import type { RouteProp } from '@react-navigation/native';
 import {
   CommonActions,
@@ -17,9 +17,11 @@ import type {
   PresetSymptomRow,
   SymptomPromptAnswer,
   SymptomPromptAnswers,
+  SymptomResponseType,
 } from '@abstrack/types';
 import { episodeSymptomRowsToAnswersMap } from '@abstrack/types';
 import {
+  deleteEpisodeSymptomAnswer,
   listEpisodeSymptomsForEpisode,
   listPresetSymptomsForPreset,
   upsertEpisodeSymptomAnswer,
@@ -53,6 +55,46 @@ function clampIndex(index: number, length: number): number {
   }
   const i = Math.trunc(index);
   return Math.max(0, Math.min(i, length - 1));
+}
+
+function defaultAnswerForType(type: SymptomResponseType): SymptomPromptAnswer {
+  switch (type) {
+    case 'yes_no':
+      return { type: 'yes_no', value: null };
+    case 'severity_scale':
+      return { type: 'severity_scale', value: null };
+    case 'free_text':
+      return { type: 'free_text', value: '' };
+    case 'photo':
+      return { type: 'photo', value: null };
+    case 'video':
+      return { type: 'video', value: null };
+    default: {
+      const _exhaustive: never = type;
+      return _exhaustive;
+    }
+  }
+}
+
+function hasAnswerValue(answer: SymptomPromptAnswer | undefined): boolean {
+  if (!answer) {
+    return false;
+  }
+  switch (answer.type) {
+    case 'yes_no':
+      return answer.value !== null;
+    case 'severity_scale':
+      return answer.value !== null;
+    case 'free_text':
+      return answer.value.trim().length > 0;
+    case 'photo':
+    case 'video':
+      return false;
+    default: {
+      const _exhaustive: never = answer;
+      return _exhaustive;
+    }
+  }
 }
 
 /** Debounce Supabase writes for free-text answers (matches web episode flow). */
@@ -103,6 +145,7 @@ export function SymptomPromptScreen() {
    * surface errors for the wrong episode ({@link executeServerPersist}).
    */
   const serverPersistGenerationRef = useRef(0);
+  const allowRemovalRef = useRef(false);
 
   /**
    * Caches the auth user id on {@link userIdRef}. Called from {@link load} before `ready`, and
@@ -161,6 +204,44 @@ export function SymptomPromptScreen() {
           episodeId: targetEpisodeId,
           line,
           answer,
+        });
+        if (generation !== serverPersistGenerationRef.current) {
+          return;
+        }
+        if (episodeIdRef.current !== targetEpisodeId) {
+          return;
+        }
+        if (!r.ok) {
+          setPersistError(r.error.message);
+        } else {
+          setPersistError(null);
+        }
+      })();
+    },
+    [resolveSessionUserId],
+  );
+
+  const executeServerDelete = useCallback(
+    (line: PresetSymptomRow) => {
+      const targetEpisodeId = episodeIdRef.current;
+      const generation = ++serverPersistGenerationRef.current;
+      void (async () => {
+        const supabase = getMobileSupabaseClient();
+        const uid = await resolveSessionUserId(supabase);
+        if (generation !== serverPersistGenerationRef.current) {
+          return;
+        }
+        if (!uid) {
+          if (episodeIdRef.current === targetEpisodeId) {
+            setPersistError(
+              'Your session could not be verified. Try signing in again.',
+            );
+          }
+          return;
+        }
+        const r = await deleteEpisodeSymptomAnswer(supabase, {
+          episodeId: targetEpisodeId,
+          presetSymptomId: line.id,
         });
         if (generation !== serverPersistGenerationRef.current) {
           return;
@@ -339,6 +420,10 @@ export function SymptomPromptScreen() {
   }, [episodeId, symptomPresetId, flushPendingServerPersist]);
 
   const currentLine = lines[activeIndex] ?? null;
+  const currentAnswer = currentLine ? answers[currentLine.id] : undefined;
+  const currentLineAnswered = hasAnswerValue(currentAnswer);
+  const canProceedWithNext = !currentLine || currentLineAnswered;
+  const canSkipCurrentLine = Boolean(currentLine) && !currentLineAnswered;
   const stepLabel =
     lines.length === 0
       ? 'No symptoms'
@@ -368,19 +453,58 @@ export function SymptomPromptScreen() {
   const goBackStep = () => {
     flushPendingServerPersist();
     const idx = activeIndexRef.current;
-    if (idx > 0) {
-      const next = idx - 1;
-      activeIndexRef.current = next;
-      setActiveIndex(next);
-      persist(next, answersRef.current);
-      announce(`Back to step ${next + 1} of ${lines.length}.`);
-    } else {
-      navigation.goBack();
+    if (idx <= 0) {
+      return;
     }
+    const next = idx - 1;
+    activeIndexRef.current = next;
+    setActiveIndex(next);
+    persist(next, answersRef.current);
+    announce(`Back to step ${next + 1} of ${lines.length}.`);
   };
 
-  const goNext = () => {
-    flushPendingServerPersist();
+  const confirmExitFlow = useCallback((action: () => void) => {
+    Alert.alert(
+      'Exit symptom flow?',
+      'If you exit now, you will return home. Starting again creates a new episode.',
+      [
+        { text: 'Stay here', style: 'cancel' },
+        {
+          text: 'Exit',
+          style: 'destructive',
+          onPress: action,
+        },
+      ],
+    );
+  }, []);
+
+  const requestExitToPreviousScreen = useCallback(() => {
+    confirmExitFlow(() => {
+      allowRemovalRef.current = true;
+      navigation.goBack();
+    });
+  }, [confirmExitFlow, navigation]);
+
+  useEffect(() => {
+    const unsub = navigation.addListener('beforeRemove', (e) => {
+      if (allowRemovalRef.current || phase === 'complete') {
+        allowRemovalRef.current = false;
+        return;
+      }
+      e.preventDefault();
+      confirmExitFlow(() => {
+        allowRemovalRef.current = true;
+        navigation.dispatch(e.data.action);
+      });
+    });
+    return unsub;
+  }, [confirmExitFlow, navigation, phase]);
+
+  const onExitFlowPress = () => {
+    requestExitToPreviousScreen();
+  };
+
+  const advanceToNextStep = () => {
     if (lines.length === 0) {
       setPhase('complete');
       return;
@@ -395,6 +519,29 @@ export function SymptomPromptScreen() {
     }
     setPhase('complete');
     announce('Symptom list complete.');
+  };
+
+  const goNext = () => {
+    flushPendingServerPersist();
+    advanceToNextStep();
+  };
+
+  const skipCurrentSymptom = () => {
+    if (!currentLine) {
+      return;
+    }
+    flushPendingServerPersist();
+    const skippedAnswer = defaultAnswerForType(currentLine.response_type);
+    const merged: SymptomPromptAnswers = {
+      ...answersRef.current,
+      [currentLine.id]: skippedAnswer,
+    };
+    answersRef.current = merged;
+    setAnswers(merged);
+    persist(activeIndexRef.current, merged);
+    executeServerDelete(currentLine);
+    announce(`Skipped ${currentLine.symptom_name}.`);
+    advanceToNextStep();
   };
 
   const onFinishToHome = () => {
@@ -449,103 +596,145 @@ export function SymptomPromptScreen() {
             </Pressable>
           </View>
         ) : (
-          <AsyncScreenContainer
-            status={status}
-            loadingAccessibilityLabel="Loading symptom list"
-            errorTitle="Could not load symptoms"
-            errorMessage={errorMessage ?? undefined}
-            onRetry={() => {
-              void load();
-            }}
-          >
-            <ScrollView
-              className="flex-1"
-              keyboardShouldPersistTaps="handled"
-              contentContainerStyle={{ paddingBottom: 24 }}
+          <>
+            <AsyncScreenContainer
+              status={status}
+              loadingAccessibilityLabel="Loading symptom list"
+              errorTitle="Could not load symptoms"
+              errorMessage={errorMessage ?? undefined}
+              onRetry={() => {
+                void load();
+              }}
             >
-              <Text
-                accessibilityRole="text"
-                className={`mb-2 text-base font-medium ${nw.textMuted}`}
-                maxFontSizeMultiplier={2}
+              <ScrollView
+                className="flex-1"
+                keyboardShouldPersistTaps="handled"
+                contentContainerStyle={{ paddingBottom: 24 }}
               >
-                {stepLabel}
-              </Text>
-
-              {lines.length === 0 ? (
                 <Text
-                  className={`text-base leading-relaxed ${nw.textInk}`}
+                  accessibilityRole="text"
+                  className={`mb-2 text-base font-medium ${nw.textMuted}`}
                   maxFontSizeMultiplier={2}
                 >
-                  This preset has no symptoms yet. You can add symptoms under
-                  Templates when you are not in an episode.
+                  {stepLabel}
                 </Text>
-              ) : currentLine ? (
-                <View className="gap-4">
+
+                {lines.length === 0 ? (
                   <Text
-                    accessibilityRole="header"
-                    className={`text-xl font-semibold ${nw.textInk}`}
+                    className={`text-base leading-relaxed ${nw.textInk}`}
                     maxFontSizeMultiplier={2}
                   >
-                    {currentLine.symptom_name}
+                    This preset has no symptoms yet. You can add symptoms under
+                    Templates when you are not in an episode.
                   </Text>
-                  {currentLine.prompt_instruction ? (
+                ) : currentLine ? (
+                  <View className="gap-4">
                     <Text
-                      className={`text-base leading-relaxed ${nw.textMuted}`}
+                      accessibilityRole="header"
+                      className={`text-xl font-semibold ${nw.textInk}`}
                       maxFontSizeMultiplier={2}
                     >
-                      {currentLine.prompt_instruction}
+                      {currentLine.symptom_name}
                     </Text>
-                  ) : null}
-                  <SymptomPromptResponseField
-                    line={currentLine}
-                    answer={answers[currentLine.id]}
-                    onChange={onChangeAnswer}
-                    disabled={status !== 'ready'}
-                  />
-                </View>
-              ) : null}
+                    {currentLine.prompt_instruction ? (
+                      <Text
+                        className={`text-base leading-relaxed ${nw.textMuted}`}
+                        maxFontSizeMultiplier={2}
+                      >
+                        {currentLine.prompt_instruction}
+                      </Text>
+                    ) : null}
+                    <SymptomPromptResponseField
+                      line={currentLine}
+                      answer={answers[currentLine.id]}
+                      onChange={onChangeAnswer}
+                      disabled={status !== 'ready'}
+                    />
+                  </View>
+                ) : null}
 
-              <View className="mt-6 flex-row gap-3">
-                <Pressable
-                  accessibilityRole="button"
-                  accessibilityLabel={
-                    activeIndex === 0
-                      ? 'Go back to previous screen'
-                      : 'Previous symptom'
-                  }
-                  onPress={goBackStep}
-                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                  className="min-w-[120px] flex-1 items-center justify-center rounded-xl border-2 border-app-border bg-app-bg px-3 py-4 active:opacity-90 dark:border-app-border-dark dark:bg-app-bg-dark"
-                >
-                  <Text
-                    className={`text-center text-[17px] font-semibold ${nw.textInk}`}
-                    maxFontSizeMultiplier={2}
+                <View className="mt-6 gap-3">
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Previous symptom"
+                    accessibilityState={{ disabled: activeIndex === 0 }}
+                    disabled={activeIndex === 0}
+                    onPress={goBackStep}
+                    style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                    className={`w-full items-center justify-center rounded-xl border-2 border-app-border bg-app-bg px-3 py-4 dark:border-app-border-dark dark:bg-app-bg-dark ${
+                      activeIndex === 0 ? 'opacity-50' : 'active:opacity-90'
+                    }`}
                   >
-                    {activeIndex === 0 ? 'Exit' : 'Back'}
-                  </Text>
-                </Pressable>
-                <Pressable
-                  accessibilityRole="button"
-                  accessibilityLabel={
-                    lines.length > 0 && activeIndex >= lines.length - 1
-                      ? 'Finish symptom list'
-                      : 'Next symptom'
-                  }
-                  onPress={goNext}
-                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                  className="min-w-[120px] flex-1 items-center justify-center rounded-xl bg-red-700 px-3 py-4 active:opacity-90 dark:bg-red-600"
-                >
-                  <Text className="text-center text-[17px] font-semibold text-white">
-                    {lines.length === 0
-                      ? 'Done'
-                      : activeIndex >= lines.length - 1
-                        ? 'Finish'
-                        : 'Next'}
-                  </Text>
-                </Pressable>
-              </View>
-            </ScrollView>
-          </AsyncScreenContainer>
+                    <Text
+                      className={`text-center text-[17px] font-semibold ${nw.textInk}`}
+                      maxFontSizeMultiplier={2}
+                    >
+                      Back
+                    </Text>
+                  </Pressable>
+                  {currentLine ? (
+                    <Pressable
+                      accessibilityRole="button"
+                      accessibilityLabel="Skip this symptom"
+                      accessibilityState={{ disabled: !canSkipCurrentLine }}
+                      disabled={!canSkipCurrentLine}
+                      onPress={skipCurrentSymptom}
+                      style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                      className={`w-full items-center justify-center rounded-xl border-2 border-app-border bg-app-bg px-3 py-4 dark:border-app-border-dark dark:bg-app-bg-dark ${
+                        canSkipCurrentLine ? 'active:opacity-90' : 'opacity-50'
+                      }`}
+                    >
+                      <Text
+                        className={`text-center text-[17px] font-semibold ${nw.textInk}`}
+                        maxFontSizeMultiplier={2}
+                      >
+                        Skip
+                      </Text>
+                    </Pressable>
+                  ) : null}
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel={
+                      lines.length > 0 && activeIndex >= lines.length - 1
+                        ? 'Finish symptom list'
+                        : 'Next symptom'
+                    }
+                    accessibilityState={{ disabled: !canProceedWithNext }}
+                    disabled={!canProceedWithNext}
+                    onPress={goNext}
+                    style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                    className={`w-full items-center justify-center rounded-xl px-3 py-4 dark:bg-red-600 ${
+                      canProceedWithNext
+                        ? 'bg-red-700 active:opacity-90'
+                        : 'bg-red-400 opacity-60 dark:bg-red-800'
+                    }`}
+                  >
+                    <Text className="text-center text-[17px] font-semibold text-white">
+                      {lines.length === 0
+                        ? 'Done'
+                        : activeIndex >= lines.length - 1
+                          ? 'Finish'
+                          : 'Next'}
+                    </Text>
+                  </Pressable>
+                </View>
+              </ScrollView>
+            </AsyncScreenContainer>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Exit symptom flow"
+              onPress={onExitFlowPress}
+              style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+              className="mt-auto w-full items-center justify-center rounded-lg px-3 py-3 active:opacity-80"
+            >
+              <Text
+                className={`text-base font-medium ${nw.textMuted}`}
+                maxFontSizeMultiplier={2}
+              >
+                Exit symptom flow
+              </Text>
+            </Pressable>
+          </>
         )}
       </View>
     </ScreenShell>

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -60,6 +60,11 @@ function clampIndex(index: number, length: number): number {
   return Math.max(0, Math.min(i, length - 1));
 }
 
+/** Queue key so the same preset symptom id does not serialize writes across episodes. */
+function lineWriteQueueKey(episodeId: string, presetSymptomId: string): string {
+  return `${episodeId}:${presetSymptomId}`;
+}
+
 /** Debounce Supabase writes for free-text answers (matches web episode flow). */
 const SERVER_SYMPTOM_PERSIST_DEBOUNCE_MS = 300;
 
@@ -98,7 +103,10 @@ export function SymptomPromptScreen() {
     line: PresetSymptomRow;
     answer: SymptomPromptAnswer;
   } | null>(null);
-  /** Per-line write queue so upsert/delete requests execute in user action order. */
+  /**
+   * Per (episode, preset symptom) write queue — ordering is within the active episode only, not
+   * across `episodeId` changes while this screen stays mounted.
+   */
   const lineWriteQueueRef = useRef<Map<string, Promise<void>>>(new Map());
   const userIdRef = useRef<string | null>(null);
   /** Bumps on each `load()` start and on effect cleanup so in-flight loads ignore stale results after unmount, retry, or param change. */
@@ -152,9 +160,10 @@ export function SymptomPromptScreen() {
     (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
       const enqueueEpisodeId = episodeIdRef.current;
       const enqueueEpoch = serverPersistEpochRef.current;
+      const queueKey = lineWriteQueueKey(enqueueEpisodeId, line.id);
 
       const queues = lineWriteQueueRef.current;
-      const previous = queues.get(line.id) ?? Promise.resolve();
+      const previous = queues.get(queueKey) ?? Promise.resolve();
       const next = previous
         .catch(() => {
           // Keep the chain alive so later writes still run.
@@ -196,10 +205,10 @@ export function SymptomPromptScreen() {
             setPersistError(null);
           }
         });
-      queues.set(line.id, next);
+      queues.set(queueKey, next);
       void next.finally(() => {
-        if (queues.get(line.id) === next) {
-          queues.delete(line.id);
+        if (queues.get(queueKey) === next) {
+          queues.delete(queueKey);
         }
       });
     },
@@ -210,9 +219,10 @@ export function SymptomPromptScreen() {
     (line: PresetSymptomRow) => {
       const enqueueEpisodeId = episodeIdRef.current;
       const enqueueEpoch = serverPersistEpochRef.current;
+      const queueKey = lineWriteQueueKey(enqueueEpisodeId, line.id);
 
       const queues = lineWriteQueueRef.current;
-      const previous = queues.get(line.id) ?? Promise.resolve();
+      const previous = queues.get(queueKey) ?? Promise.resolve();
       const next = previous
         .catch(() => {
           // Keep the chain alive so later writes still run.
@@ -252,10 +262,10 @@ export function SymptomPromptScreen() {
             setPersistError(null);
           }
         });
-      queues.set(line.id, next);
+      queues.set(queueKey, next);
       void next.finally(() => {
-        if (queues.get(line.id) === next) {
-          queues.delete(line.id);
+        if (queues.get(queueKey) === next) {
+          queues.delete(queueKey);
         }
       });
     },

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -116,6 +116,11 @@ export function SymptomPromptScreen() {
    * invalidates UI feedback; queued writes still run for the episode id captured at enqueue time.
    */
   const serverPersistEpochRef = useRef(0);
+  /**
+   * Monotonic id per enqueue; only matching completions update {@link setPersistError} so
+   * cross-line out-of-order results cannot clobber a newer failure or success state.
+   */
+  const persistUiAttemptRef = useRef(0);
   /** Suppresses {@link setPersistError} after unmount. */
   const isMountedRef = useRef(true);
   const allowRemovalRef = useRef(false);
@@ -160,6 +165,8 @@ export function SymptomPromptScreen() {
     (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
       const enqueueEpisodeId = episodeIdRef.current;
       const enqueueEpoch = serverPersistEpochRef.current;
+      persistUiAttemptRef.current += 1;
+      const attemptId = persistUiAttemptRef.current;
       const queueKey = lineWriteQueueKey(enqueueEpisodeId, line.id);
 
       const queues = lineWriteQueueRef.current;
@@ -176,7 +183,8 @@ export function SymptomPromptScreen() {
             if (
               isMountedRef.current &&
               episodeIdRef.current === enqueueEpisodeId &&
-              enqueueEpoch === serverPersistEpochRef.current
+              enqueueEpoch === serverPersistEpochRef.current &&
+              attemptId === persistUiAttemptRef.current
             ) {
               setPersistError(
                 'Your session could not be verified. Try signing in again.',
@@ -199,6 +207,9 @@ export function SymptomPromptScreen() {
           if (episodeIdRef.current !== enqueueEpisodeId) {
             return;
           }
+          if (attemptId !== persistUiAttemptRef.current) {
+            return;
+          }
           if (!r.ok) {
             setPersistError(r.error.message);
           } else {
@@ -219,6 +230,8 @@ export function SymptomPromptScreen() {
     (line: PresetSymptomRow) => {
       const enqueueEpisodeId = episodeIdRef.current;
       const enqueueEpoch = serverPersistEpochRef.current;
+      persistUiAttemptRef.current += 1;
+      const attemptId = persistUiAttemptRef.current;
       const queueKey = lineWriteQueueKey(enqueueEpisodeId, line.id);
 
       const queues = lineWriteQueueRef.current;
@@ -235,7 +248,8 @@ export function SymptomPromptScreen() {
             if (
               isMountedRef.current &&
               episodeIdRef.current === enqueueEpisodeId &&
-              enqueueEpoch === serverPersistEpochRef.current
+              enqueueEpoch === serverPersistEpochRef.current &&
+              attemptId === persistUiAttemptRef.current
             ) {
               setPersistError(
                 'Your session could not be verified. Try signing in again.',
@@ -254,6 +268,9 @@ export function SymptomPromptScreen() {
             return;
           }
           if (episodeIdRef.current !== enqueueEpisodeId) {
+            return;
+          }
+          if (attemptId !== persistUiAttemptRef.current) {
             return;
           }
           if (!r.ok) {

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -100,6 +100,8 @@ export function SymptomPromptFlow({
     line: PresetSymptomRow;
     answer: SymptomPromptAnswer;
   } | null>(null);
+  /** Per-line write queue so upsert/delete requests execute in user action order. */
+  const lineWriteQueueRef = useRef<Map<string, Promise<void>>>(new Map());
   const userIdRef = useRef<string | null>(null);
   /** Bumps on each `load()` start and on effect cleanup so in-flight loads ignore stale results after unmount, retry, or param change. */
   const loadGenRef = useRef(0);
@@ -144,76 +146,100 @@ export function SymptomPromptFlow({
 
   const executeServerPersist = useCallback(
     (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
-      const targetEpisodeId = episodeIdRef.current;
-      const generation = ++serverPersistGenerationRef.current;
-      void (async () => {
-        const uid = await resolveSessionUserId(supabase);
-        if (generation !== serverPersistGenerationRef.current) {
-          return;
-        }
-        if (!uid) {
-          if (episodeIdRef.current === targetEpisodeId) {
-            setPersistError(
-              'Your session could not be verified. Try signing in again.',
-            );
+      const queues = lineWriteQueueRef.current;
+      const previous = queues.get(line.id) ?? Promise.resolve();
+      const next = previous
+        .catch(() => {
+          // Keep the chain alive so later writes still run.
+        })
+        .then(async () => {
+          const targetEpisodeId = episodeIdRef.current;
+          const generation = ++serverPersistGenerationRef.current;
+          const uid = await resolveSessionUserId(supabase);
+          if (generation !== serverPersistGenerationRef.current) {
+            return;
           }
-          return;
-        }
-        const r = await upsertEpisodeSymptomAnswer(supabase, {
-          userId: uid,
-          episodeId: targetEpisodeId,
-          line,
-          answer,
+          if (!uid) {
+            if (episodeIdRef.current === targetEpisodeId) {
+              setPersistError(
+                'Your session could not be verified. Try signing in again.',
+              );
+            }
+            return;
+          }
+          const r = await upsertEpisodeSymptomAnswer(supabase, {
+            userId: uid,
+            episodeId: targetEpisodeId,
+            line,
+            answer,
+          });
+          if (generation !== serverPersistGenerationRef.current) {
+            return;
+          }
+          if (episodeIdRef.current !== targetEpisodeId) {
+            return;
+          }
+          if (!r.ok) {
+            setPersistError(r.error.message);
+          } else {
+            setPersistError(null);
+          }
         });
-        if (generation !== serverPersistGenerationRef.current) {
-          return;
+      queues.set(line.id, next);
+      void next.finally(() => {
+        if (queues.get(line.id) === next) {
+          queues.delete(line.id);
         }
-        if (episodeIdRef.current !== targetEpisodeId) {
-          return;
-        }
-        if (!r.ok) {
-          setPersistError(r.error.message);
-        } else {
-          setPersistError(null);
-        }
-      })();
+      });
     },
     [resolveSessionUserId, supabase],
   );
 
   const executeServerDelete = useCallback(
     (line: PresetSymptomRow) => {
-      const targetEpisodeId = episodeIdRef.current;
-      const generation = ++serverPersistGenerationRef.current;
-      void (async () => {
-        const uid = await resolveSessionUserId(supabase);
-        if (generation !== serverPersistGenerationRef.current) {
-          return;
-        }
-        if (!uid) {
-          if (episodeIdRef.current === targetEpisodeId) {
-            setPersistError(
-              'Your session could not be verified. Try signing in again.',
-            );
+      const queues = lineWriteQueueRef.current;
+      const previous = queues.get(line.id) ?? Promise.resolve();
+      const next = previous
+        .catch(() => {
+          // Keep the chain alive so later writes still run.
+        })
+        .then(async () => {
+          const targetEpisodeId = episodeIdRef.current;
+          const generation = ++serverPersistGenerationRef.current;
+          const uid = await resolveSessionUserId(supabase);
+          if (generation !== serverPersistGenerationRef.current) {
+            return;
           }
-          return;
-        }
-        const r = await deleteEpisodeSymptomAnswer(supabase, {
-          episodeId: targetEpisodeId,
-          presetSymptomId: line.id,
+          if (!uid) {
+            if (episodeIdRef.current === targetEpisodeId) {
+              setPersistError(
+                'Your session could not be verified. Try signing in again.',
+              );
+            }
+            return;
+          }
+          const r = await deleteEpisodeSymptomAnswer(supabase, {
+            episodeId: targetEpisodeId,
+            presetSymptomId: line.id,
+          });
+          if (generation !== serverPersistGenerationRef.current) {
+            return;
+          }
+          if (episodeIdRef.current !== targetEpisodeId) {
+            return;
+          }
+          if (!r.ok) {
+            setPersistError(r.error.message);
+          } else {
+            setPersistError(null);
+          }
         });
-        if (generation !== serverPersistGenerationRef.current) {
-          return;
+      queues.set(line.id, next);
+      void next.finally(() => {
+        if (queues.get(line.id) === next) {
+          queues.delete(line.id);
         }
-        if (episodeIdRef.current !== targetEpisodeId) {
-          return;
-        }
-        if (!r.ok) {
-          setPersistError(r.error.message);
-        } else {
-          setPersistError(null);
-        }
-      })();
+      });
     },
     [resolveSessionUserId, supabase],
   );

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -235,6 +235,19 @@ export function SymptomPromptFlow({
     executeServerPersist(pending.line, pending.answer);
   }, [executeServerPersist]);
 
+  /**
+   * Cancels any pending debounced free-text upsert and invalidates older in-flight persists.
+   * Used before skip/delete so a delayed upsert cannot recreate a row after delete.
+   */
+  const cancelPendingServerPersist = useCallback(() => {
+    if (serverPersistTimerRef.current !== null) {
+      clearTimeout(serverPersistTimerRef.current);
+      serverPersistTimerRef.current = null;
+    }
+    pendingServerFreeTextPersistRef.current = null;
+    serverPersistGenerationRef.current += 1;
+  }, []);
+
   const schedulePersistToSupabase = useCallback(
     (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
       if (answer.type === 'free_text') {
@@ -556,6 +569,8 @@ export function SymptomPromptFlow({
         event.stopPropagation();
         return;
       }
+      flushPendingTextPersist();
+      flushPendingServerPersist();
       allowNavigationRef.current = true;
     };
 
@@ -573,7 +588,7 @@ export function SymptomPromptFlow({
       document.removeEventListener('click', onDocumentClick, true);
       window.removeEventListener('beforeunload', onBeforeUnload);
     };
-  }, [phase]);
+  }, [flushPendingServerPersist, flushPendingTextPersist, phase]);
 
   const goNext = () => {
     flushPendingTextPersist();
@@ -586,7 +601,7 @@ export function SymptomPromptFlow({
       return;
     }
     flushPendingTextPersist();
-    flushPendingServerPersist();
+    cancelPendingServerPersist();
     const skippedAnswer = createDefaultSymptomPromptAnswer(
       currentLine.response_type,
     );

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import {
   useCallback,
@@ -14,12 +13,14 @@ import type {
   PresetSymptomRow,
   SymptomPromptAnswer,
   SymptomPromptAnswers,
+  SymptomResponseType,
 } from '@abstrack/types';
 import {
   createInitialSymptomPromptSession,
   episodeSymptomRowsToAnswersMap,
 } from '@abstrack/types';
 import {
+  deleteEpisodeSymptomAnswer,
   listEpisodeSymptomsForEpisode,
   listPresetSymptomsForPreset,
   upsertEpisodeSymptomAnswer,
@@ -55,6 +56,46 @@ function clampIndex(index: number, length: number): number {
   }
   const i = Math.trunc(index);
   return Math.max(0, Math.min(i, length - 1));
+}
+
+function defaultAnswerForType(type: SymptomResponseType): SymptomPromptAnswer {
+  switch (type) {
+    case 'yes_no':
+      return { type: 'yes_no', value: null };
+    case 'severity_scale':
+      return { type: 'severity_scale', value: null };
+    case 'free_text':
+      return { type: 'free_text', value: '' };
+    case 'photo':
+      return { type: 'photo', value: null };
+    case 'video':
+      return { type: 'video', value: null };
+    default: {
+      const _exhaustive: never = type;
+      return _exhaustive;
+    }
+  }
+}
+
+function hasAnswerValue(answer: SymptomPromptAnswer | undefined): boolean {
+  if (!answer) {
+    return false;
+  }
+  switch (answer.type) {
+    case 'yes_no':
+      return answer.value !== null;
+    case 'severity_scale':
+      return answer.value !== null;
+    case 'free_text':
+      return answer.value.trim().length > 0;
+    case 'photo':
+    case 'video':
+      return false;
+    default: {
+      const _exhaustive: never = answer;
+      return _exhaustive;
+    }
+  }
 }
 
 /**
@@ -107,6 +148,7 @@ export function SymptomPromptFlow({
    * captured per attempt so flushes during navigation cannot attach errors to the wrong episode.
    */
   const serverPersistGenerationRef = useRef(0);
+  const allowNavigationRef = useRef(false);
 
   const supabase = useMemo(() => createBrowserClient(), []);
 
@@ -161,6 +203,43 @@ export function SymptomPromptFlow({
           episodeId: targetEpisodeId,
           line,
           answer,
+        });
+        if (generation !== serverPersistGenerationRef.current) {
+          return;
+        }
+        if (episodeIdRef.current !== targetEpisodeId) {
+          return;
+        }
+        if (!r.ok) {
+          setPersistError(r.error.message);
+        } else {
+          setPersistError(null);
+        }
+      })();
+    },
+    [resolveSessionUserId, supabase],
+  );
+
+  const executeServerDelete = useCallback(
+    (line: PresetSymptomRow) => {
+      const targetEpisodeId = episodeIdRef.current;
+      const generation = ++serverPersistGenerationRef.current;
+      void (async () => {
+        const uid = await resolveSessionUserId(supabase);
+        if (generation !== serverPersistGenerationRef.current) {
+          return;
+        }
+        if (!uid) {
+          if (episodeIdRef.current === targetEpisodeId) {
+            setPersistError(
+              'Your session could not be verified. Try signing in again.',
+            );
+          }
+          return;
+        }
+        const r = await deleteEpisodeSymptomAnswer(supabase, {
+          episodeId: targetEpisodeId,
+          presetSymptomId: line.id,
         });
         if (generation !== serverPersistGenerationRef.current) {
           return;
@@ -352,6 +431,10 @@ export function SymptomPromptFlow({
   }, [load]);
 
   const currentLine = lines[activeIndex] ?? null;
+  const currentAnswer = currentLine ? answers[currentLine.id] : undefined;
+  const currentLineAnswered = hasAnswerValue(currentAnswer);
+  const canProceedWithNext = !currentLine || currentLineAnswered;
+  const canSkipCurrentLine = Boolean(currentLine) && !currentLineAnswered;
   const stepLabel =
     lines.length === 0
       ? 'No symptoms'
@@ -409,26 +492,7 @@ export function SymptomPromptFlow({
     }
   };
 
-  const goBackStep = () => {
-    flushPendingTextPersist();
-    flushPendingServerPersist();
-    const idx = activeIndexRef.current;
-    if (idx > 0) {
-      const next = idx - 1;
-      activeIndexRef.current = next;
-      setActiveIndex(next);
-      persistImmediate(next, answersRef.current);
-      announce(`Back to step ${next + 1} of ${lines.length}.`, {
-        politeness: 'polite',
-      });
-    } else {
-      router.push('/dashboard');
-    }
-  };
-
-  const goNext = () => {
-    flushPendingTextPersist();
-    flushPendingServerPersist();
+  const advanceToNextStep = () => {
     if (lines.length === 0) {
       setPhase('complete');
       return;
@@ -443,6 +507,127 @@ export function SymptomPromptFlow({
     }
     setPhase('complete');
     announce('Symptom list complete.', { politeness: 'polite' });
+  };
+
+  const goBackStep = () => {
+    flushPendingTextPersist();
+    flushPendingServerPersist();
+    const idx = activeIndexRef.current;
+    if (idx <= 0) {
+      return;
+    }
+    const next = idx - 1;
+    activeIndexRef.current = next;
+    setActiveIndex(next);
+    persistImmediate(next, answersRef.current);
+    announce(`Back to step ${next + 1} of ${lines.length}.`, {
+      politeness: 'polite',
+    });
+  };
+
+  const confirmExitFlow = () => {
+    const shouldExit = window.confirm(
+      'Exit symptom flow? If you exit now, you will return home. Starting again creates a new episode.',
+    );
+    if (shouldExit) {
+      router.push('/dashboard');
+    } else {
+      announce('Stayed on the current symptom step.', {
+        politeness: 'polite',
+      });
+    }
+  };
+
+  useEffect(() => {
+    if (phase !== 'prompting') {
+      return;
+    }
+    const confirmMessage =
+      'Exit symptom flow? If you exit now, you will return home. Starting again creates a new episode.';
+
+    const onDocumentClick = (event: MouseEvent) => {
+      if (allowNavigationRef.current) {
+        return;
+      }
+      if (event.defaultPrevented) {
+        return;
+      }
+      if (event.button !== 0) {
+        return;
+      }
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+        return;
+      }
+      const target = event.target;
+      if (!(target instanceof Element)) {
+        return;
+      }
+      const anchor = target.closest('a[href]');
+      if (!(anchor instanceof HTMLAnchorElement)) {
+        return;
+      }
+      if (anchor.target && anchor.target !== '_self') {
+        return;
+      }
+      if (anchor.hasAttribute('download')) {
+        return;
+      }
+      const destination = new URL(anchor.href, window.location.href);
+      const current = new URL(window.location.href);
+      if (destination.href === current.href) {
+        return;
+      }
+      const shouldLeave = window.confirm(confirmMessage);
+      if (!shouldLeave) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+      allowNavigationRef.current = true;
+    };
+
+    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (allowNavigationRef.current) {
+        return;
+      }
+      event.preventDefault();
+      event.returnValue = '';
+    };
+
+    document.addEventListener('click', onDocumentClick, true);
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => {
+      document.removeEventListener('click', onDocumentClick, true);
+      window.removeEventListener('beforeunload', onBeforeUnload);
+    };
+  }, [phase]);
+
+  const goNext = () => {
+    flushPendingTextPersist();
+    flushPendingServerPersist();
+    advanceToNextStep();
+  };
+
+  const skipCurrentSymptom = () => {
+    if (!currentLine) {
+      return;
+    }
+    flushPendingTextPersist();
+    flushPendingServerPersist();
+    const skippedAnswer = defaultAnswerForType(currentLine.response_type);
+    const merged: SymptomPromptAnswers = {
+      ...answersRef.current,
+      [currentLine.id]: skippedAnswer,
+    };
+    answersRef.current = merged;
+    setAnswers(merged);
+    setSymptomPromptSession(episodeIdRef.current, {
+      activeIndex: activeIndexRef.current,
+      answers: merged,
+    });
+    executeServerDelete(currentLine);
+    announce(`Skipped ${currentLine.symptom_name}.`, { politeness: 'polite' });
+    advanceToNextStep();
   };
 
   const onFinishToDashboard = () => {
@@ -516,12 +701,13 @@ export function SymptomPromptFlow({
     <div className="space-y-6">
       <div>
         <p className="text-sm font-medium text-app-muted">
-          <Link
-            href="/dashboard"
+          <button
+            type="button"
+            onClick={confirmExitFlow}
             className="rounded-md text-app-primary underline decoration-app-primary/40 underline-offset-2 outline-none transition hover:text-app-ink hover:decoration-app-primary focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
           >
             ← Back to dashboard
-          </Link>
+          </button>
         </p>
         <h1 className="mt-4 text-2xl font-bold tracking-tight text-app-ink">
           Episode symptoms
@@ -570,14 +756,34 @@ export function SymptomPromptFlow({
       <div className="flex flex-col gap-3 sm:flex-row">
         <button
           type="button"
+          disabled={activeIndex === 0}
           className="inline-flex min-h-[56px] flex-1 items-center justify-center rounded-xl border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
           onClick={goBackStep}
         >
-          {activeIndex === 0 ? 'Exit to dashboard' : 'Back'}
+          Back
         </button>
+        {currentLine ? (
+          <button
+            type="button"
+            disabled={!canSkipCurrentLine}
+            className={`inline-flex min-h-[56px] flex-1 items-center justify-center rounded-xl border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg ${
+              canSkipCurrentLine
+                ? 'hover:bg-app-surface/80'
+                : 'cursor-not-allowed opacity-50'
+            }`}
+            onClick={skipCurrentSymptom}
+          >
+            Skip symptom
+          </button>
+        ) : null}
         <button
           type="button"
-          className="inline-flex min-h-[56px] flex-1 items-center justify-center rounded-xl bg-red-700 px-4 text-base font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:bg-red-600 dark:hover:bg-red-500"
+          disabled={!canProceedWithNext}
+          className={`inline-flex min-h-[56px] flex-1 items-center justify-center rounded-xl px-4 text-base font-semibold text-white shadow-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:bg-red-600 ${
+            canProceedWithNext
+              ? 'bg-red-700 hover:bg-red-800 dark:hover:bg-red-500'
+              : 'cursor-not-allowed bg-red-400 opacity-60 dark:bg-red-800'
+          }`}
           onClick={goNext}
         >
           {lines.length === 0
@@ -587,6 +793,13 @@ export function SymptomPromptFlow({
               : 'Next'}
         </button>
       </div>
+      <button
+        type="button"
+        className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-3 py-2 text-base font-medium text-app-muted transition hover:text-app-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+        onClick={confirmExitFlow}
+      >
+        Exit symptom flow
+      </button>
     </div>
   );
 }

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -59,6 +59,11 @@ function clampIndex(index: number, length: number): number {
   return Math.max(0, Math.min(i, length - 1));
 }
 
+/** Queue key so the same preset symptom id does not serialize writes across episodes. */
+function lineWriteQueueKey(episodeId: string, presetSymptomId: string): string {
+  return `${episodeId}:${presetSymptomId}`;
+}
+
 /**
  * Linear symptom stepper for the active episode’s preset (Week 5 skeleton).
  *
@@ -100,7 +105,10 @@ export function SymptomPromptFlow({
     line: PresetSymptomRow;
     answer: SymptomPromptAnswer;
   } | null>(null);
-  /** Per-line write queue so upsert/delete requests execute in user action order. */
+  /**
+   * Per (episode, preset symptom) write queue so upsert/delete requests execute in user action
+   * order within an episode only — not across `episodeId` changes while mounted.
+   */
   const lineWriteQueueRef = useRef<Map<string, Promise<void>>>(new Map());
   const userIdRef = useRef<string | null>(null);
   /** Bumps on each `load()` start and on effect cleanup so in-flight loads ignore stale results after unmount, retry, or param change. */
@@ -158,9 +166,10 @@ export function SymptomPromptFlow({
       /** Captured at enqueue so queued work cannot attach to a later episode after route change. */
       const enqueueEpisodeId = episodeIdRef.current;
       const enqueueEpoch = serverPersistEpochRef.current;
+      const queueKey = lineWriteQueueKey(enqueueEpisodeId, line.id);
 
       const queues = lineWriteQueueRef.current;
-      const previous = queues.get(line.id) ?? Promise.resolve();
+      const previous = queues.get(queueKey) ?? Promise.resolve();
       const next = previous
         .catch(() => {
           // Keep the chain alive so later writes still run.
@@ -199,10 +208,10 @@ export function SymptomPromptFlow({
             }
           }
         });
-      queues.set(line.id, next);
+      queues.set(queueKey, next);
       void next.finally(() => {
-        if (queues.get(line.id) === next) {
-          queues.delete(line.id);
+        if (queues.get(queueKey) === next) {
+          queues.delete(queueKey);
         }
       });
     },
@@ -213,9 +222,10 @@ export function SymptomPromptFlow({
     (line: PresetSymptomRow) => {
       const enqueueEpisodeId = episodeIdRef.current;
       const enqueueEpoch = serverPersistEpochRef.current;
+      const queueKey = lineWriteQueueKey(enqueueEpisodeId, line.id);
 
       const queues = lineWriteQueueRef.current;
-      const previous = queues.get(line.id) ?? Promise.resolve();
+      const previous = queues.get(queueKey) ?? Promise.resolve();
       const next = previous
         .catch(() => {
           // Keep the chain alive so later writes still run.
@@ -252,10 +262,10 @@ export function SymptomPromptFlow({
             }
           }
         });
-      queues.set(line.id, next);
+      queues.set(queueKey, next);
       void next.finally(() => {
-        if (queues.get(line.id) === next) {
-          queues.delete(line.id);
+        if (queues.get(queueKey) === next) {
+          queues.delete(queueKey);
         }
       });
     },

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -839,7 +839,7 @@ export function SymptomPromptFlow({
       <ConfirmDialog
         open={discardDialogOpen}
         title="Exit symptom flow?"
-        description="If you exit now, you will return home. Starting again creates a new episode."
+        description="If you exit now, you will return to the dashboard. Starting again creates a new episode."
         confirmLabel="Exit"
         cancelLabel="Stay"
         onConfirm={() => {

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -250,6 +250,11 @@ export function SymptomPromptFlow({
 
   const schedulePersistToSupabase = useCallback(
     (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
+      if (!symptomPromptAnswerHasValue(answer)) {
+        cancelPendingServerPersist();
+        executeServerDelete(line);
+        return;
+      }
       if (answer.type === 'free_text') {
         pendingServerFreeTextPersistRef.current = { line, answer };
         if (serverPersistTimerRef.current !== null) {
@@ -272,7 +277,7 @@ export function SymptomPromptFlow({
         executeServerPersist(line, answer);
       }
     },
-    [executeServerPersist],
+    [cancelPendingServerPersist, executeServerDelete, executeServerPersist],
   );
 
   useLayoutEffect(() => {
@@ -504,6 +509,9 @@ export function SymptomPromptFlow({
       'Exit symptom flow? If you exit now, you will return home. Starting again creates a new episode.',
     );
     if (shouldExit) {
+      flushPendingTextPersist();
+      flushPendingServerPersist();
+      allowNavigationRef.current = true;
       router.push('/dashboard');
     } else {
       announce('Stayed on the current symptom step.', {

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -106,11 +106,12 @@ export function SymptomPromptFlow({
   /** Bumps on each `load()` start and on effect cleanup so in-flight loads ignore stale results after unmount, retry, or param change. */
   const loadGenRef = useRef(0);
   /**
-   * Monotonic id for `executeServerPersist` attempts; bumped on each new persist and on episode
-   * change so out-of-order async completions do not clobber {@link persistError}. Episode id is
-   * captured per attempt so flushes during navigation cannot attach errors to the wrong episode.
+   * Bumped only on episode change, unmount, and {@link cancelPendingServerPersist} so in-flight
+   * work can be abandoned without clobbering UI after navigation. Each write captures the epoch at
+   * enqueue time (does not bump per write) so parallel writes to different symptom lines still
+   * surface their own errors when they complete.
    */
-  const serverPersistGenerationRef = useRef(0);
+  const serverPersistEpochRef = useRef(0);
   const allowNavigationRef = useRef(false);
 
   const supabase = useMemo(() => createBrowserClient(), []);
@@ -154,9 +155,9 @@ export function SymptomPromptFlow({
         })
         .then(async () => {
           const targetEpisodeId = episodeIdRef.current;
-          const generation = ++serverPersistGenerationRef.current;
+          const epochAtStart = serverPersistEpochRef.current;
           const uid = await resolveSessionUserId(supabase);
-          if (generation !== serverPersistGenerationRef.current) {
+          if (epochAtStart !== serverPersistEpochRef.current) {
             return;
           }
           if (!uid) {
@@ -173,7 +174,7 @@ export function SymptomPromptFlow({
             line,
             answer,
           });
-          if (generation !== serverPersistGenerationRef.current) {
+          if (epochAtStart !== serverPersistEpochRef.current) {
             return;
           }
           if (episodeIdRef.current !== targetEpisodeId) {
@@ -205,9 +206,9 @@ export function SymptomPromptFlow({
         })
         .then(async () => {
           const targetEpisodeId = episodeIdRef.current;
-          const generation = ++serverPersistGenerationRef.current;
+          const epochAtStart = serverPersistEpochRef.current;
           const uid = await resolveSessionUserId(supabase);
-          if (generation !== serverPersistGenerationRef.current) {
+          if (epochAtStart !== serverPersistEpochRef.current) {
             return;
           }
           if (!uid) {
@@ -222,7 +223,7 @@ export function SymptomPromptFlow({
             episodeId: targetEpisodeId,
             presetSymptomId: line.id,
           });
-          if (generation !== serverPersistGenerationRef.current) {
+          if (epochAtStart !== serverPersistEpochRef.current) {
             return;
           }
           if (episodeIdRef.current !== targetEpisodeId) {
@@ -271,7 +272,7 @@ export function SymptomPromptFlow({
       serverPersistTimerRef.current = null;
     }
     pendingServerFreeTextPersistRef.current = null;
-    serverPersistGenerationRef.current += 1;
+    serverPersistEpochRef.current += 1;
   }, []);
 
   const schedulePersistToSupabase = useCallback(
@@ -316,7 +317,7 @@ export function SymptomPromptFlow({
         answers: answersRef.current,
       });
     }
-    serverPersistGenerationRef.current += 1;
+    serverPersistEpochRef.current += 1;
     flushPendingServerPersist();
     episodeIdRef.current = episodeId;
     const s = getSymptomPromptSession(episodeId);
@@ -359,7 +360,7 @@ export function SymptomPromptFlow({
 
   useEffect(() => {
     return () => {
-      serverPersistGenerationRef.current += 1;
+      serverPersistEpochRef.current += 1;
       flushPendingServerPersist();
     };
   }, [flushPendingServerPersist]);

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -796,14 +796,15 @@ export function SymptomPromptFlow({
       ) : null}
 
       <div className="flex flex-col gap-3 sm:flex-row">
-        <button
-          type="button"
-          disabled={activeIndex === 0}
-          className="inline-flex min-h-[56px] flex-1 items-center justify-center rounded-xl border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-          onClick={goBackStep}
-        >
-          Back
-        </button>
+        {activeIndex > 0 ? (
+          <button
+            type="button"
+            className="inline-flex min-h-[56px] flex-1 items-center justify-center rounded-xl border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+            onClick={goBackStep}
+          >
+            Back
+          </button>
+        ) : null}
         {currentLine ? (
           <button
             type="button"

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -106,12 +106,13 @@ export function SymptomPromptFlow({
   /** Bumps on each `load()` start and on effect cleanup so in-flight loads ignore stale results after unmount, retry, or param change. */
   const loadGenRef = useRef(0);
   /**
-   * Bumped only on episode change, unmount, and {@link cancelPendingServerPersist} so in-flight
-   * work can be abandoned without clobbering UI after navigation. Each write captures the epoch at
-   * enqueue time (does not bump per write) so parallel writes to different symptom lines still
-   * surface their own errors when they complete.
+   * Bumped only by {@link cancelPendingServerPersist}. Used with mount + episode id to gate
+   * {@link setPersistError} only — upsert/delete for the captured `enqueueEpisodeId` always runs
+   * so Supabase stays aligned when the user navigates or cancels debounced work.
    */
   const serverPersistEpochRef = useRef(0);
+  /** Suppresses {@link setPersistError} after unmount (epoch is not bumped on unmount). */
+  const isMountedRef = useRef(true);
   const allowNavigationRef = useRef(false);
 
   const supabase = useMemo(() => createBrowserClient(), []);
@@ -145,6 +146,13 @@ export function SymptomPromptFlow({
     answersRef.current = answers;
   }, [answers]);
 
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
   const executeServerPersist = useCallback(
     (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
       /** Captured at enqueue so queued work cannot attach to a later episode after route change. */
@@ -158,16 +166,11 @@ export function SymptomPromptFlow({
           // Keep the chain alive so later writes still run.
         })
         .then(async () => {
-          if (enqueueEpoch !== serverPersistEpochRef.current) {
-            return;
-          }
           const targetEpisodeId = enqueueEpisodeId;
           const uid = await resolveSessionUserId(supabase);
-          if (enqueueEpoch !== serverPersistEpochRef.current) {
-            return;
-          }
           if (!uid) {
             if (
+              isMountedRef.current &&
               episodeIdRef.current === enqueueEpisodeId &&
               enqueueEpoch === serverPersistEpochRef.current
             ) {
@@ -183,16 +186,17 @@ export function SymptomPromptFlow({
             line,
             answer,
           });
-          if (enqueueEpoch !== serverPersistEpochRef.current) {
-            return;
-          }
-          if (episodeIdRef.current !== enqueueEpisodeId) {
-            return;
-          }
-          if (!r.ok) {
-            setPersistError(r.error.message);
-          } else {
-            setPersistError(null);
+          // Epoch/mount/episode gate UI only — the upsert above always ran for `targetEpisodeId`.
+          if (
+            isMountedRef.current &&
+            episodeIdRef.current === enqueueEpisodeId &&
+            enqueueEpoch === serverPersistEpochRef.current
+          ) {
+            if (!r.ok) {
+              setPersistError(r.error.message);
+            } else {
+              setPersistError(null);
+            }
           }
         });
       queues.set(line.id, next);
@@ -217,16 +221,11 @@ export function SymptomPromptFlow({
           // Keep the chain alive so later writes still run.
         })
         .then(async () => {
-          if (enqueueEpoch !== serverPersistEpochRef.current) {
-            return;
-          }
           const targetEpisodeId = enqueueEpisodeId;
           const uid = await resolveSessionUserId(supabase);
-          if (enqueueEpoch !== serverPersistEpochRef.current) {
-            return;
-          }
           if (!uid) {
             if (
+              isMountedRef.current &&
               episodeIdRef.current === enqueueEpisodeId &&
               enqueueEpoch === serverPersistEpochRef.current
             ) {
@@ -240,16 +239,17 @@ export function SymptomPromptFlow({
             episodeId: targetEpisodeId,
             presetSymptomId: line.id,
           });
-          if (enqueueEpoch !== serverPersistEpochRef.current) {
-            return;
-          }
-          if (episodeIdRef.current !== enqueueEpisodeId) {
-            return;
-          }
-          if (!r.ok) {
-            setPersistError(r.error.message);
-          } else {
-            setPersistError(null);
+          // Epoch/mount/episode gate UI only — the delete above always ran for `targetEpisodeId`.
+          if (
+            isMountedRef.current &&
+            episodeIdRef.current === enqueueEpisodeId &&
+            enqueueEpoch === serverPersistEpochRef.current
+          ) {
+            if (!r.ok) {
+              setPersistError(r.error.message);
+            } else {
+              setPersistError(null);
+            }
           }
         });
       queues.set(line.id, next);
@@ -334,7 +334,6 @@ export function SymptomPromptFlow({
         answers: answersRef.current,
       });
     }
-    serverPersistEpochRef.current += 1;
     flushPendingServerPersist();
     episodeIdRef.current = episodeId;
     const s = getSymptomPromptSession(episodeId);
@@ -377,7 +376,8 @@ export function SymptomPromptFlow({
 
   useEffect(() => {
     return () => {
-      serverPersistEpochRef.current += 1;
+      // Do not bump serverPersistEpochRef here — queued per-line writes should still reach Supabase;
+      // isMountedRef gates setPersistError after unmount.
       flushPendingServerPersist();
     };
   }, [flushPendingServerPersist]);

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -29,10 +29,15 @@ import {
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import {
+  useUnsavedChangesLeaveGuard,
+  type PendingLeaveAction,
+} from '@/lib/use-unsaved-changes-leave-guard';
+import {
   clearSymptomPromptSession,
   getSymptomPromptSession,
   setSymptomPromptSession,
 } from '@/lib/episode-flow/symptom-prompt-session-store';
+import { ConfirmDialog } from '../symptom-presets/ConfirmDialog';
 import { SymptomPromptResponseField } from './SymptomPromptResponseField';
 
 export type SymptomPromptFlowProps = {
@@ -63,6 +68,13 @@ function clampIndex(index: number, length: number): number {
 function lineWriteQueueKey(episodeId: string, presetSymptomId: string): string {
   return `${episodeId}:${presetSymptomId}`;
 }
+
+/**
+ * No form in this flow uses this id; the shared leave guard requires a truthy `exemptFormId` to
+ * register submit capture so non-exempt forms (all of them, here) are intercepted.
+ */
+const SYMPTOM_FLOW_LEAVE_GUARD_EXEMPT_FORM_ID =
+  '__symptom_prompt_leave_guard_no_exempt__';
 
 /**
  * Linear symptom stepper for the active episode’s preset (Week 5 skeleton).
@@ -119,9 +131,17 @@ export function SymptomPromptFlow({
    * so Supabase stays aligned when the user navigates or cancels debounced work.
    */
   const serverPersistEpochRef = useRef(0);
+  /**
+   * Increments on every enqueue of {@link executeServerPersist} / {@link executeServerDelete}.
+   * Completions only call {@link setPersistError} when their captured id still equals this ref so
+   * out-of-order finishes across lines cannot clear a newer failure (or show stale errors).
+   */
+  const persistUiAttemptRef = useRef(0);
   /** Suppresses {@link setPersistError} after unmount (epoch is not bumped on unmount). */
   const isMountedRef = useRef(true);
-  const allowNavigationRef = useRef(false);
+
+  const [discardDialogOpen, setDiscardDialogOpen] = useState(false);
+  const pendingLeaveRef = useRef<PendingLeaveAction | null>(null);
 
   const supabase = useMemo(() => createBrowserClient(), []);
 
@@ -166,6 +186,8 @@ export function SymptomPromptFlow({
       /** Captured at enqueue so queued work cannot attach to a later episode after route change. */
       const enqueueEpisodeId = episodeIdRef.current;
       const enqueueEpoch = serverPersistEpochRef.current;
+      persistUiAttemptRef.current += 1;
+      const attemptId = persistUiAttemptRef.current;
       const queueKey = lineWriteQueueKey(enqueueEpisodeId, line.id);
 
       const queues = lineWriteQueueRef.current;
@@ -181,7 +203,8 @@ export function SymptomPromptFlow({
             if (
               isMountedRef.current &&
               episodeIdRef.current === enqueueEpisodeId &&
-              enqueueEpoch === serverPersistEpochRef.current
+              enqueueEpoch === serverPersistEpochRef.current &&
+              attemptId === persistUiAttemptRef.current
             ) {
               setPersistError(
                 'Your session could not be verified. Try signing in again.',
@@ -195,11 +218,12 @@ export function SymptomPromptFlow({
             line,
             answer,
           });
-          // Epoch/mount/episode gate UI only — the upsert above always ran for `targetEpisodeId`.
+          // Epoch/mount/episode/attempt gate UI only — the upsert above always ran for `targetEpisodeId`.
           if (
             isMountedRef.current &&
             episodeIdRef.current === enqueueEpisodeId &&
-            enqueueEpoch === serverPersistEpochRef.current
+            enqueueEpoch === serverPersistEpochRef.current &&
+            attemptId === persistUiAttemptRef.current
           ) {
             if (!r.ok) {
               setPersistError(r.error.message);
@@ -222,6 +246,8 @@ export function SymptomPromptFlow({
     (line: PresetSymptomRow) => {
       const enqueueEpisodeId = episodeIdRef.current;
       const enqueueEpoch = serverPersistEpochRef.current;
+      persistUiAttemptRef.current += 1;
+      const attemptId = persistUiAttemptRef.current;
       const queueKey = lineWriteQueueKey(enqueueEpisodeId, line.id);
 
       const queues = lineWriteQueueRef.current;
@@ -237,7 +263,8 @@ export function SymptomPromptFlow({
             if (
               isMountedRef.current &&
               episodeIdRef.current === enqueueEpisodeId &&
-              enqueueEpoch === serverPersistEpochRef.current
+              enqueueEpoch === serverPersistEpochRef.current &&
+              attemptId === persistUiAttemptRef.current
             ) {
               setPersistError(
                 'Your session could not be verified. Try signing in again.',
@@ -249,11 +276,12 @@ export function SymptomPromptFlow({
             episodeId: targetEpisodeId,
             presetSymptomId: line.id,
           });
-          // Epoch/mount/episode gate UI only — the delete above always ran for `targetEpisodeId`.
+          // Epoch/mount/episode/attempt gate UI only — the delete above always ran for `targetEpisodeId`.
           if (
             isMountedRef.current &&
             episodeIdRef.current === enqueueEpisodeId &&
-            enqueueEpoch === serverPersistEpochRef.current
+            enqueueEpoch === serverPersistEpochRef.current &&
+            attemptId === persistUiAttemptRef.current
           ) {
             if (!r.ok) {
               setPersistError(r.error.message);
@@ -369,6 +397,47 @@ export function SymptomPromptFlow({
       answers: answersRef.current,
     });
   }, []);
+
+  const onRequestDiscardDialog = useCallback(() => {
+    setDiscardDialogOpen(true);
+  }, []);
+
+  const handleDiscardConfirm = useCallback(() => {
+    flushPendingTextPersist();
+    flushPendingServerPersist();
+    const action = pendingLeaveRef.current;
+    pendingLeaveRef.current = null;
+
+    if (!action) {
+      router.push('/dashboard');
+      return;
+    }
+    if (action.kind === 'form') {
+      action.form.submit();
+      return;
+    }
+    const { href } = action;
+    let url: URL;
+    try {
+      url = new URL(href, window.location.origin);
+    } catch {
+      router.push('/dashboard');
+      return;
+    }
+    if (url.origin !== window.location.origin) {
+      window.location.assign(href);
+      return;
+    }
+    router.push(`${url.pathname}${url.search}${url.hash}`);
+  }, [flushPendingServerPersist, flushPendingTextPersist, router]);
+
+  useUnsavedChangesLeaveGuard({
+    active: phase === 'prompting' && status === 'ready',
+    dialogOpen: discardDialogOpen,
+    pendingLeaveRef,
+    onRequestDiscard: onRequestDiscardDialog,
+    exemptFormId: SYMPTOM_FLOW_LEAVE_GUARD_EXEMPT_FORM_ID,
+  });
 
   useEffect(() => {
     return () => {
@@ -558,99 +627,10 @@ export function SymptomPromptFlow({
     });
   };
 
-  const confirmExitFlow = () => {
-    const shouldExit = window.confirm(
-      'Exit symptom flow? If you exit now, you will return home. Starting again creates a new episode.',
-    );
-    if (shouldExit) {
-      flushPendingTextPersist();
-      flushPendingServerPersist();
-      allowNavigationRef.current = true;
-      router.push('/dashboard');
-    } else {
-      announce('Stayed on the current symptom step.', {
-        politeness: 'polite',
-      });
-    }
-  };
-
-  useEffect(() => {
-    if (phase !== 'prompting') {
-      return;
-    }
-    const confirmMessage =
-      'Exit symptom flow? If you exit now, you will return home. Starting again creates a new episode.';
-
-    const onDocumentClick = (event: MouseEvent) => {
-      if (allowNavigationRef.current) {
-        return;
-      }
-      if (event.defaultPrevented) {
-        return;
-      }
-      if (event.button !== 0) {
-        return;
-      }
-      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
-        return;
-      }
-      const target = event.target;
-      if (!(target instanceof Element)) {
-        return;
-      }
-      const anchor = target.closest('a[href]');
-      if (!(anchor instanceof HTMLAnchorElement)) {
-        return;
-      }
-      const rawHref = anchor.getAttribute('href');
-      if (rawHref?.startsWith('#')) {
-        return;
-      }
-      if (anchor.target && anchor.target !== '_self') {
-        return;
-      }
-      if (anchor.hasAttribute('download')) {
-        return;
-      }
-      const destination = new URL(anchor.href, window.location.href);
-      const current = new URL(window.location.href);
-      if (
-        destination.origin === current.origin &&
-        destination.pathname === current.pathname &&
-        destination.search === current.search &&
-        destination.hash !== current.hash
-      ) {
-        return;
-      }
-      if (destination.href === current.href) {
-        return;
-      }
-      const shouldLeave = window.confirm(confirmMessage);
-      if (!shouldLeave) {
-        event.preventDefault();
-        event.stopPropagation();
-        return;
-      }
-      flushPendingTextPersist();
-      flushPendingServerPersist();
-      allowNavigationRef.current = true;
-    };
-
-    const onBeforeUnload = (event: BeforeUnloadEvent) => {
-      if (allowNavigationRef.current) {
-        return;
-      }
-      event.preventDefault();
-      event.returnValue = '';
-    };
-
-    document.addEventListener('click', onDocumentClick, true);
-    window.addEventListener('beforeunload', onBeforeUnload);
-    return () => {
-      document.removeEventListener('click', onDocumentClick, true);
-      window.removeEventListener('beforeunload', onBeforeUnload);
-    };
-  }, [flushPendingServerPersist, flushPendingTextPersist, phase]);
+  const confirmExitFlow = useCallback(() => {
+    pendingLeaveRef.current = { kind: 'href', href: '/dashboard' };
+    setDiscardDialogOpen(true);
+  }, []);
 
   const goNext = () => {
     flushPendingTextPersist();
@@ -750,109 +730,126 @@ export function SymptomPromptFlow({
   }
 
   return (
-    <div className="space-y-6">
-      <div>
-        <p className="text-sm font-medium text-app-muted">
-          <button
-            type="button"
-            onClick={confirmExitFlow}
-            className="rounded-md text-app-primary underline decoration-app-primary/40 underline-offset-2 outline-none transition hover:text-app-ink hover:decoration-app-primary focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-          >
-            ← Back to dashboard
-          </button>
-        </p>
-        <h1 className="mt-4 text-2xl font-bold tracking-tight text-app-ink">
-          Episode symptoms
-        </h1>
-        {persistError ? (
-          <p
-            className="mt-2 text-sm text-amber-800 dark:text-amber-200"
-            role="status"
-          >
-            Could not sync with the server: {persistError}
+    <>
+      <div className="space-y-6">
+        <div>
+          <p className="text-sm font-medium text-app-muted">
+            <button
+              type="button"
+              onClick={confirmExitFlow}
+              className="rounded-md text-app-primary underline decoration-app-primary/40 underline-offset-2 outline-none transition hover:text-app-ink hover:decoration-app-primary focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+            >
+              ← Back to dashboard
+            </button>
           </p>
-        ) : null}
-      </div>
-
-      <p className="text-base font-medium text-app-muted">{stepLabel}</p>
-
-      {lines.length === 0 ? (
-        <div
-          className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
-          role="status"
-        >
-          <p className="text-sm leading-relaxed text-app-ink">
-            This preset has no symptoms yet. You can add symptoms under
-            Templates when you are not in an episode.
-          </p>
-        </div>
-      ) : currentLine ? (
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-app-ink">
-            {currentLine.symptom_name}
-          </h2>
-          {currentLine.prompt_instruction ? (
-            <p className="text-sm leading-relaxed text-app-muted">
-              {currentLine.prompt_instruction}
+          <h1 className="mt-4 text-2xl font-bold tracking-tight text-app-ink">
+            Episode symptoms
+          </h1>
+          {persistError ? (
+            <p
+              className="mt-2 text-sm text-amber-800 dark:text-amber-200"
+              role="status"
+            >
+              Could not sync with the server: {persistError}
             </p>
           ) : null}
-          <SymptomPromptResponseField
-            line={currentLine}
-            answer={answers[currentLine.id]}
-            onChange={onChangeAnswer}
-            disabled={status !== 'ready'}
-          />
         </div>
-      ) : null}
 
-      <div className="flex flex-col gap-3 sm:flex-row">
-        {activeIndex > 0 ? (
-          <button
-            type="button"
-            className="inline-flex min-h-[56px] flex-1 items-center justify-center rounded-xl border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-            onClick={goBackStep}
+        <p className="text-base font-medium text-app-muted">{stepLabel}</p>
+
+        {lines.length === 0 ? (
+          <div
+            className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
+            role="status"
           >
-            Back
-          </button>
+            <p className="text-sm leading-relaxed text-app-ink">
+              This preset has no symptoms yet. You can add symptoms under
+              Templates when you are not in an episode.
+            </p>
+          </div>
+        ) : currentLine ? (
+          <div className="space-y-4">
+            <h2 className="text-xl font-semibold text-app-ink">
+              {currentLine.symptom_name}
+            </h2>
+            {currentLine.prompt_instruction ? (
+              <p className="text-sm leading-relaxed text-app-muted">
+                {currentLine.prompt_instruction}
+              </p>
+            ) : null}
+            <SymptomPromptResponseField
+              line={currentLine}
+              answer={answers[currentLine.id]}
+              onChange={onChangeAnswer}
+              disabled={status !== 'ready'}
+            />
+          </div>
         ) : null}
-        {currentLine ? (
+
+        <div className="flex flex-col gap-3 sm:flex-row">
+          {activeIndex > 0 ? (
+            <button
+              type="button"
+              className="inline-flex min-h-[56px] flex-1 items-center justify-center rounded-xl border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+              onClick={goBackStep}
+            >
+              Back
+            </button>
+          ) : null}
+          {currentLine ? (
+            <button
+              type="button"
+              disabled={!canSkipCurrentLine}
+              className={`inline-flex min-h-[56px] flex-1 items-center justify-center rounded-xl border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg ${
+                canSkipCurrentLine
+                  ? 'hover:bg-app-surface/80'
+                  : 'cursor-not-allowed opacity-50'
+              }`}
+              onClick={skipCurrentSymptom}
+            >
+              Skip symptom
+            </button>
+          ) : null}
           <button
             type="button"
-            disabled={!canSkipCurrentLine}
-            className={`inline-flex min-h-[56px] flex-1 items-center justify-center rounded-xl border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg ${
-              canSkipCurrentLine
-                ? 'hover:bg-app-surface/80'
-                : 'cursor-not-allowed opacity-50'
+            disabled={!canProceedWithNext}
+            className={`inline-flex min-h-[56px] flex-1 items-center justify-center rounded-xl px-4 text-base font-semibold text-white shadow-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:bg-red-600 ${
+              canProceedWithNext
+                ? 'bg-red-700 hover:bg-red-800 dark:hover:bg-red-500'
+                : 'cursor-not-allowed bg-red-400 opacity-60 dark:bg-red-800'
             }`}
-            onClick={skipCurrentSymptom}
+            onClick={goNext}
           >
-            Skip symptom
+            {lines.length === 0
+              ? 'Done'
+              : activeIndex >= lines.length - 1
+                ? 'Finish'
+                : 'Next'}
           </button>
-        ) : null}
+        </div>
         <button
           type="button"
-          disabled={!canProceedWithNext}
-          className={`inline-flex min-h-[56px] flex-1 items-center justify-center rounded-xl px-4 text-base font-semibold text-white shadow-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:bg-red-600 ${
-            canProceedWithNext
-              ? 'bg-red-700 hover:bg-red-800 dark:hover:bg-red-500'
-              : 'cursor-not-allowed bg-red-400 opacity-60 dark:bg-red-800'
-          }`}
-          onClick={goNext}
+          className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-3 py-2 text-base font-medium text-app-muted transition hover:text-app-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          onClick={confirmExitFlow}
         >
-          {lines.length === 0
-            ? 'Done'
-            : activeIndex >= lines.length - 1
-              ? 'Finish'
-              : 'Next'}
+          Exit symptom flow
         </button>
       </div>
-      <button
-        type="button"
-        className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-3 py-2 text-base font-medium text-app-muted transition hover:text-app-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-        onClick={confirmExitFlow}
-      >
-        Exit symptom flow
-      </button>
-    </div>
+
+      <ConfirmDialog
+        open={discardDialogOpen}
+        title="Exit symptom flow?"
+        description="If you exit now, you will return home. Starting again creates a new episode."
+        confirmLabel="Exit"
+        cancelLabel="Stay"
+        onConfirm={() => {
+          handleDiscardConfirm();
+        }}
+        onClose={() => {
+          pendingLeaveRef.current = null;
+          setDiscardDialogOpen(false);
+        }}
+      />
+    </>
   );
 }

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -566,6 +566,10 @@ export function SymptomPromptFlow({
       if (!(anchor instanceof HTMLAnchorElement)) {
         return;
       }
+      const rawHref = anchor.getAttribute('href');
+      if (rawHref?.startsWith('#')) {
+        return;
+      }
       if (anchor.target && anchor.target !== '_self') {
         return;
       }
@@ -574,6 +578,14 @@ export function SymptomPromptFlow({
       }
       const destination = new URL(anchor.href, window.location.href);
       const current = new URL(window.location.href);
+      if (
+        destination.origin === current.origin &&
+        destination.pathname === current.pathname &&
+        destination.search === current.search &&
+        destination.hash !== current.hash
+      ) {
+        return;
+      }
       if (destination.href === current.href) {
         return;
       }

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -147,6 +147,10 @@ export function SymptomPromptFlow({
 
   const executeServerPersist = useCallback(
     (line: PresetSymptomRow, answer: SymptomPromptAnswer) => {
+      /** Captured at enqueue so queued work cannot attach to a later episode after route change. */
+      const enqueueEpisodeId = episodeIdRef.current;
+      const enqueueEpoch = serverPersistEpochRef.current;
+
       const queues = lineWriteQueueRef.current;
       const previous = queues.get(line.id) ?? Promise.resolve();
       const next = previous
@@ -154,14 +158,19 @@ export function SymptomPromptFlow({
           // Keep the chain alive so later writes still run.
         })
         .then(async () => {
-          const targetEpisodeId = episodeIdRef.current;
-          const epochAtStart = serverPersistEpochRef.current;
+          if (enqueueEpoch !== serverPersistEpochRef.current) {
+            return;
+          }
+          const targetEpisodeId = enqueueEpisodeId;
           const uid = await resolveSessionUserId(supabase);
-          if (epochAtStart !== serverPersistEpochRef.current) {
+          if (enqueueEpoch !== serverPersistEpochRef.current) {
             return;
           }
           if (!uid) {
-            if (episodeIdRef.current === targetEpisodeId) {
+            if (
+              episodeIdRef.current === enqueueEpisodeId &&
+              enqueueEpoch === serverPersistEpochRef.current
+            ) {
               setPersistError(
                 'Your session could not be verified. Try signing in again.',
               );
@@ -174,10 +183,10 @@ export function SymptomPromptFlow({
             line,
             answer,
           });
-          if (epochAtStart !== serverPersistEpochRef.current) {
+          if (enqueueEpoch !== serverPersistEpochRef.current) {
             return;
           }
-          if (episodeIdRef.current !== targetEpisodeId) {
+          if (episodeIdRef.current !== enqueueEpisodeId) {
             return;
           }
           if (!r.ok) {
@@ -198,6 +207,9 @@ export function SymptomPromptFlow({
 
   const executeServerDelete = useCallback(
     (line: PresetSymptomRow) => {
+      const enqueueEpisodeId = episodeIdRef.current;
+      const enqueueEpoch = serverPersistEpochRef.current;
+
       const queues = lineWriteQueueRef.current;
       const previous = queues.get(line.id) ?? Promise.resolve();
       const next = previous
@@ -205,14 +217,19 @@ export function SymptomPromptFlow({
           // Keep the chain alive so later writes still run.
         })
         .then(async () => {
-          const targetEpisodeId = episodeIdRef.current;
-          const epochAtStart = serverPersistEpochRef.current;
+          if (enqueueEpoch !== serverPersistEpochRef.current) {
+            return;
+          }
+          const targetEpisodeId = enqueueEpisodeId;
           const uid = await resolveSessionUserId(supabase);
-          if (epochAtStart !== serverPersistEpochRef.current) {
+          if (enqueueEpoch !== serverPersistEpochRef.current) {
             return;
           }
           if (!uid) {
-            if (episodeIdRef.current === targetEpisodeId) {
+            if (
+              episodeIdRef.current === enqueueEpisodeId &&
+              enqueueEpoch === serverPersistEpochRef.current
+            ) {
               setPersistError(
                 'Your session could not be verified. Try signing in again.',
               );
@@ -223,10 +240,10 @@ export function SymptomPromptFlow({
             episodeId: targetEpisodeId,
             presetSymptomId: line.id,
           });
-          if (epochAtStart !== serverPersistEpochRef.current) {
+          if (enqueueEpoch !== serverPersistEpochRef.current) {
             return;
           }
-          if (episodeIdRef.current !== targetEpisodeId) {
+          if (episodeIdRef.current !== enqueueEpisodeId) {
             return;
           }
           if (!r.ok) {

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -13,11 +13,12 @@ import type {
   PresetSymptomRow,
   SymptomPromptAnswer,
   SymptomPromptAnswers,
-  SymptomResponseType,
 } from '@abstrack/types';
 import {
+  createDefaultSymptomPromptAnswer,
   createInitialSymptomPromptSession,
   episodeSymptomRowsToAnswersMap,
+  symptomPromptAnswerHasValue,
 } from '@abstrack/types';
 import {
   deleteEpisodeSymptomAnswer,
@@ -56,46 +57,6 @@ function clampIndex(index: number, length: number): number {
   }
   const i = Math.trunc(index);
   return Math.max(0, Math.min(i, length - 1));
-}
-
-function defaultAnswerForType(type: SymptomResponseType): SymptomPromptAnswer {
-  switch (type) {
-    case 'yes_no':
-      return { type: 'yes_no', value: null };
-    case 'severity_scale':
-      return { type: 'severity_scale', value: null };
-    case 'free_text':
-      return { type: 'free_text', value: '' };
-    case 'photo':
-      return { type: 'photo', value: null };
-    case 'video':
-      return { type: 'video', value: null };
-    default: {
-      const _exhaustive: never = type;
-      return _exhaustive;
-    }
-  }
-}
-
-function hasAnswerValue(answer: SymptomPromptAnswer | undefined): boolean {
-  if (!answer) {
-    return false;
-  }
-  switch (answer.type) {
-    case 'yes_no':
-      return answer.value !== null;
-    case 'severity_scale':
-      return answer.value !== null;
-    case 'free_text':
-      return answer.value.trim().length > 0;
-    case 'photo':
-    case 'video':
-      return false;
-    default: {
-      const _exhaustive: never = answer;
-      return _exhaustive;
-    }
-  }
 }
 
 /**
@@ -432,7 +393,7 @@ export function SymptomPromptFlow({
 
   const currentLine = lines[activeIndex] ?? null;
   const currentAnswer = currentLine ? answers[currentLine.id] : undefined;
-  const currentLineAnswered = hasAnswerValue(currentAnswer);
+  const currentLineAnswered = symptomPromptAnswerHasValue(currentAnswer);
   const canProceedWithNext = !currentLine || currentLineAnswered;
   const canSkipCurrentLine = Boolean(currentLine) && !currentLineAnswered;
   const stepLabel =
@@ -626,7 +587,9 @@ export function SymptomPromptFlow({
     }
     flushPendingTextPersist();
     flushPendingServerPersist();
-    const skippedAnswer = defaultAnswerForType(currentLine.response_type);
+    const skippedAnswer = createDefaultSymptomPromptAnswer(
+      currentLine.response_type,
+    );
     const merged: SymptomPromptAnswers = {
       ...answersRef.current,
       [currentLine.id]: skippedAnswer,

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
@@ -1,10 +1,7 @@
 'use client';
 
-import type {
-  PresetSymptomRow,
-  SymptomPromptAnswer,
-  SymptomResponseType,
-} from '@abstrack/types';
+import type { PresetSymptomRow, SymptomPromptAnswer } from '@abstrack/types';
+import { createDefaultSymptomPromptAnswer } from '@abstrack/types';
 
 /** Visible focus ring on keyboard-focused radio buttons (`button[role="radio"]`). */
 const radioLabelFocusVisibleClass =
@@ -16,25 +13,6 @@ export type SymptomPromptResponseFieldProps = {
   onChange: (next: SymptomPromptAnswer) => void;
   disabled: boolean;
 };
-
-function defaultAnswerForType(type: SymptomResponseType): SymptomPromptAnswer {
-  switch (type) {
-    case 'yes_no':
-      return { type: 'yes_no', value: null };
-    case 'severity_scale':
-      return { type: 'severity_scale', value: null };
-    case 'free_text':
-      return { type: 'free_text', value: '' };
-    case 'photo':
-      return { type: 'photo', value: null };
-    case 'video':
-      return { type: 'video', value: null };
-    default: {
-      const _exhaustive: never = type;
-      return _exhaustive;
-    }
-  }
-}
 
 /**
  * Renders the capture UI for one preset symptom line (Week 5 skeleton: no media pipeline).
@@ -48,7 +26,8 @@ export function SymptomPromptResponseField({
   onChange,
   disabled,
 }: SymptomPromptResponseFieldProps) {
-  const effective = answer ?? defaultAnswerForType(line.response_type);
+  const effective =
+    answer ?? createDefaultSymptomPromptAnswer(line.response_type);
 
   switch (line.response_type) {
     case 'yes_no': {

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRef, type KeyboardEvent } from 'react';
 import type { PresetSymptomRow, SymptomPromptAnswer } from '@abstrack/types';
 import { createDefaultSymptomPromptAnswer } from '@abstrack/types';
 
@@ -13,6 +14,211 @@ export type SymptomPromptResponseFieldProps = {
   onChange: (next: SymptomPromptAnswer) => void;
   disabled: boolean;
 };
+
+type YesNoValue = boolean | null;
+
+function SymptomYesNoRadiogroup({
+  line,
+  v,
+  onChange,
+  disabled,
+}: {
+  line: PresetSymptomRow;
+  v: YesNoValue;
+  onChange: (next: SymptomPromptAnswer) => void;
+  disabled: boolean;
+}) {
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  /** Roving tabindex: selected option, or first when none (matches WAI radiogroup tab order). */
+  const tabStopIndex = v === true ? 0 : v === false ? 1 : 0;
+
+  const getFocusedIdx = (): number => {
+    const ae = typeof document !== 'undefined' ? document.activeElement : null;
+    const i = itemRefs.current.findIndex((el) => el === ae);
+    return i >= 0 ? i : tabStopIndex;
+  };
+
+  const moveTo = (nextIdx: number) => {
+    const boolVal = nextIdx === 0;
+    onChange({
+      type: 'yes_no',
+      value: boolVal,
+    });
+    requestAnimationFrame(() => {
+      itemRefs.current[nextIdx]?.focus();
+    });
+  };
+
+  const onGroupKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (disabled) {
+      return;
+    }
+    const len = 2;
+    const cur = getFocusedIdx();
+    const { key } = e;
+    if (key === 'ArrowDown' || key === 'ArrowRight') {
+      e.preventDefault();
+      moveTo((cur + 1) % len);
+      return;
+    }
+    if (key === 'ArrowUp' || key === 'ArrowLeft') {
+      e.preventDefault();
+      moveTo((cur - 1 + len) % len);
+      return;
+    }
+    if (key === 'Home') {
+      e.preventDefault();
+      moveTo(0);
+      return;
+    }
+    if (key === 'End') {
+      e.preventDefault();
+      moveTo(len - 1);
+    }
+  };
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={`${line.symptom_name} yes or no`}
+      className="flex flex-col gap-3"
+      onKeyDown={onGroupKeyDown}
+    >
+      {(['yes', 'no'] as const).map((which, i) => {
+        const boolVal = which === 'yes';
+        const selected = v === boolVal;
+        return (
+          <button
+            key={which}
+            ref={(el) => {
+              itemRefs.current[i] = el;
+            }}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            aria-label={which}
+            tabIndex={i === tabStopIndex ? 0 : -1}
+            disabled={disabled}
+            onClick={() => {
+              onChange({
+                type: 'yes_no',
+                value: selected ? null : boolVal,
+              });
+            }}
+            className={`flex min-h-[56px] cursor-pointer items-center justify-center rounded-xl border-2 px-4 py-4 text-base font-semibold transition ${radioLabelFocusVisibleClass} ${
+              selected
+                ? 'border-app-primary bg-app-primary/10 text-app-ink ring-1 ring-app-primary/20'
+                : 'border-app-border/90 bg-app-surface text-app-ink hover:border-app-border'
+            } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
+          >
+            <span className="capitalize">{which}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function SymptomSeverityRadiogroup({
+  line,
+  sev,
+  onChange,
+  disabled,
+}: {
+  line: PresetSymptomRow;
+  sev: number | null;
+  onChange: (next: SymptomPromptAnswer) => void;
+  disabled: boolean;
+}) {
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const values = [1, 2, 3, 4, 5] as const;
+  const len = values.length;
+  const tabStopIndex = sev !== null ? sev - 1 : 0;
+
+  const getFocusedIdx = (): number => {
+    const ae = typeof document !== 'undefined' ? document.activeElement : null;
+    const i = itemRefs.current.findIndex((el) => el === ae);
+    return i >= 0 ? i : tabStopIndex;
+  };
+
+  const moveTo = (index: number) => {
+    const n = values[index];
+    onChange({
+      type: 'severity_scale',
+      value: n,
+    });
+    requestAnimationFrame(() => {
+      itemRefs.current[index]?.focus();
+    });
+  };
+
+  const onGroupKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (disabled) {
+      return;
+    }
+    const cur = getFocusedIdx();
+    const { key } = e;
+    if (key === 'ArrowDown' || key === 'ArrowRight') {
+      e.preventDefault();
+      moveTo((cur + 1) % len);
+      return;
+    }
+    if (key === 'ArrowUp' || key === 'ArrowLeft') {
+      e.preventDefault();
+      moveTo((cur - 1 + len) % len);
+      return;
+    }
+    if (key === 'Home') {
+      e.preventDefault();
+      moveTo(0);
+      return;
+    }
+    if (key === 'End') {
+      e.preventDefault();
+      moveTo(len - 1);
+    }
+  };
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={`${line.symptom_name} severity 1 to 5`}
+      className="flex flex-wrap gap-2"
+      onKeyDown={onGroupKeyDown}
+    >
+      {values.map((n, i) => {
+        const selected = sev === n;
+        return (
+          <button
+            key={n}
+            ref={(el) => {
+              itemRefs.current[i] = el;
+            }}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            aria-label={`Severity ${n}`}
+            tabIndex={i === tabStopIndex ? 0 : -1}
+            disabled={disabled}
+            onClick={() => {
+              onChange({
+                type: 'severity_scale',
+                value: selected ? null : n,
+              });
+            }}
+            className={`flex h-14 min-w-[52px] cursor-pointer items-center justify-center rounded-xl border-2 px-3 text-base font-semibold transition ${radioLabelFocusVisibleClass} ${
+              selected
+                ? 'border-app-primary bg-app-primary/10 text-app-ink ring-1 ring-app-primary/20'
+                : 'border-app-border/90 bg-app-surface text-app-ink hover:border-app-border'
+            } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
+          >
+            {n}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
 
 /**
  * Renders the capture UI for one preset symptom line (Week 5 skeleton: no media pipeline).
@@ -33,76 +239,23 @@ export function SymptomPromptResponseField({
     case 'yes_no': {
       const v = effective.type === 'yes_no' ? effective.value : null;
       return (
-        <div
-          role="radiogroup"
-          aria-label={`${line.symptom_name} yes or no`}
-          className="flex flex-col gap-3"
-        >
-          {(['yes', 'no'] as const).map((which) => {
-            const boolVal = which === 'yes';
-            const selected = v === boolVal;
-            return (
-              <button
-                key={which}
-                type="button"
-                role="radio"
-                aria-checked={selected}
-                aria-label={which}
-                disabled={disabled}
-                onClick={() => {
-                  onChange({
-                    type: 'yes_no',
-                    value: selected ? null : boolVal,
-                  });
-                }}
-                className={`flex min-h-[56px] cursor-pointer items-center justify-center rounded-xl border-2 px-4 py-4 text-base font-semibold transition ${radioLabelFocusVisibleClass} ${
-                  selected
-                    ? 'border-app-primary bg-app-primary/10 text-app-ink ring-1 ring-app-primary/20'
-                    : 'border-app-border/90 bg-app-surface text-app-ink hover:border-app-border'
-                } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
-              >
-                <span className="capitalize">{which}</span>
-              </button>
-            );
-          })}
-        </div>
+        <SymptomYesNoRadiogroup
+          line={line}
+          v={v}
+          onChange={onChange}
+          disabled={disabled}
+        />
       );
     }
     case 'severity_scale': {
       const sev = effective.type === 'severity_scale' ? effective.value : null;
       return (
-        <div
-          role="radiogroup"
-          aria-label={`${line.symptom_name} severity 1 to 5`}
-          className="flex flex-wrap gap-2"
-        >
-          {[1, 2, 3, 4, 5].map((n) => {
-            const selected = sev === n;
-            return (
-              <button
-                key={n}
-                type="button"
-                role="radio"
-                aria-checked={selected}
-                aria-label={`Severity ${n}`}
-                disabled={disabled}
-                onClick={() => {
-                  onChange({
-                    type: 'severity_scale',
-                    value: selected ? null : n,
-                  });
-                }}
-                className={`flex h-14 min-w-[52px] cursor-pointer items-center justify-center rounded-xl border-2 px-3 text-base font-semibold transition ${radioLabelFocusVisibleClass} ${
-                  selected
-                    ? 'border-app-primary bg-app-primary/10 text-app-ink ring-1 ring-app-primary/20'
-                    : 'border-app-border/90 bg-app-surface text-app-ink hover:border-app-border'
-                } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
-              >
-                {n}
-              </button>
-            );
-          })}
-        </div>
+        <SymptomSeverityRadiogroup
+          line={line}
+          sev={sev}
+          onChange={onChange}
+          disabled={disabled}
+        />
       );
     }
     case 'free_text': {

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
@@ -63,26 +63,27 @@ export function SymptomPromptResponseField({
             const boolVal = which === 'yes';
             const selected = v === boolVal;
             return (
-              <label
+              <button
                 key={which}
+                type="button"
+                role="radio"
+                aria-checked={selected}
+                aria-label={which}
+                disabled={disabled}
+                onClick={() => {
+                  onChange({
+                    type: 'yes_no',
+                    value: selected ? null : boolVal,
+                  });
+                }}
                 className={`flex min-h-[56px] cursor-pointer items-center justify-center rounded-xl border-2 px-4 py-4 text-base font-semibold transition ${radioLabelFocusVisibleClass} ${
                   selected
                     ? 'border-app-primary bg-app-primary/10 text-app-ink ring-1 ring-app-primary/20'
                     : 'border-app-border/90 bg-app-surface text-app-ink hover:border-app-border'
                 } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
               >
-                <input
-                  type="radio"
-                  className="sr-only"
-                  name={`symptom-yesno-${line.id}`}
-                  checked={selected}
-                  disabled={disabled}
-                  onChange={() => {
-                    onChange({ type: 'yes_no', value: boolVal });
-                  }}
-                />
                 <span className="capitalize">{which}</span>
-              </label>
+              </button>
             );
           })}
         </div>
@@ -99,26 +100,27 @@ export function SymptomPromptResponseField({
           {[1, 2, 3, 4, 5].map((n) => {
             const selected = sev === n;
             return (
-              <label
+              <button
                 key={n}
+                type="button"
+                role="radio"
+                aria-checked={selected}
+                aria-label={`Severity ${n}`}
+                disabled={disabled}
+                onClick={() => {
+                  onChange({
+                    type: 'severity_scale',
+                    value: selected ? null : n,
+                  });
+                }}
                 className={`flex h-14 min-w-[52px] cursor-pointer items-center justify-center rounded-xl border-2 px-3 text-base font-semibold transition ${radioLabelFocusVisibleClass} ${
                   selected
                     ? 'border-app-primary bg-app-primary/10 text-app-ink ring-1 ring-app-primary/20'
                     : 'border-app-border/90 bg-app-surface text-app-ink hover:border-app-border'
                 } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
               >
-                <input
-                  type="radio"
-                  className="sr-only"
-                  name={`symptom-sev-${line.id}`}
-                  checked={selected}
-                  disabled={disabled}
-                  onChange={() => {
-                    onChange({ type: 'severity_scale', value: n });
-                  }}
-                />
                 {n}
-              </label>
+              </button>
             );
           })}
         </div>
@@ -147,8 +149,8 @@ export function SymptomPromptResponseField({
           role="status"
           className="rounded-xl border border-dashed border-app-border/90 bg-app-surface/80 p-6 text-center text-sm leading-relaxed text-app-ink"
         >
-          Photo capture will open here during an episode. This step is a
-          placeholder for now.
+          Photo symptom capture is coming in a later update. For now, use Next
+          or Skip symptom to continue this episode flow.
         </div>
       );
     case 'video':
@@ -157,8 +159,8 @@ export function SymptomPromptResponseField({
           role="status"
           className="rounded-xl border border-dashed border-app-border/90 bg-app-surface/80 p-6 text-center text-sm leading-relaxed text-app-ink"
         >
-          Video capture will open here during an episode. This step is a
-          placeholder for now.
+          Video symptom capture is coming in a later update. For now, use Next
+          or Skip symptom to continue this episode flow.
         </div>
       );
     default: {

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
@@ -6,9 +6,9 @@ import type {
   SymptomResponseType,
 } from '@abstrack/types';
 
-/** Visible focus ring on the card when the visually hidden radio is focused with keyboard (see `sr-only` inputs). */
+/** Visible focus ring on keyboard-focused radio buttons (`button[role="radio"]`). */
 const radioLabelFocusVisibleClass =
-  'has-[input:focus-visible]:outline-none has-[input:focus-visible]:ring-2 has-[input:focus-visible]:ring-app-ring has-[input:focus-visible]:ring-offset-2 has-[input:focus-visible]:ring-offset-app-bg';
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg';
 
 export type SymptomPromptResponseFieldProps = {
   line: PresetSymptomRow;

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, type KeyboardEvent } from 'react';
+import { useLayoutEffect, useRef, useState, type KeyboardEvent } from 'react';
 import type { PresetSymptomRow, SymptomPromptAnswer } from '@abstrack/types';
 import { createDefaultSymptomPromptAnswer } from '@abstrack/types';
 
@@ -29,8 +29,26 @@ function SymptomYesNoRadiogroup({
   disabled: boolean;
 }) {
   const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
-  /** Roving tabindex: selected option, or first when none (matches WAI radiogroup tab order). */
-  const tabStopIndex = v === true ? 0 : v === false ? 1 : 0;
+  /**
+   * When `v` is null (no selection / deselected), keeps the tab stop on the last-focused or
+   * last-clicked option so focus does not stay on a button with `tabIndex={-1}`.
+   */
+  const [rovingIdx, setRovingIdx] = useState(0);
+  useLayoutEffect(() => {
+    if (v === true) {
+      setRovingIdx(0);
+    } else if (v === false) {
+      setRovingIdx(1);
+    } else {
+      const ae =
+        typeof document !== 'undefined' ? document.activeElement : null;
+      const i = itemRefs.current.findIndex((el) => el === ae);
+      if (i >= 0) {
+        setRovingIdx(i);
+      }
+    }
+  }, [v]);
+  const tabStopIndex = v === null ? rovingIdx : v === true ? 0 : 1;
 
   const getFocusedIdx = (): number => {
     const ae = typeof document !== 'undefined' ? document.activeElement : null;
@@ -100,10 +118,16 @@ function SymptomYesNoRadiogroup({
             tabIndex={i === tabStopIndex ? 0 : -1}
             disabled={disabled}
             onClick={() => {
+              const next = selected ? null : boolVal;
               onChange({
                 type: 'yes_no',
-                value: selected ? null : boolVal,
+                value: next,
               });
+              if (next === null) {
+                requestAnimationFrame(() => {
+                  itemRefs.current[i]?.focus();
+                });
+              }
             }}
             className={`flex min-h-[56px] cursor-pointer items-center justify-center rounded-xl border-2 px-4 py-4 text-base font-semibold transition ${radioLabelFocusVisibleClass} ${
               selected
@@ -133,7 +157,21 @@ function SymptomSeverityRadiogroup({
   const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const values = [1, 2, 3, 4, 5] as const;
   const len = values.length;
-  const tabStopIndex = sev !== null ? sev - 1 : 0;
+  /** When `sev` is null, preserves roving tab stop after deselect (same idea as yes/no). */
+  const [rovingIdx, setRovingIdx] = useState(0);
+  useLayoutEffect(() => {
+    if (sev !== null) {
+      setRovingIdx(sev - 1);
+    } else {
+      const ae =
+        typeof document !== 'undefined' ? document.activeElement : null;
+      const i = itemRefs.current.findIndex((el) => el === ae);
+      if (i >= 0) {
+        setRovingIdx(i);
+      }
+    }
+  }, [sev]);
+  const tabStopIndex = sev !== null ? sev - 1 : rovingIdx;
 
   const getFocusedIdx = (): number => {
     const ae = typeof document !== 'undefined' ? document.activeElement : null;
@@ -201,10 +239,16 @@ function SymptomSeverityRadiogroup({
             tabIndex={i === tabStopIndex ? 0 : -1}
             disabled={disabled}
             onClick={() => {
+              const next = selected ? null : n;
               onChange({
                 type: 'severity_scale',
-                value: selected ? null : n,
+                value: next,
               });
+              if (next === null) {
+                requestAnimationFrame(() => {
+                  itemRefs.current[i]?.focus();
+                });
+              }
             }}
             className={`flex h-14 min-w-[52px] cursor-pointer items-center justify-center rounded-xl border-2 px-3 text-base font-semibold transition ${radioLabelFocusVisibleClass} ${
               selected

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -102,13 +102,19 @@
 
 **Tasks:**
 
-- [ ] Complete episode prompt flow:
+- [x] Complete episode prompt flow:
   - All symptom input types functioning (yes/no, severity 1-5, free text)
   - Health marker entry **after** symptoms, using the **health marker preset** stored on the episode row (`health_marker_preset_id`) ([PRD](PRD.md) §4)
   - "Add additional symptoms/markers" free-text entry at end
   - Episode type selection (ABS / Other) with custom label
   - Episode notes
   - Episode end flow (records `ended_at` timestamp and duration)
+- [ ] Active episode lifecycle and management (no overlap with prompt controls):
+  - Home screen detects active episode (`ended_at IS NULL`) and shows **Resume episode** as the primary continuation path
+  - Prevent accidental duplicate starts when an active episode exists (clear routing/copy for resume vs start-new)
+  - Add an **Episodes** management surface for active + recent episodes (secondary navigation, not primary impaired-user path)
+  - Add explicit **Cancel accidental episode start** flow for active episodes with destructive confirmation copy
+  - Define and implement episode deletion rules + confirmations (what can be deleted, when, and what related rows are removed)
 - [ ] Impaired-user UI polish: large text, large buttons, minimal cognitive load, high contrast mode
 - [ ] Food diary:
   - Standalone food entry from home screen

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -102,7 +102,7 @@
 
 **Tasks:**
 
-- [x] Complete episode prompt flow:
+- [ ] Complete episode prompt flow:
   - All symptom input types functioning (yes/no, severity 1-5, free text)
   - Health marker entry **after** symptoms, using the **health marker preset** stored on the episode row (`health_marker_preset_id`) ([PRD](PRD.md) §4)
   - "Add additional symptoms/markers" free-text entry at end

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -77,6 +77,7 @@ export {
 } from './lib/episode-template-data.js';
 export { createEpisode, getEpisodeById } from './lib/episode-data.js';
 export {
+  deleteEpisodeSymptomAnswer,
   listEpisodeSymptomsForEpisode,
   upsertEpisodeSymptomAnswer,
 } from './lib/episode-symptom-data.js';

--- a/packages/supabase/src/lib/episode-symptom-data.spec.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { PresetSymptomRow } from '@abstrack/types';
 import {
+  deleteEpisodeSymptomAnswer,
   listEpisodeSymptomsForEpisode,
   upsertEpisodeSymptomAnswer,
 } from './episode-symptom-data.js';
@@ -363,5 +364,28 @@ describe('upsertEpisodeSymptomAnswer', () => {
       expect(result.data.response_boolean).toBe(true);
     }
     expect(fromCalls).toBe(4);
+  });
+});
+
+describe('deleteEpisodeSymptomAnswer', () => {
+  it('deletes rows by episode_id and preset_symptom_id', async () => {
+    const eqPreset = vi.fn(() => ({ error: null }));
+    const eqEpisode = vi.fn(() => ({ eq: eqPreset }));
+    const client = {
+      from: vi.fn(() => ({
+        delete: vi.fn(() => ({
+          eq: eqEpisode,
+        })),
+      })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await deleteEpisodeSymptomAnswer(client, {
+      episodeId: 'ep-1',
+      presetSymptomId: 'ps-line-1',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(eqEpisode).toHaveBeenCalledWith('episode_id', 'ep-1');
+    expect(eqPreset).toHaveBeenCalledWith('preset_symptom_id', 'ps-line-1');
   });
 });

--- a/packages/supabase/src/lib/episode-symptom-data.spec.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.spec.ts
@@ -385,6 +385,9 @@ describe('deleteEpisodeSymptomAnswer', () => {
     });
 
     expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toBe(true);
+    }
     expect(eqEpisode).toHaveBeenCalledWith('episode_id', 'ep-1');
     expect(eqPreset).toHaveBeenCalledWith('preset_symptom_id', 'ps-line-1');
   });

--- a/packages/supabase/src/lib/episode-symptom-data.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.ts
@@ -302,3 +302,29 @@ export async function upsertEpisodeSymptomAnswer(
     };
   });
 }
+
+/**
+ * Deletes any persisted `episode_symptoms` rows for one preset line in an episode.
+ * Used when a user intentionally skips/clears a symptom so blank rows are not kept.
+ *
+ * @param client - Supabase client (RLS applies).
+ * @param args.episodeId - `episodes.id`.
+ * @param args.presetSymptomId - `preset_symptoms.id` for the current prompt line.
+ */
+export async function deleteEpisodeSymptomAnswer(
+  client: AbstrackSupabaseClient,
+  args: {
+    episodeId: Uuid;
+    presetSymptomId: Uuid;
+  },
+): Promise<PresetDataResult<boolean>> {
+  const { episodeId, presetSymptomId } = args;
+  return wrap(async () => {
+    const r = await client
+      .from('episode_symptoms')
+      .delete()
+      .eq('episode_id', episodeId)
+      .eq('preset_symptom_id', presetSymptomId);
+    return { data: true, error: r.error };
+  });
+}

--- a/packages/supabase/src/lib/episode-symptom-data.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.ts
@@ -325,6 +325,9 @@ export async function deleteEpisodeSymptomAnswer(
       .delete()
       .eq('episode_id', episodeId)
       .eq('preset_symptom_id', presetSymptomId);
-    return { data: true, error: r.error };
+    return {
+      data: r.error ? null : true,
+      error: r.error,
+    };
   });
 }

--- a/packages/types/src/lib/symptom-prompt-session.spec.ts
+++ b/packages/types/src/lib/symptom-prompt-session.spec.ts
@@ -1,10 +1,83 @@
 import { describe, expect, it } from 'vitest';
-import { createInitialSymptomPromptSession } from './symptom-prompt-session.js';
+import {
+  createDefaultSymptomPromptAnswer,
+  createInitialSymptomPromptSession,
+  symptomPromptAnswerHasValue,
+} from './symptom-prompt-session.js';
+import type { SymptomResponseType } from './types.js';
 
 describe('symptom-prompt-session', () => {
   it('createInitialSymptomPromptSession starts at first step with no answers', () => {
     const s = createInitialSymptomPromptSession();
     expect(s.activeIndex).toBe(0);
     expect(s.answers).toEqual({});
+  });
+
+  describe('createDefaultSymptomPromptAnswer', () => {
+    const cases: {
+      type: SymptomResponseType;
+      expected: ReturnType<typeof createDefaultSymptomPromptAnswer>;
+    }[] = [
+      { type: 'yes_no', expected: { type: 'yes_no', value: null } },
+      {
+        type: 'severity_scale',
+        expected: { type: 'severity_scale', value: null },
+      },
+      { type: 'free_text', expected: { type: 'free_text', value: '' } },
+      { type: 'photo', expected: { type: 'photo', value: null } },
+      { type: 'video', expected: { type: 'video', value: null } },
+    ];
+
+    it.each(cases)('returns empty shape for $type', ({ type, expected }) => {
+      expect(createDefaultSymptomPromptAnswer(type)).toEqual(expected);
+    });
+  });
+
+  describe('symptomPromptAnswerHasValue', () => {
+    it('returns false for undefined', () => {
+      expect(symptomPromptAnswerHasValue(undefined)).toBe(false);
+    });
+
+    it('yes_no: false when null, true when boolean', () => {
+      expect(symptomPromptAnswerHasValue({ type: 'yes_no', value: null })).toBe(
+        false,
+      );
+      expect(symptomPromptAnswerHasValue({ type: 'yes_no', value: true })).toBe(
+        true,
+      );
+      expect(
+        symptomPromptAnswerHasValue({ type: 'yes_no', value: false }),
+      ).toBe(true);
+    });
+
+    it('severity_scale: false when null, true when set', () => {
+      expect(
+        symptomPromptAnswerHasValue({ type: 'severity_scale', value: null }),
+      ).toBe(false);
+      expect(
+        symptomPromptAnswerHasValue({ type: 'severity_scale', value: 3 }),
+      ).toBe(true);
+    });
+
+    it('free_text: false when empty or whitespace-only after trim', () => {
+      expect(
+        symptomPromptAnswerHasValue({ type: 'free_text', value: '' }),
+      ).toBe(false);
+      expect(
+        symptomPromptAnswerHasValue({ type: 'free_text', value: '   \n\t  ' }),
+      ).toBe(false);
+      expect(
+        symptomPromptAnswerHasValue({ type: 'free_text', value: ' ok ' }),
+      ).toBe(true);
+    });
+
+    it('photo and video never count as having a value (Week 6 placeholders)', () => {
+      expect(symptomPromptAnswerHasValue({ type: 'photo', value: null })).toBe(
+        false,
+      );
+      expect(symptomPromptAnswerHasValue({ type: 'video', value: null })).toBe(
+        false,
+      );
+    });
   });
 });

--- a/packages/types/src/lib/symptom-prompt-session.ts
+++ b/packages/types/src/lib/symptom-prompt-session.ts
@@ -1,4 +1,4 @@
-import type { Uuid } from './types.js';
+import type { SymptomResponseType, Uuid } from './types.js';
 
 /**
  * One stored answer for a preset symptom line during the Week 5 traversal skeleton.
@@ -33,4 +33,60 @@ export interface SymptomPromptSessionState {
  */
 export function createInitialSymptomPromptSession(): SymptomPromptSessionState {
   return { activeIndex: 0, answers: {} };
+}
+
+/**
+ * Builds the empty/default answer shape for a response type.
+ *
+ * @param type - Symptom response type configured on the preset line.
+ * @returns Empty answer payload for UI/session initialization and "skip/clear" behavior.
+ */
+export function createDefaultSymptomPromptAnswer(
+  type: SymptomResponseType,
+): SymptomPromptAnswer {
+  switch (type) {
+    case 'yes_no':
+      return { type: 'yes_no', value: null };
+    case 'severity_scale':
+      return { type: 'severity_scale', value: null };
+    case 'free_text':
+      return { type: 'free_text', value: '' };
+    case 'photo':
+      return { type: 'photo', value: null };
+    case 'video':
+      return { type: 'video', value: null };
+    default: {
+      const _exhaustive: never = type;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * Indicates whether an answer is meaningfully filled for gating next-step actions.
+ *
+ * @param answer - Current in-memory answer for a symptom line.
+ * @returns `true` when the user has provided a value (not null/empty), else `false`.
+ */
+export function symptomPromptAnswerHasValue(
+  answer: SymptomPromptAnswer | undefined,
+): boolean {
+  if (!answer) {
+    return false;
+  }
+  switch (answer.type) {
+    case 'yes_no':
+      return answer.value !== null;
+    case 'severity_scale':
+      return answer.value !== null;
+    case 'free_text':
+      return answer.value.trim().length > 0;
+    case 'photo':
+    case 'video':
+      return false;
+    default: {
+      const _exhaustive: never = answer;
+      return _exhaustive;
+    }
+  }
 }


### PR DESCRIPTION
Closes #92

## Summary

- Completes the preset symptom phase for active episodes in both `apps/web` and `apps/mobile` for all non-media response types (`yes_no`, `severity_scale`, `free_text`) with end-to-end persistence to `episode_symptoms` under RLS.
- Improves impaired-user flow safety by adding explicit skip behavior, answer/skip gating, deselect-on-tap/click support, guarded exit/navigation confirmations, and less error-prone action hierarchy.
- Keeps photo/video out of scope for this issue while providing accessible, honest “coming later” placeholders (no capture/upload implementation).

## What Changed

### Symptom response behavior (web + mobile)

- `yes_no`, `severity_scale`, and `free_text` inputs now function end-to-end in symptom prompt flow.
- Selected `yes_no` and `severity_scale` options can be deselected by tapping/clicking the same option again.
- Added explicit **Skip** action for unanswered lines.
- Enforced mutually exclusive next-step actions:
  - if unanswered: `Skip` enabled, `Next/Finish` disabled
  - if answered: `Next/Finish` enabled, `Skip` disabled

### Persistence and data integrity

- Preserves free-text keystrokes via debounce + flush patterns on navigation/step transitions.
- Added delete-on-skip semantics so skipped symptoms do not leave null-clutter rows:
  - introduced `deleteEpisodeSymptomAnswer` in `@abstrack/supabase`
  - wired skip in web/mobile to remove existing row for `(episode_id, preset_symptom_id)` instead of persisting null answers
- Kept session/local state and server writes aligned to avoid stale values and accidental carryover.

### Accessibility and impaired-user UX

- Continued use of `useAnnounce` (web) and `announce` (mobile) for step/flow feedback.
- Added confirmation guards for exiting symptom flow:
  - explicit `Exit symptom flow` confirmation (web + mobile)
  - protected top/back navigation paths with the same guard behavior
  - web guard also covers link/menu navigation away while prompting
- Demoted exit prominence relative to primary progression actions and repositioned mobile exit action to reduce accidental touch.

### Photo/video placeholders (explicitly non-implemented here)

- Updated placeholder copy to clearly communicate that photo/video symptom capture is coming later.
- Avoids implying a broken feature and stays aligned with Week 7 scope.

### Roadmap update

- Updated `docs/ROADMAP.md` (Week 6) to explicitly track active episode lifecycle work:
  - resume active episode
  - duplicate-start prevention
  - episodes management surface
  - cancel accidental starts
  - deletion rules/confirmations

## Out of Scope (unchanged)

- No photo/video capture pipeline or Storage upload implementation.
- No health marker prompt phase implementation in this PR.
- No schema migration required for this issue’s delivered behavior.

## Test Plan

- [x] `pnpm nx lint web`
- [x] `pnpm nx lint mobile`
- [x] `pnpm nx lint @abstrack/supabase`
- [x] `pnpm nx test mobile --runInBand --testPathPatterns=SymptomPromptScreen.spec.tsx`
- [x] `pnpm nx test @abstrack/supabase`

### Manual checks

- [ ] Web