### PR TITLE
feat(episodes): add home “Resume episode” entry and fix symptom exit/resume persistence (web + mobile)

### DIFF
--- a/apps/mobile/src/app/App.spec.tsx
+++ b/apps/mobile/src/app/App.spec.tsx
@@ -93,24 +93,39 @@ describe('mobile auth state sync', () => {
   const invalidOrExpiredMessage =
     'This reset link is invalid or expired. Request a new one.';
 
+  /**
+   * Supabase registers multiple `onAuthStateChange` listeners (e.g. App + HomeScreen). Tests must
+   * broadcast to every subscriber; a single stored callback misses App when Home overwrites it.
+   */
+  function multiSubscriberOnAuthStateChange() {
+    const callbacks: Array<
+      (event: string, session: Session | null) => void
+    > = [];
+    const onAuthStateChange = jest.fn((callback) => {
+      callbacks.push(callback);
+      return {
+        data: {
+          subscription: {
+            unsubscribe: jest.fn(),
+          },
+        },
+      };
+    });
+    const emitAuth = (event: string, session: Session | null) => {
+      for (const cb of callbacks) {
+        cb(event, session);
+      }
+    };
+    return { onAuthStateChange, emitAuth };
+  }
+
   test('returns to Login after SIGNED_OUT even if auth route was Signup', async () => {
-    let authStateListener:
-      | ((event: string, session: Session | null) => void)
-      | null = null;
+    const { onAuthStateChange, emitAuth } = multiSubscriberOnAuthStateChange();
 
     const mockClient = {
       auth: {
         getSession: jest.fn(async () => ({ data: { session: null } })),
-        onAuthStateChange: jest.fn((callback) => {
-          authStateListener = callback;
-          return {
-            data: {
-              subscription: {
-                unsubscribe: jest.fn(),
-              },
-            },
-          };
-        }),
+        onAuthStateChange,
       },
     } as unknown as AbstrackSupabaseClient;
 
@@ -131,7 +146,7 @@ describe('mobile auth state sync', () => {
     });
 
     await act(async () => {
-      authStateListener?.('SIGNED_IN', {
+      emitAuth('SIGNED_IN', {
         access_token: 'access',
         refresh_token: 'refresh',
         token_type: 'bearer',
@@ -146,7 +161,7 @@ describe('mobile auth state sync', () => {
     });
 
     await act(async () => {
-      authStateListener?.('SIGNED_OUT', null);
+      emitAuth('SIGNED_OUT', null);
     });
 
     await waitFor(() => {
@@ -156,23 +171,12 @@ describe('mobile auth state sync', () => {
   });
 
   test('switches between auth stack and main stack from auth events', async () => {
-    let authStateListener:
-      | ((event: string, session: Session | null) => void)
-      | null = null;
+    const { onAuthStateChange, emitAuth } = multiSubscriberOnAuthStateChange();
 
     const mockClient = {
       auth: {
         getSession: jest.fn(async () => ({ data: { session: null } })),
-        onAuthStateChange: jest.fn((callback) => {
-          authStateListener = callback;
-          return {
-            data: {
-              subscription: {
-                unsubscribe: jest.fn(),
-              },
-            },
-          };
-        }),
+        onAuthStateChange,
       },
     } as unknown as AbstrackSupabaseClient;
 
@@ -184,10 +188,10 @@ describe('mobile auth state sync', () => {
       expect(getByText('Login')).toBeTruthy();
     });
 
-    expect(authStateListener).toBeTruthy();
+    expect(onAuthStateChange).toHaveBeenCalled();
 
     await act(async () => {
-      authStateListener?.('SIGNED_IN', {
+      emitAuth('SIGNED_IN', {
         access_token: 'access',
         refresh_token: 'refresh',
         token_type: 'bearer',
@@ -202,7 +206,7 @@ describe('mobile auth state sync', () => {
     });
 
     await act(async () => {
-      authStateListener?.('SIGNED_OUT', null);
+      emitAuth('SIGNED_OUT', null);
     });
 
     await waitFor(() => {
@@ -640,9 +644,7 @@ describe('mobile auth state sync', () => {
         } as unknown as ReturnType<typeof AppState.addEventListener>;
       });
 
-    let authStateListener:
-      | ((event: string, session: Session | null) => void)
-      | null = null;
+    const { onAuthStateChange, emitAuth } = multiSubscriberOnAuthStateChange();
 
     const signedInSession = {
       access_token: 'access',
@@ -654,7 +656,7 @@ describe('mobile auth state sync', () => {
     } as unknown as Session;
 
     const signOut = jest.fn(async () => {
-      authStateListener?.('SIGNED_OUT', null);
+      emitAuth('SIGNED_OUT', null);
       return { error: null };
     });
 
@@ -665,16 +667,7 @@ describe('mobile auth state sync', () => {
           error: null,
         })),
         signOut,
-        onAuthStateChange: jest.fn((callback) => {
-          authStateListener = callback;
-          return {
-            data: {
-              subscription: {
-                unsubscribe: jest.fn(),
-              },
-            },
-          };
-        }),
+        onAuthStateChange,
       },
     } as unknown as AbstrackSupabaseClient;
 

--- a/apps/mobile/src/app/App.spec.tsx
+++ b/apps/mobile/src/app/App.spec.tsx
@@ -98,9 +98,8 @@ describe('mobile auth state sync', () => {
    * broadcast to every subscriber; a single stored callback misses App when Home overwrites it.
    */
   function multiSubscriberOnAuthStateChange() {
-    const callbacks: Array<
-      (event: string, session: Session | null) => void
-    > = [];
+    const callbacks: Array<(event: string, session: Session | null) => void> =
+      [];
     const onAuthStateChange = jest.fn((callback) => {
       callbacks.push(callback);
       return {

--- a/apps/mobile/src/app/components/episode-flow/EpisodeStartHomeCta.tsx
+++ b/apps/mobile/src/app/components/episode-flow/EpisodeStartHomeCta.tsx
@@ -1,22 +1,65 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Pressable, Text, View } from 'react-native';
+import { announce } from '@abstrack/ui/native';
 import { nw } from '../../theme/app-nativewind-classes';
 
+/** Active episode with the symptom preset needed to resume the prompt flow. */
+export type ActiveEpisodeHomeSummary = {
+  episodeId: string;
+  symptomPresetId: string;
+};
+
 export type EpisodeStartHomeCtaProps = {
-  /** Invoked when the user starts the episode flow. */
+  /** Invoked when the user starts the episode flow (no active episode). */
   onStartEpisode: () => void;
+  /** Invoked when the user resumes an active episode. */
+  onResumeEpisode: (episode: ActiveEpisodeHomeSummary) => void;
+  /** When set, the primary control resumes this episode instead of starting a new one. */
+  activeEpisode: ActiveEpisodeHomeSummary | null;
+  /** Whether an active-episode check is still running. */
+  activeEpisodeLoading: boolean;
 };
 
 /**
- * Prominent home entry point for episode logging: large touch target, high-contrast control, and
- * supporting copy for VoiceOver and TalkBack.
+ * Prominent home entry point for episode logging: large touch target, high-contrast primary
+ * control, and supporting copy for VoiceOver and TalkBack. Shows **Resume episode** when
+ * {@link ActiveEpisodeHomeSummary} is provided.
  *
  * @param props - Props.
  * @returns Episode CTA section for the home screen.
  */
 export function EpisodeStartHomeCta({
   onStartEpisode,
+  onResumeEpisode,
+  activeEpisode,
+  activeEpisodeLoading,
 }: EpisodeStartHomeCtaProps) {
+  const prevResumeRef = useRef<boolean | null>(null);
+
+  useEffect(() => {
+    if (activeEpisodeLoading) {
+      return;
+    }
+    const hasResume = activeEpisode !== null;
+    if (prevResumeRef.current === hasResume) {
+      return;
+    }
+    prevResumeRef.current = hasResume;
+    if (hasResume) {
+      void announce(
+        'You have an episode in progress. Resume episode is the primary action.',
+        { politeness: 'polite' },
+      );
+    } else {
+      void announce(
+        'No episode in progress. You can start logging a new episode.',
+        { politeness: 'polite' },
+      );
+    }
+  }, [activeEpisode, activeEpisodeLoading]);
+
+  const showResume = !activeEpisodeLoading && activeEpisode !== null;
+
   return (
     <View
       testID="episode-start-home-cta"
@@ -33,25 +76,62 @@ export function EpisodeStartHomeCta({
       <Text
         className={`text-base leading-relaxed ${nw.textMuted}`}
         maxFontSizeMultiplier={2}
+        accessibilityLiveRegion="polite"
       >
-        Opens the guided flow to record what you are experiencing during this
-        episode.
+        {activeEpisodeLoading && 'Checking for an episode in progress…'}
+        {!activeEpisodeLoading &&
+          showResume &&
+          'You have an episode in progress. Continue where you left off in the guided symptom flow.'}
+        {!activeEpisodeLoading &&
+          !showResume &&
+          'Opens the guided flow to record what you are experiencing during this episode.'}
       </Text>
-      <Pressable
-        accessibilityRole="button"
-        accessibilityLabel="I'm having an episode"
-        accessibilityHint="Opens the guided episode logging flow"
-        accessibilityState={{ disabled: false }}
-        onPress={onStartEpisode}
-        className="min-h-[56px] items-center justify-center rounded-xl bg-red-700 px-4 py-4 active:opacity-90 dark:bg-red-600"
-      >
-        <Text
-          className="text-center text-[18px] font-semibold text-white"
-          maxFontSizeMultiplier={2}
+      {activeEpisodeLoading ? (
+        <View
+          className="min-h-[56px] items-center justify-center rounded-xl border border-app-border bg-app-surface/90 px-4 py-4 dark:border-neutral-700 dark:bg-neutral-900/80"
+          accessibilityRole="progressbar"
+          accessibilityLabel="Checking for an episode in progress"
         >
-          I'm having an episode
-        </Text>
-      </Pressable>
+          <Text
+            className={`text-center text-base font-medium ${nw.textMuted}`}
+            maxFontSizeMultiplier={2}
+          >
+            Loading…
+          </Text>
+        </View>
+      ) : showResume && activeEpisode ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Resume episode"
+          accessibilityHint="Opens your in-progress episode at the next symptom step"
+          accessibilityState={{ disabled: false }}
+          onPress={() => onResumeEpisode(activeEpisode)}
+          className="min-h-[56px] items-center justify-center rounded-xl bg-red-700 px-4 py-4 active:opacity-90 dark:bg-red-600"
+        >
+          <Text
+            className="text-center text-[18px] font-semibold text-white"
+            maxFontSizeMultiplier={2}
+          >
+            Resume episode
+          </Text>
+        </Pressable>
+      ) : (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="I'm having an episode"
+          accessibilityHint="Opens the guided episode logging flow"
+          accessibilityState={{ disabled: false }}
+          onPress={onStartEpisode}
+          className="min-h-[56px] items-center justify-center rounded-xl bg-red-700 px-4 py-4 active:opacity-90 dark:bg-red-600"
+        >
+          <Text
+            className="text-center text-[18px] font-semibold text-white"
+            maxFontSizeMultiplier={2}
+          >
+            I'm having an episode
+          </Text>
+        </Pressable>
+      )}
     </View>
   );
 }

--- a/apps/mobile/src/app/components/episode-flow/EpisodeStartHomeCta.tsx
+++ b/apps/mobile/src/app/components/episode-flow/EpisodeStartHomeCta.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { Pressable, Text, View } from 'react-native';
+import { Platform, Pressable, Text, View } from 'react-native';
 import { announce } from '@abstrack/ui/native';
 import { nw } from '../../theme/app-nativewind-classes';
 
@@ -22,8 +22,9 @@ export type EpisodeStartHomeCtaProps = {
 
 /**
  * Prominent home entry point for episode logging: large touch target, high-contrast primary
- * control, and supporting copy for VoiceOver and TalkBack. Shows **Resume episode** when
- * {@link ActiveEpisodeHomeSummary} is provided.
+ * control, and supporting copy for VoiceOver and TalkBack. CTA mode updates use
+ * `accessibilityLiveRegion` on Android only and `announce()` elsewhere so assistive output is not
+ * duplicated. Shows **Resume episode** when {@link ActiveEpisodeHomeSummary} is provided.
  *
  * @param props - Props.
  * @returns Episode CTA section for the home screen.
@@ -45,6 +46,12 @@ export function EpisodeStartHomeCta({
       return;
     }
     prevResumeRef.current = hasResume;
+    // Android: TalkBack announces `accessibilityLiveRegion` on the description Text — skip
+    // `announce` to avoid duplicate output. Other platforms: rely on `announce` (iOS VoiceOver;
+    // web/other builds do not use the Android live region).
+    if (Platform.OS === 'android') {
+      return;
+    }
     if (hasResume) {
       void announce(
         'You have an episode in progress. Resume episode is the primary action.',
@@ -76,7 +83,9 @@ export function EpisodeStartHomeCta({
       <Text
         className={`text-base leading-relaxed ${nw.textMuted}`}
         maxFontSizeMultiplier={2}
-        accessibilityLiveRegion="polite"
+        accessibilityLiveRegion={
+          Platform.OS === 'android' ? 'polite' : undefined
+        }
       >
         {activeEpisodeLoading && 'Checking for an episode in progress…'}
         {!activeEpisodeLoading &&

--- a/apps/mobile/src/app/navigation/MainTabNavigator.tsx
+++ b/apps/mobile/src/app/navigation/MainTabNavigator.tsx
@@ -5,6 +5,7 @@ import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
 import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
+import type { ActiveEpisodeHomeSummary } from '../components/episode-flow/EpisodeStartHomeCta';
 import { HomeScreen } from '../screens/HomeScreen';
 import { EpisodeTemplatesNavigator } from './EpisodeTemplatesNavigator';
 import { HealthMarkerPresetsNavigator } from './HealthMarkerPresetsNavigator';
@@ -46,6 +47,24 @@ function navigateFromHomeTabToEpisodeStart(
     );
   }
   stackNavigation.navigate('EpisodeStart');
+}
+
+function navigateFromHomeTabToSymptomPromptResume(
+  navigation: BottomTabNavigationProp<MainTabParamList, 'Home'>,
+  episode: ActiveEpisodeHomeSummary,
+) {
+  const stackNavigation =
+    navigation.getParent<NativeStackNavigationProp<MainStackParamList>>();
+  if (stackNavigation == null) {
+    throw new Error(
+      'MainTabNavigator: expected native stack parent (MainStack) to open SymptomPrompt.',
+    );
+  }
+  stackNavigation.navigate('SymptomPrompt', {
+    episodeId: episode.episodeId,
+    symptomPresetId: episode.symptomPresetId,
+    resume: true,
+  });
 }
 
 type IonName = React.ComponentProps<typeof Ionicons>['name'];
@@ -112,6 +131,9 @@ export function MainTabNavigator() {
               }}
               onStartEpisode={() => {
                 navigateFromHomeTabToEpisodeStart(navigation);
+              }}
+              onResumeEpisode={(episode) => {
+                navigateFromHomeTabToSymptomPromptResume(navigation, episode);
               }}
             />
           )}

--- a/apps/mobile/src/app/navigation/types.ts
+++ b/apps/mobile/src/app/navigation/types.ts
@@ -35,6 +35,11 @@ export type MainStackParamList = {
   /** Episode logging entry: shell until template selection and prompts ship. */
   EpisodeStart: undefined;
   /** Linear symptom prompts for the active episode (preset lines). */
-  SymptomPrompt: { episodeId: string; symptomPresetId: string };
+  SymptomPrompt: {
+    episodeId: string;
+    symptomPresetId: string;
+    /** When true, initial step is derived from saved answers (e.g. home “Resume episode”). */
+    resume?: boolean;
+  };
   Settings: undefined;
 };

--- a/apps/mobile/src/app/screens/HomeScreen.tsx
+++ b/apps/mobile/src/app/screens/HomeScreen.tsx
@@ -1,13 +1,17 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Pressable, ScrollView, Text, View } from 'react-native';
 import {
+  getActiveEpisodeForUser,
   getAuthUser,
   healthCheckProfilesLimit1,
   signOut,
 } from '@abstrack/supabase';
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { mapAuthError } from '../auth-helpers';
-import { EpisodeStartHomeCta } from '../components/episode-flow/EpisodeStartHomeCta';
+import {
+  EpisodeStartHomeCta,
+  type ActiveEpisodeHomeSummary,
+} from '../components/episode-flow/EpisodeStartHomeCta';
 import { AppNavigationShell } from '../components/AppNavigationShell';
 import { nw } from '../theme/app-nativewind-classes';
 
@@ -20,11 +24,13 @@ interface HealthCheckResult {
 type HomeScreenProps = {
   onGoToSettings: () => void;
   onStartEpisode: () => void;
+  onResumeEpisode: (episode: ActiveEpisodeHomeSummary) => void;
 };
 
 export function HomeScreen({
   onGoToSettings,
   onStartEpisode,
+  onResumeEpisode,
 }: HomeScreenProps) {
   const isTestEnv =
     typeof process !== 'undefined' && process.env.NODE_ENV === 'test';
@@ -35,6 +41,53 @@ export function HomeScreen({
   const [healthCheck, setHealthCheck] = useState<HealthCheckResult | null>(
     null,
   );
+  const [activeEpisode, setActiveEpisode] =
+    useState<ActiveEpisodeHomeSummary | null>(null);
+  const [activeEpisodeLoading, setActiveEpisodeLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadActiveEpisode = async () => {
+      setActiveEpisodeLoading(true);
+      try {
+        const mobileSupabase = getMobileSupabaseClient();
+        const {
+          data: { user },
+        } = await mobileSupabase.auth.getUser();
+        if (cancelled) {
+          return;
+        }
+        if (!user) {
+          setActiveEpisode(null);
+          return;
+        }
+        const result = await getActiveEpisodeForUser(mobileSupabase, user.id);
+        if (cancelled) {
+          return;
+        }
+        if (!result.ok || !result.data?.symptom_preset_id) {
+          setActiveEpisode(null);
+          return;
+        }
+        setActiveEpisode({
+          episodeId: result.data.id,
+          symptomPresetId: result.data.symptom_preset_id,
+        });
+      } catch {
+        if (!cancelled) {
+          setActiveEpisode(null);
+        }
+      } finally {
+        if (!cancelled) {
+          setActiveEpisodeLoading(false);
+        }
+      }
+    };
+    void loadActiveEpisode();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -135,7 +188,12 @@ export function HomeScreen({
         }}
         keyboardShouldPersistTaps="handled"
       >
-        <EpisodeStartHomeCta onStartEpisode={onStartEpisode} />
+        <EpisodeStartHomeCta
+          onStartEpisode={onStartEpisode}
+          onResumeEpisode={onResumeEpisode}
+          activeEpisode={activeEpisode}
+          activeEpisodeLoading={activeEpisodeLoading}
+        />
 
         <View className={`gap-3 rounded-xl p-4 ${nw.card} ${nw.cardShadow}`}>
           <Text

--- a/apps/mobile/src/app/screens/HomeScreen.tsx
+++ b/apps/mobile/src/app/screens/HomeScreen.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Pressable, ScrollView, Text, View } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
 import {
   getActiveEpisodeForUser,
   getAuthUser,
@@ -45,16 +46,17 @@ export function HomeScreen({
     useState<ActiveEpisodeHomeSummary | null>(null);
   const [activeEpisodeLoading, setActiveEpisodeLoading] = useState(true);
 
-  useEffect(() => {
-    let cancelled = false;
-    const loadActiveEpisode = async () => {
+  const loadActiveEpisode = useCallback(
+    async (cancel?: { cancelled: boolean }) => {
+      const stale = () => cancel?.cancelled === true;
+
       setActiveEpisodeLoading(true);
       try {
         const mobileSupabase = getMobileSupabaseClient();
         const {
           data: { user },
         } = await mobileSupabase.auth.getUser();
-        if (cancelled) {
+        if (stale()) {
           return;
         }
         if (!user) {
@@ -62,7 +64,7 @@ export function HomeScreen({
           return;
         }
         const result = await getActiveEpisodeForUser(mobileSupabase, user.id);
-        if (cancelled) {
+        if (stale()) {
           return;
         }
         if (!result.ok || !result.data?.symptom_preset_id) {
@@ -74,20 +76,41 @@ export function HomeScreen({
           symptomPresetId: result.data.symptom_preset_id,
         });
       } catch {
-        if (!cancelled) {
+        if (!stale()) {
           setActiveEpisode(null);
         }
       } finally {
-        if (!cancelled) {
+        if (!stale()) {
           setActiveEpisodeLoading(false);
         }
       }
-    };
-    void loadActiveEpisode();
+    },
+    [],
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      const cancel = { cancelled: false };
+      void loadActiveEpisode(cancel);
+      return () => {
+        cancel.cancelled = true;
+      };
+    }, [loadActiveEpisode]),
+  );
+
+  useEffect(() => {
+    const supabase = getMobileSupabaseClient();
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event) => {
+      if (event === 'SIGNED_IN' || event === 'SIGNED_OUT') {
+        void loadActiveEpisode();
+      }
+    });
     return () => {
-      cancelled = true;
+      subscription.unsubscribe();
     };
-  }, []);
+  }, [loadActiveEpisode]);
 
   useEffect(() => {
     isMountedRef.current = true;

--- a/apps/mobile/src/app/screens/HomeScreen.tsx
+++ b/apps/mobile/src/app/screens/HomeScreen.tsx
@@ -46,9 +46,14 @@ export function HomeScreen({
     useState<ActiveEpisodeHomeSummary | null>(null);
   const [activeEpisodeLoading, setActiveEpisodeLoading] = useState(true);
 
+  /** Bumped on each load start and on blur/unmount so in-flight loads never win over newer work. */
+  const loadGenerationRef = useRef(0);
+
   const loadActiveEpisode = useCallback(
     async (cancel?: { cancelled: boolean }) => {
-      const stale = () => cancel?.cancelled === true;
+      const generation = ++loadGenerationRef.current;
+      const stale = () =>
+        cancel?.cancelled === true || generation !== loadGenerationRef.current;
 
       setActiveEpisodeLoading(true);
       try {
@@ -94,6 +99,7 @@ export function HomeScreen({
       void loadActiveEpisode(cancel);
       return () => {
         cancel.cancelled = true;
+        loadGenerationRef.current += 1;
       };
     }, [loadActiveEpisode]),
   );
@@ -109,6 +115,7 @@ export function HomeScreen({
     });
     return () => {
       subscription.unsubscribe();
+      loadGenerationRef.current += 1;
     };
   }, [loadActiveEpisode]);
 

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
@@ -473,7 +473,7 @@ describe('SymptomPromptScreen', () => {
 
     expect(alertSpy).toHaveBeenCalledWith(
       'Exit symptom flow?',
-      'If you exit now, you will return home. Starting again creates a new episode.',
+      'If you exit now, you will return home. This episode stays open, your progress is saved, and you can resume from home when you are ready.',
       expect.any(Array),
     );
     expect(mockGoBack).not.toHaveBeenCalled();

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
@@ -410,7 +410,13 @@ describe('SymptomPromptScreen', () => {
     });
   });
 
-  test('restores activeIndex from session after load', async () => {
+  test('resume: false restores activeIndex from session after load', async () => {
+    jest.mocked(useRoute).mockReturnValue({
+      key: 'SymptomPrompt',
+      name: 'SymptomPrompt',
+      params: { episodeId, symptomPresetId, resume: false },
+    } as never);
+
     jest.mocked(getSymptomPromptSession).mockReturnValue({
       activeIndex: 1,
       answers: {},
@@ -423,6 +429,136 @@ describe('SymptomPromptScreen', () => {
     });
 
     expect(screen.getByText('Headache')).toBeTruthy();
+  });
+
+  test('resume: false uses session index even when server has progress on earlier lines', async () => {
+    jest.mocked(useRoute).mockReturnValue({
+      key: 'SymptomPrompt',
+      name: 'SymptomPrompt',
+      params: { episodeId, symptomPresetId, resume: false },
+    } as never);
+
+    jest.mocked(getSymptomPromptSession).mockReturnValue({
+      activeIndex: 0,
+      answers: {},
+    });
+
+    jest.mocked(listEpisodeSymptomsForEpisode).mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          id: 'es-a',
+          user_id: 'test-user-1',
+          episode_id: episodeId,
+          preset_symptom_id: lineA.id,
+          symptom_name: lineA.symptom_name,
+          response_type: 'yes_no',
+          response_boolean: true,
+          response_severity: null,
+          response_text: null,
+          sort_order: 0,
+          created_at: '2020-01-01T00:00:00Z',
+          updated_at: '2020-01-01T00:00:00Z',
+        },
+      ],
+    });
+
+    const screen = render(<SymptomPromptScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 1 of 2')).toBeTruthy();
+    });
+    expect(screen.getByText('Nausea')).toBeTruthy();
+  });
+
+  test('resume: true lands on first unanswered line from merged server+session', async () => {
+    jest.mocked(useRoute).mockReturnValue({
+      key: 'SymptomPrompt',
+      name: 'SymptomPrompt',
+      params: { episodeId, symptomPresetId, resume: true },
+    } as never);
+
+    jest.mocked(getSymptomPromptSession).mockReturnValue({
+      activeIndex: 0,
+      answers: {},
+    });
+
+    jest.mocked(listEpisodeSymptomsForEpisode).mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          id: 'es-a',
+          user_id: 'test-user-1',
+          episode_id: episodeId,
+          preset_symptom_id: lineA.id,
+          symptom_name: lineA.symptom_name,
+          response_type: 'yes_no',
+          response_boolean: true,
+          response_severity: null,
+          response_text: null,
+          sort_order: 0,
+          created_at: '2020-01-01T00:00:00Z',
+          updated_at: '2020-01-01T00:00:00Z',
+        },
+      ],
+    });
+
+    const screen = render(<SymptomPromptScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 2 of 2')).toBeTruthy();
+    });
+    expect(screen.getByText('Headache')).toBeTruthy();
+  });
+
+  test('resume: true shows complete phase when every line is answered on the server', async () => {
+    jest.mocked(useRoute).mockReturnValue({
+      key: 'SymptomPrompt',
+      name: 'SymptomPrompt',
+      params: { episodeId, symptomPresetId, resume: true },
+    } as never);
+
+    jest.mocked(listEpisodeSymptomsForEpisode).mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          id: 'es-a',
+          user_id: 'test-user-1',
+          episode_id: episodeId,
+          preset_symptom_id: lineA.id,
+          symptom_name: lineA.symptom_name,
+          response_type: 'yes_no',
+          response_boolean: true,
+          response_severity: null,
+          response_text: null,
+          sort_order: 0,
+          created_at: '2020-01-01T00:00:00Z',
+          updated_at: '2020-01-01T00:00:00Z',
+        },
+        {
+          id: 'es-b',
+          user_id: 'test-user-1',
+          episode_id: episodeId,
+          preset_symptom_id: lineB.id,
+          symptom_name: lineB.symptom_name,
+          response_type: 'severity_scale',
+          response_boolean: null,
+          response_severity: 3,
+          response_text: null,
+          sort_order: 1,
+          created_at: '2020-01-01T00:00:00Z',
+          updated_at: '2020-01-01T00:00:00Z',
+        },
+      ],
+    });
+
+    const screen = render(<SymptomPromptScreen />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/You reached the end of your symptom list/),
+      ).toBeTruthy();
+    });
   });
 
   test('Skip on free-text flushes immediately after answer is cleared', async () => {

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -19,6 +19,7 @@ import type {
   SymptomPromptAnswers,
 } from '@abstrack/types';
 import {
+  computeSymptomResumePlacement,
   createDefaultSymptomPromptAnswer,
   episodeSymptomRowsToAnswersMap,
   symptomPromptAnswerHasValue,
@@ -76,7 +77,16 @@ const SERVER_SYMPTOM_PERSIST_DEBOUNCE_MS = 300;
 export function SymptomPromptScreen() {
   const navigation = useNavigation<SymptomPromptNav>();
   const route = useRoute<SymptomPromptRoute>();
-  const { episodeId, symptomPresetId } = route.params;
+  const {
+    episodeId,
+    symptomPresetId,
+    resume: resumeFromEntry = false,
+  } = route.params;
+
+  const resumeFromHomeIntentRef = useRef(!!resumeFromEntry);
+  if (resumeFromEntry) {
+    resumeFromHomeIntentRef.current = true;
+  }
 
   const [status, setStatus] = useState<'loading' | 'error' | 'ready'>(
     'loading',
@@ -146,11 +156,11 @@ export function SymptomPromptScreen() {
     [],
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     answersRef.current = answers;
   }, [answers]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     activeIndexRef.current = activeIndex;
   }, [activeIndex]);
 
@@ -421,11 +431,31 @@ export function SymptomPromptScreen() {
       const session = getSymptomPromptSession(episodeId);
       // Session overlays server so local drafts survive hydrate (debounced/offline/failed sync).
       const mergedAnswers = { ...serverAnswers, ...session.answers };
-      const idx = clampIndex(session.activeIndex, result.data.length);
+      let idx: number;
+      let initialPhase: 'prompting' | 'complete' = 'prompting';
+      const treatAsResumeFromHome = resumeFromHomeIntentRef.current;
+      if (treatAsResumeFromHome) {
+        const placement = computeSymptomResumePlacement(
+          result.data,
+          mergedAnswers,
+        );
+        if (placement.phase === 'complete') {
+          idx = placement.activeIndex;
+          initialPhase = 'complete';
+        } else {
+          const sIdx = clampIndex(session.activeIndex, result.data.length);
+          const pIdx = placement.activeIndex;
+          idx = clampIndex(Math.max(sIdx, pIdx), result.data.length);
+          initialPhase = 'prompting';
+        }
+      } else {
+        idx = clampIndex(session.activeIndex, result.data.length);
+      }
       activeIndexRef.current = idx;
       setActiveIndex(idx);
       setAnswers(mergedAnswers);
       answersRef.current = mergedAnswers;
+      setPhase(initialPhase);
       setSymptomPromptSession(episodeId, {
         activeIndex: idx,
         answers: mergedAnswers,
@@ -514,7 +544,7 @@ export function SymptomPromptScreen() {
   const confirmExitFlow = useCallback((action: () => void) => {
     Alert.alert(
       'Exit symptom flow?',
-      'If you exit now, you will return home. Starting again creates a new episode.',
+      'If you exit now, you will return home. This episode stays open, your progress is saved, and you can resume from home when you are ready.',
       [
         { text: 'Stay here', style: 'cancel' },
         {
@@ -529,7 +559,10 @@ export function SymptomPromptScreen() {
   /** Matches {@link onFinishToHome}: reset stack to MainTabs so copy matches behavior (not `goBack`). */
   const exitSymptomFlowToHome = useCallback(() => {
     flushPendingServerPersist();
-    clearSymptomPromptSession(episodeId);
+    setSymptomPromptSession(episodeIdRef.current, {
+      activeIndex: activeIndexRef.current,
+      answers: answersRef.current,
+    });
     allowRemovalRef.current = true;
     navigation.dispatch(
       CommonActions.reset({
@@ -537,7 +570,7 @@ export function SymptomPromptScreen() {
         routes: [{ name: 'MainTabs' }],
       }),
     );
-  }, [episodeId, flushPendingServerPersist, navigation]);
+  }, [flushPendingServerPersist, navigation]);
 
   const requestExitToHome = useCallback(() => {
     confirmExitFlow(() => {

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -83,10 +83,8 @@ export function SymptomPromptScreen() {
     resume: resumeFromEntry = false,
   } = route.params;
 
+  /** Synced in {@link useLayoutEffect} when route params change so a latched “resume” does not apply to the next episode while this screen stays mounted. */
   const resumeFromHomeIntentRef = useRef(!!resumeFromEntry);
-  if (resumeFromEntry) {
-    resumeFromHomeIntentRef.current = true;
-  }
 
   const [status, setStatus] = useState<'loading' | 'error' | 'ready'>(
     'loading',
@@ -484,6 +482,7 @@ export function SymptomPromptScreen() {
 
   useLayoutEffect(() => {
     flushPendingServerPersist();
+    resumeFromHomeIntentRef.current = !!resumeFromEntry;
     episodeIdRef.current = episodeId;
     const s = getSymptomPromptSession(episodeId);
     activeIndexRef.current = s.activeIndex;
@@ -495,7 +494,7 @@ export function SymptomPromptScreen() {
     setErrorMessage(null);
     setPersistError(null);
     setLines([]);
-  }, [episodeId, symptomPresetId, flushPendingServerPersist]);
+  }, [episodeId, symptomPresetId, resumeFromEntry, flushPendingServerPersist]);
 
   const currentLine = lines[activeIndex] ?? null;
   const currentAnswer = currentLine ? answers[currentLine.id] : undefined;

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,4 +1,5 @@
 //@ts-check
+const path = require('path');
 const { composePlugins, withNx } = require('@nx/next');
 
 /**
@@ -8,11 +9,24 @@ const nextConfig = {
   // Use this to set Nx-specific options
   // See: https://nx.dev/recipes/next/next-config-setup
   nx: {},
-  transpilePackages: ['@abstrack/ui', 'react-native', 'react-native-web'],
+  // Transpile workspace packages. `@abstrack/types` must match TS `customConditions: @abstrack/source`
+  // so the dev server does not bundle a stale `packages/types/dist` (see webpack alias below).
+  transpilePackages: [
+    '@abstrack/ui',
+    '@abstrack/types',
+    'react-native',
+    'react-native-web',
+  ],
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
       'react-native$': 'react-native-web',
+      // Resolve to source: package `exports` default points at `dist/`, which is easy to forget to
+      // rebuild and causes runtime undefined exports (e.g. new helpers not in dist yet).
+      '@abstrack/types': path.join(
+        __dirname,
+        '../../packages/types/src/index.ts',
+      ),
     };
     return config;
   },

--- a/apps/web/src/app/(app)/episode/[episodeId]/symptoms/page.tsx
+++ b/apps/web/src/app/(app)/episode/[episodeId]/symptoms/page.tsx
@@ -4,7 +4,7 @@ import { SymptomPromptFlow } from '@/components/episode-flow/SymptomPromptFlow';
 type PageProps = {
   /** Next.js 16 passes dynamic route params as a Promise (await before use). */
   params: Promise<{ episodeId: string }>;
-  searchParams: Promise<{ symptomPresetId?: string }>;
+  searchParams: Promise<{ symptomPresetId?: string; resume?: string }>;
 };
 
 /**
@@ -18,7 +18,9 @@ export default async function EpisodeSymptomsPage({
   searchParams,
 }: PageProps) {
   const { episodeId } = await params;
-  const { symptomPresetId } = await searchParams;
+  const { symptomPresetId, resume } = await searchParams;
+  const resumeFromEntry =
+    resume === '1' || resume === 'true' || resume === 'yes';
 
   if (!symptomPresetId) {
     return (
@@ -46,6 +48,7 @@ export default async function EpisodeSymptomsPage({
     <SymptomPromptFlow
       episodeId={episodeId}
       symptomPresetId={symptomPresetId}
+      resumeFromEntry={resumeFromEntry}
     />
   );
 }

--- a/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
@@ -1,20 +1,43 @@
 'use client';
 
 import Link from 'next/link';
-import { useId } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
+import { getActiveEpisodeForUser } from '@abstrack/supabase';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import { createBrowserClient } from '@/lib/supabase/browser-client';
+import { useAuth } from '@/lib/auth-provider';
 
 export type EpisodeStartHomeCtaProps = {
   /** Extra classes for the outer section (spacing, etc.). */
   className?: string;
 };
 
+type CtaMode = 'loading' | 'resume' | 'start';
+
 /**
- * Prominent home entry point for the episode logging flow: large target, high-contrast primary
- * control, and supporting copy for keyboard and touch users. Uses {@link useId} so multiple
- * instances on one page do not duplicate DOM ids or break ARIA references.
+ * Builds the symptom flow URL with resume placement so the stepper opens at the correct line.
+ *
+ * @param episodeId - `episodes.id`.
+ * @param symptomPresetId - `symptom_presets.id` on the episode row.
+ * @returns Path under `/episode/[id]/symptoms`.
+ */
+function buildResumeEpisodeHref(
+  episodeId: string,
+  symptomPresetId: string,
+): string {
+  const q = new URLSearchParams();
+  q.set('symptomPresetId', symptomPresetId);
+  q.set('resume', '1');
+  return `/episode/${episodeId}/symptoms?${q.toString()}`;
+}
+
+/**
+ * Prominent home entry for episode logging: detects an active episode and offers **Resume** as the
+ * primary action; otherwise **I'm having an episode** starts a new flow. Announces mode changes for
+ * assistive tech.
  *
  * @param props - Props.
- * @returns Section with link to the episode-start shell route.
+ * @returns Section with primary CTA for signed-in users.
  */
 export function EpisodeStartHomeCta({
   className = '',
@@ -22,6 +45,85 @@ export function EpisodeStartHomeCta({
   const instanceId = useId();
   const headingId = `episode-start-home-cta-heading${instanceId}`;
   const descId = `episode-start-home-cta-desc${instanceId}`;
+  const statusId = `episode-start-home-cta-status${instanceId}`;
+
+  const { session, loading: authLoading } = useAuth();
+  const { announce } = useAnnounce();
+  const announcedFromLoadingRef = useRef(false);
+
+  const [ctaMode, setCtaMode] = useState<CtaMode>('loading');
+  const [resumeHref, setResumeHref] = useState<string | null>(null);
+
+  useEffect(() => {
+    announcedFromLoadingRef.current = false;
+  }, [session?.user?.id]);
+
+  useEffect(() => {
+    if (authLoading) {
+      return;
+    }
+    const userId = session?.user?.id;
+    if (!userId) {
+      setCtaMode('start');
+      setResumeHref(null);
+      return;
+    }
+
+    let cancelled = false;
+    setCtaMode('loading');
+    setResumeHref(null);
+
+    const run = async (): Promise<void> => {
+      const supabase = createBrowserClient();
+      const result = await getActiveEpisodeForUser(supabase, userId);
+      if (cancelled) {
+        return;
+      }
+      if (!result.ok) {
+        setCtaMode('start');
+        setResumeHref(null);
+        return;
+      }
+      const row = result.data;
+      const presetId = row?.symptom_preset_id ?? null;
+      if (row && presetId) {
+        setResumeHref(buildResumeEpisodeHref(row.id, presetId));
+        setCtaMode('resume');
+        return;
+      }
+      setCtaMode('start');
+      setResumeHref(null);
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authLoading, session?.user?.id]);
+
+  useEffect(() => {
+    if (ctaMode === 'loading' || authLoading) {
+      return;
+    }
+    if (!announcedFromLoadingRef.current) {
+      announcedFromLoadingRef.current = true;
+      if (ctaMode === 'resume') {
+        announce(
+          'You have an episode in progress. Resume episode is available as the primary action.',
+          { politeness: 'polite' },
+        );
+      } else {
+        announce(
+          'No episode in progress. You can start logging a new episode.',
+          { politeness: 'polite' },
+        );
+      }
+    }
+  }, [announce, authLoading, ctaMode]);
+
+  const primaryLinkClass =
+    'inline-flex min-h-[56px] w-full items-center justify-center rounded-xl bg-red-700 px-5 py-4 text-center text-base font-semibold leading-snug text-white shadow-md outline-none ring-2 ring-transparent transition hover:bg-red-800 focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-red-50 dark:bg-red-600 dark:hover:bg-red-500 dark:focus-visible:ring-offset-red-950';
 
   return (
     <section
@@ -35,17 +137,46 @@ export function EpisodeStartHomeCta({
         Episode logging
       </h2>
       <p id={descId} className="mt-1.5 text-sm leading-relaxed text-app-muted">
-        Opens the guided flow to record what you are experiencing during this
-        episode.
+        {ctaMode === 'loading' && 'Checking for an episode in progress…'}
+        {ctaMode === 'resume' &&
+          'You have an episode in progress. Continue where you left off in the guided symptom flow.'}
+        {ctaMode === 'start' &&
+          'Opens the guided flow to record what you are experiencing during this episode.'}
+      </p>
+      <p id={statusId} className="sr-only" role="status" aria-live="polite">
+        {ctaMode === 'loading' && 'Checking for an in-progress episode.'}
+        {ctaMode === 'resume' &&
+          'An episode is in progress. Primary action: Resume episode.'}
+        {ctaMode === 'start' &&
+          'No episode in progress. Primary action: start a new episode.'}
       </p>
       <div className="mt-5">
-        <Link
-          href="/episode/start"
-          className="inline-flex min-h-[56px] w-full items-center justify-center rounded-xl bg-red-700 px-5 py-4 text-center text-base font-semibold leading-snug text-white shadow-md outline-none ring-2 ring-transparent transition hover:bg-red-800 focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-red-50 dark:bg-red-600 dark:hover:bg-red-500 dark:focus-visible:ring-offset-red-950"
-          aria-describedby={descId}
-        >
-          I&apos;m having an episode
-        </Link>
+        {ctaMode === 'loading' && (
+          <div
+            className="inline-flex min-h-[56px] w-full items-center justify-center rounded-xl border border-app-border/80 bg-app-surface/80 px-5 py-4 text-center text-sm font-medium text-app-muted"
+            aria-busy="true"
+          >
+            Loading…
+          </div>
+        )}
+        {ctaMode === 'resume' && resumeHref !== null && (
+          <Link
+            href={resumeHref}
+            className={primaryLinkClass}
+            aria-describedby={`${descId} ${statusId}`}
+          >
+            Resume episode
+          </Link>
+        )}
+        {ctaMode === 'start' && (
+          <Link
+            href="/episode/start"
+            className={primaryLinkClass}
+            aria-describedby={descId}
+          >
+            I&apos;m having an episode
+          </Link>
+        )}
       </div>
     </section>
   );

--- a/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useId, useRef, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 import { getActiveEpisodeForUser } from '@abstrack/supabase';
-import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { useAuth } from '@/lib/auth-provider';
 
@@ -15,7 +14,10 @@ export type EpisodeStartHomeCtaProps = {
 type CtaMode = 'loading' | 'resume' | 'start';
 
 /**
- * Builds the symptom flow URL with resume placement so the stepper opens at the correct line.
+ * Builds the `/episode/[id]/symptoms` URL for continuing an active episode: `symptomPresetId`
+ * selects the preset, and `resume=1` tells {@link SymptomPromptFlow} to hydrate with resume logic.
+ * The step index is **not** in the query string; it is computed in the flow from merged server +
+ * session answers (and related resume handling).
  *
  * @param episodeId - `episodes.id`.
  * @param symptomPresetId - `symptom_presets.id` on the episode row.
@@ -33,8 +35,8 @@ function buildResumeEpisodeHref(
 
 /**
  * Prominent home entry for episode logging: detects an active episode and offers **Resume** as the
- * primary action; otherwise **I'm having an episode** starts a new flow. Announces mode changes for
- * assistive tech.
+ * primary action; otherwise **I'm having an episode** starts a new flow. CTA mode is conveyed to
+ * assistive technologies via a single `aria-live` status region (no duplicate transient announce).
  *
  * @param props - Props.
  * @returns Section with primary CTA for signed-in users.
@@ -48,15 +50,9 @@ export function EpisodeStartHomeCta({
   const statusId = `episode-start-home-cta-status${instanceId}`;
 
   const { session, loading: authLoading } = useAuth();
-  const { announce } = useAnnounce();
-  const announcedFromLoadingRef = useRef(false);
 
   const [ctaMode, setCtaMode] = useState<CtaMode>('loading');
   const [resumeHref, setResumeHref] = useState<string | null>(null);
-
-  useEffect(() => {
-    announcedFromLoadingRef.current = false;
-  }, [session?.user?.id]);
 
   useEffect(() => {
     if (authLoading) {
@@ -101,26 +97,6 @@ export function EpisodeStartHomeCta({
       cancelled = true;
     };
   }, [authLoading, session?.user?.id]);
-
-  useEffect(() => {
-    if (ctaMode === 'loading' || authLoading) {
-      return;
-    }
-    if (!announcedFromLoadingRef.current) {
-      announcedFromLoadingRef.current = true;
-      if (ctaMode === 'resume') {
-        announce(
-          'You have an episode in progress. Resume episode is available as the primary action.',
-          { politeness: 'polite' },
-        );
-      } else {
-        announce(
-          'No episode in progress. You can start logging a new episode.',
-          { politeness: 'polite' },
-        );
-      }
-    }
-  }, [announce, authLoading, ctaMode]);
 
   const primaryLinkClass =
     'inline-flex min-h-[56px] w-full items-center justify-center rounded-xl bg-red-700 px-5 py-4 text-center text-base font-semibold leading-snug text-white shadow-md outline-none ring-2 ring-transparent transition hover:bg-red-800 focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-red-50 dark:bg-red-600 dark:hover:bg-red-500 dark:focus-visible:ring-offset-red-950';

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -150,8 +150,10 @@ export function SymptomPromptFlow({
   const [discardDialogOpen, setDiscardDialogOpen] = useState(false);
   const pendingLeaveRef = useRef<PendingLeaveAction | null>(null);
   /**
-   * Stays true once this mount ever saw `resumeFromEntry` so stripping `resume` from the URL does
-   * not flip {@link load} behavior when the server re-renders with updated search params.
+   * When `episodeId` / `symptomPresetId` change, the layout reset syncs this to `resumeFromEntry` so a
+   * new episode is not stuck in “resume from home” after visiting with `?resume=1` earlier.
+   * While the route is unchanged, `resumeFromEntry` may become true later, or the URL may strip
+   * `resume` after load — the render latch below keeps intent stable for that case.
    */
   const resumeFromHomeIntentRef = useRef(!!resumeFromEntry);
   if (resumeFromEntry) {
@@ -389,6 +391,7 @@ export function SymptomPromptFlow({
       });
     }
     flushPendingServerPersist();
+    resumeFromHomeIntentRef.current = !!resumeFromEntry;
     episodeIdRef.current = episodeId;
     const s = getSymptomPromptSession(episodeId);
     setActiveIndex(s.activeIndex);

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -15,6 +15,7 @@ import type {
   SymptomPromptAnswers,
 } from '@abstrack/types';
 import {
+  computeSymptomResumePlacement,
   createDefaultSymptomPromptAnswer,
   createInitialSymptomPromptSession,
   episodeSymptomRowsToAnswersMap,
@@ -45,6 +46,11 @@ export type SymptomPromptFlowProps = {
   episodeId: string;
   /** `symptom_presets.id` for the active episode (from template at start). */
   symptomPresetId: string;
+  /**
+   * When true (e.g. `?resume=1` from home), initial step follows merged server + session answers
+   * instead of session index alone.
+   */
+  resumeFromEntry?: boolean;
 };
 
 /** Delay before writing free-text drafts to `sessionStorage` (keystrokes stay snappy in React state). */
@@ -85,6 +91,7 @@ const SYMPTOM_FLOW_LEAVE_GUARD_EXEMPT_FORM_ID =
 export function SymptomPromptFlow({
   episodeId,
   symptomPresetId,
+  resumeFromEntry = false,
 }: SymptomPromptFlowProps) {
   const router = useRouter();
   const { announce } = useAnnounce();
@@ -142,6 +149,14 @@ export function SymptomPromptFlow({
 
   const [discardDialogOpen, setDiscardDialogOpen] = useState(false);
   const pendingLeaveRef = useRef<PendingLeaveAction | null>(null);
+  /**
+   * Stays true once this mount ever saw `resumeFromEntry` so stripping `resume` from the URL does
+   * not flip {@link load} behavior when the server re-renders with updated search params.
+   */
+  const resumeFromHomeIntentRef = useRef(!!resumeFromEntry);
+  if (resumeFromEntry) {
+    resumeFromHomeIntentRef.current = true;
+  }
 
   const supabase = useMemo(() => createBrowserClient(), []);
 
@@ -166,11 +181,12 @@ export function SymptomPromptFlow({
     [],
   );
 
-  useEffect(() => {
+  /** Keep refs aligned before paint so exit / unmount persist cannot read a stale step after Next. */
+  useLayoutEffect(() => {
     activeIndexRef.current = activeIndex;
   }, [activeIndex]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     answersRef.current = answers;
   }, [answers]);
 
@@ -405,6 +421,10 @@ export function SymptomPromptFlow({
   const handleDiscardConfirm = useCallback(() => {
     flushPendingTextPersist();
     flushPendingServerPersist();
+    setSymptomPromptSession(episodeIdRef.current, {
+      activeIndex: activeIndexRef.current,
+      answers: answersRef.current,
+    });
     const action = pendingLeaveRef.current;
     pendingLeaveRef.current = null;
 
@@ -441,25 +461,14 @@ export function SymptomPromptFlow({
 
   useEffect(() => {
     return () => {
-      if (textPersistTimerRef.current === null) {
-        return;
-      }
-      clearTimeout(textPersistTimerRef.current);
-      textPersistTimerRef.current = null;
+      flushPendingTextPersist();
+      flushPendingServerPersist();
       setSymptomPromptSession(episodeIdRef.current, {
         activeIndex: activeIndexRef.current,
         answers: answersRef.current,
       });
     };
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      // Do not bump serverPersistEpochRef here — queued per-line writes should still reach Supabase;
-      // isMountedRef gates setPersistError after unmount.
-      flushPendingServerPersist();
-    };
-  }, [flushPendingServerPersist]);
+  }, [flushPendingServerPersist, flushPendingTextPersist]);
 
   const persistImmediate = useCallback(
     (nextIndex: number, nextAnswers: typeof answers) => {
@@ -510,11 +519,34 @@ export function SymptomPromptFlow({
     const session = getSymptomPromptSession(episodeId);
     // Session overlays server so local drafts survive hydrate (debounced/offline/failed sync).
     const mergedAnswers = { ...serverAnswers, ...session.answers };
-    const idx = clampIndex(session.activeIndex, result.data.length);
+    let idx: number;
+    let initialPhase: 'prompting' | 'complete' = 'prompting';
+    const treatAsResumeFromHome = resumeFromHomeIntentRef.current;
+    if (treatAsResumeFromHome) {
+      const placement = computeSymptomResumePlacement(
+        result.data,
+        mergedAnswers,
+      );
+      if (placement.phase === 'complete') {
+        idx = placement.activeIndex;
+        initialPhase = 'complete';
+      } else {
+        const sIdx = clampIndex(session.activeIndex, result.data.length);
+        const pIdx = placement.activeIndex;
+        // `session.activeIndex` can be 0 if persist ran before refs caught up with Next (fixed via
+        // useLayoutEffect). `placement` is first unanswered from merged server + session answers.
+        // Max covers stale 0 + answered first line → land on the second symptom as expected.
+        idx = clampIndex(Math.max(sIdx, pIdx), result.data.length);
+        initialPhase = 'prompting';
+      }
+    } else {
+      idx = clampIndex(session.activeIndex, result.data.length);
+    }
     setActiveIndex(idx);
     setAnswers(mergedAnswers);
     answersRef.current = mergedAnswers;
     activeIndexRef.current = idx;
+    setPhase(initialPhase);
     setSymptomPromptSession(episodeId, {
       activeIndex: idx,
       answers: mergedAnswers,
@@ -531,6 +563,21 @@ export function SymptomPromptFlow({
       loadGenRef.current += 1;
     };
   }, [load]);
+
+  useEffect(() => {
+    if (!resumeFromEntry || status !== 'ready') {
+      return;
+    }
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const url = new URL(window.location.href);
+    if (!url.searchParams.has('resume')) {
+      return;
+    }
+    url.searchParams.delete('resume');
+    router.replace(`${url.pathname}${url.search}${url.hash}`);
+  }, [resumeFromEntry, router, status]);
 
   const currentLine = lines[activeIndex] ?? null;
   const currentAnswer = currentLine ? answers[currentLine.id] : undefined;
@@ -839,7 +886,7 @@ export function SymptomPromptFlow({
       <ConfirmDialog
         open={discardDialogOpen}
         title="Exit symptom flow?"
-        description="If you exit now, you will return to the dashboard. Starting again creates a new episode."
+        description="If you exit now, you will return to the dashboard. This episode stays open, your progress is saved, and you can resume from home when you are ready."
         confirmLabel="Exit"
         cancelLabel="Stay"
         onConfirm={() => {

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -75,7 +75,11 @@ export {
   listEpisodeTemplates,
   updateEpisodeTemplate,
 } from './lib/episode-template-data.js';
-export { createEpisode, getEpisodeById } from './lib/episode-data.js';
+export {
+  createEpisode,
+  getActiveEpisodeForUser,
+  getEpisodeById,
+} from './lib/episode-data.js';
 export {
   deleteEpisodeSymptomAnswer,
   listEpisodeSymptomsForEpisode,

--- a/packages/supabase/src/lib/episode-data.spec.ts
+++ b/packages/supabase/src/lib/episode-data.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { EpisodeInsert, EpisodeRow } from '@abstrack/types';
-import { createEpisode, getEpisodeById } from './episode-data.js';
+import {
+  createEpisode,
+  getActiveEpisodeForUser,
+  getEpisodeById,
+} from './episode-data.js';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
 
 describe('createEpisode', () => {
@@ -83,6 +87,74 @@ describe('getEpisodeById', () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.data?.id).toBe('ep-1');
+    }
+  });
+});
+
+describe('getActiveEpisodeForUser', () => {
+  it('returns the newest active episode for the user', async () => {
+    const row: EpisodeRow = {
+      id: 'ep-active',
+      user_id: 'user-1',
+      symptom_preset_id: 'sym-1',
+      health_marker_preset_id: 'hm-1',
+      episode_type: 'Other',
+      episode_label: null,
+      note: null,
+      started_at: '2026-04-18T14:00:00.000Z',
+      ended_at: null,
+      created_at: '2026-04-18T14:00:00.000Z',
+      updated_at: '2026-04-18T14:00:00.000Z',
+    };
+    const client = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            is: vi.fn(() => ({
+              order: vi.fn(() => ({
+                limit: vi.fn(() => ({
+                  maybeSingle: vi.fn(async () => ({ data: row, error: null })),
+                })),
+              })),
+            })),
+          })),
+        })),
+      })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await getActiveEpisodeForUser(client, 'user-1');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data?.id).toBe('ep-active');
+      expect(result.data?.ended_at).toBeNull();
+    }
+    expect(client.from).toHaveBeenCalledWith('episodes');
+  });
+
+  it('returns null when no active episode exists', async () => {
+    const maybeSingle = vi.fn(async () => ({ data: null, error: null }));
+    const client = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            is: vi.fn(() => ({
+              order: vi.fn(() => ({
+                limit: vi.fn(() => ({
+                  maybeSingle,
+                })),
+              })),
+            })),
+          })),
+        })),
+      })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await getActiveEpisodeForUser(client, 'user-1');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toBeNull();
     }
   });
 });

--- a/packages/supabase/src/lib/episode-data.ts
+++ b/packages/supabase/src/lib/episode-data.ts
@@ -48,3 +48,34 @@ export async function getEpisodeById(
     return { ok: false, error: toPresetDataError(caught) };
   }
 }
+
+/**
+ * Returns the caller’s newest active episode (`ended_at IS NULL`), if any. Uses the same RLS as
+ * other `episodes` reads; when multiple active rows exist (unexpected), the most recently started
+ * wins.
+ *
+ * @param client - Supabase client (RLS applies).
+ * @param userId - `auth.users.id` / `episodes.user_id`.
+ * @returns The row, or `null` when there is no active episode.
+ */
+export async function getActiveEpisodeForUser(
+  client: AbstrackSupabaseClient,
+  userId: Uuid,
+): Promise<PresetDataResult<EpisodeRow | null>> {
+  try {
+    const { data, error } = await client
+      .from('episodes')
+      .select('*')
+      .eq('user_id', userId)
+      .is('ended_at', null)
+      .order('started_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (error) {
+      return { ok: false, error: toPresetDataError(error) };
+    }
+    return { ok: true, data: data as EpisodeRow | null };
+  } catch (caught) {
+    return { ok: false, error: toPresetDataError(caught) };
+  }
+}

--- a/packages/types/src/lib/symptom-prompt-session.spec.ts
+++ b/packages/types/src/lib/symptom-prompt-session.spec.ts
@@ -151,5 +151,17 @@ describe('symptom-prompt-session', () => {
       const placement = computeSymptomResumePlacement([a], {});
       expect(placement).toEqual({ activeIndex: 0, phase: 'prompting' });
     });
+
+    it('returns index 0 and prompting when the preset has no symptom lines', () => {
+      expect(computeSymptomResumePlacement([], {})).toEqual({
+        activeIndex: 0,
+        phase: 'prompting',
+      });
+      expect(
+        computeSymptomResumePlacement([], {
+          'orphan-id': { type: 'yes_no', value: true },
+        }),
+      ).toEqual({ activeIndex: 0, phase: 'prompting' });
+    });
   });
 });

--- a/packages/types/src/lib/symptom-prompt-session.spec.ts
+++ b/packages/types/src/lib/symptom-prompt-session.spec.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
+  computeSymptomResumePlacement,
   createDefaultSymptomPromptAnswer,
   createInitialSymptomPromptSession,
+  hasSymptomSessionTraversalProgress,
   symptomPromptAnswerHasValue,
 } from './symptom-prompt-session.js';
-import type { SymptomResponseType } from './types.js';
+import type { PresetSymptomRow, SymptomResponseType } from './types.js';
 
 describe('symptom-prompt-session', () => {
   it('createInitialSymptomPromptSession starts at first step with no answers', () => {
@@ -78,6 +80,76 @@ describe('symptom-prompt-session', () => {
       expect(symptomPromptAnswerHasValue({ type: 'video', value: null })).toBe(
         false,
       );
+    });
+  });
+
+  describe('hasSymptomSessionTraversalProgress', () => {
+    it('is false for the initial empty session', () => {
+      expect(
+        hasSymptomSessionTraversalProgress(createInitialSymptomPromptSession()),
+      ).toBe(false);
+    });
+
+    it('is true when activeIndex is past the first step', () => {
+      expect(
+        hasSymptomSessionTraversalProgress({
+          activeIndex: 2,
+          answers: {},
+        }),
+      ).toBe(true);
+    });
+
+    it('is true when answers map is non-empty even at step zero', () => {
+      expect(
+        hasSymptomSessionTraversalProgress({
+          activeIndex: 0,
+          answers: { 'line-1': { type: 'yes_no', value: true } },
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe('computeSymptomResumePlacement', () => {
+    const line = (
+      id: string,
+      sortOrder: number,
+      responseType: SymptomResponseType,
+    ): PresetSymptomRow => ({
+      id,
+      preset_id: 'preset-1',
+      sort_order: sortOrder,
+      symptom_name: 'S',
+      response_type: responseType,
+      prompt_instruction: null,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    });
+
+    it('returns the first unanswered line index', () => {
+      const a = line('a', 0, 'yes_no');
+      const b = line('b', 1, 'yes_no');
+      const c = line('c', 2, 'free_text');
+      const placement = computeSymptomResumePlacement([a, b, c], {
+        [a.id]: { type: 'yes_no', value: true },
+        [b.id]: { type: 'yes_no', value: false },
+      });
+      expect(placement).toEqual({ activeIndex: 2, phase: 'prompting' });
+    });
+
+    it('returns complete on the last line when every line is answered', () => {
+      const a = line('a', 0, 'yes_no');
+      const b = line('b', 1, 'yes_no');
+      const placement = computeSymptomResumePlacement([a, b], {
+        [a.id]: { type: 'yes_no', value: true },
+        [b.id]: { type: 'yes_no', value: false },
+      });
+      expect(placement).toEqual({ activeIndex: 1, phase: 'complete' });
+    });
+
+    it('returns prompting step zero when no answers exist', () => {
+      const a = line('a', 0, 'yes_no');
+      const placement = computeSymptomResumePlacement([a], {});
+      expect(placement).toEqual({ activeIndex: 0, phase: 'prompting' });
     });
   });
 });

--- a/packages/types/src/lib/symptom-prompt-session.ts
+++ b/packages/types/src/lib/symptom-prompt-session.ts
@@ -1,4 +1,4 @@
-import type { SymptomResponseType, Uuid } from './types.js';
+import type { PresetSymptomRow, SymptomResponseType, Uuid } from './types.js';
 
 /**
  * One stored answer for a preset symptom line during the Week 5 traversal skeleton.
@@ -89,4 +89,48 @@ export function symptomPromptAnswerHasValue(
       return _exhaustive;
     }
   }
+}
+
+/**
+ * Whether local session storage has meaningful traversal state (not the default empty session).
+ * Used to prefer the saved step index when resuming an episode on the same device.
+ *
+ * @param session - Stored session for one episode.
+ * @returns `true` when the user advanced past the first step and/or has draft answers keyed by line.
+ */
+export function hasSymptomSessionTraversalProgress(
+  session: SymptomPromptSessionState,
+): boolean {
+  if (session.activeIndex > 0) {
+    return true;
+  }
+  return Object.keys(session.answers).length > 0;
+}
+
+/**
+ * Picks the step index and completion phase when entering the symptom flow from a “resume” entry
+ * (e.g. home), using merged server + local answers. Walks preset lines in order and stops at the
+ * first line without a meaningful answer; if every line is filled, returns the last index and
+ * `complete` so the UI can show the completion state.
+ *
+ * @param lines - Ordered preset symptom lines for the episode’s symptom preset.
+ * @param mergedAnswers - Server-backed answers overlaid with session drafts.
+ * @returns Active index and whether the list is already complete.
+ */
+export function computeSymptomResumePlacement(
+  lines: PresetSymptomRow[],
+  mergedAnswers: SymptomPromptAnswers,
+): { activeIndex: number; phase: 'prompting' | 'complete' } {
+  if (lines.length === 0) {
+    return { activeIndex: 0, phase: 'prompting' };
+  }
+  const firstUnanswered = lines.findIndex(
+    (line) => !symptomPromptAnswerHasValue(mergedAnswers[line.id]),
+  );
+  if (firstUnanswered === -1) {
+    return { activeIndex: lines.length - 1, phase: 'complete' };
+  }
+  const i = Math.trunc(firstUnanswered);
+  const clamped = Math.max(0, Math.min(i, lines.length - 1));
+  return { activeIndex: clamped, phase: 'prompting' };
 }

--- a/packages/types/src/lib/symptom-prompt-session.ts
+++ b/packages/types/src/lib/symptom-prompt-session.ts
@@ -130,7 +130,5 @@ export function computeSymptomResumePlacement(
   if (firstUnanswered === -1) {
     return { activeIndex: lines.length - 1, phase: 'complete' };
   }
-  const i = Math.trunc(firstUnanswered);
-  const clamped = Math.max(0, Math.min(i, lines.length - 1));
-  return { activeIndex: clamped, phase: 'prompting' };
+  return { activeIndex: firstUnanswered, phase: 'prompting' };
 }


### PR DESCRIPTION
Closes #101

## Summary

Adds an **active episode** path on home so signed-in users can **resume** the in-progress symptom flow instead of only starting a new episode, with matching behavior on **web** and **mobile**. Includes RLS-safe data access, resume routing to the correct symptom step, accessibility updates, and fixes for exit/resume session handling.

## Changes

- **`@abstrack/supabase`:** `getActiveEpisodeForUser` — newest row with `ended_at IS NULL` for the current user (plus unit tests).
- **`@abstrack/types`:** `computeSymptomResumePlacement`, `hasSymptomSessionTraversalProgress` (helper used in tests / types; resume index logic in flows uses placement + session as described in code).
- **Web:** `EpisodeStartHomeCta` loads active episode client-side; primary CTA **Resume episode** → `/episode/:id/symptoms?symptomPresetId=…&resume=1` when a preset exists; otherwise **I'm having an episode** → `/episode/start`. `LiveAnnouncer` + `role="status"` for mode changes. `SymptomPromptFlow`: resume hydration (`resumeFromEntry`), strip `resume` from URL after load, persist session on exit/unmount, `useLayoutEffect` ref sync, locked resume intent ref to avoid double `load` when the query string changes, combine session index with first-unanswered placement for resume. Exit dialog copy no longer claims leaving always starts a **new** episode.
- **`apps/web/next.config.js`:** Resolve `@abstrack/types` to **source** + `transpilePackages` so dev builds don’t serve a stale `dist` (fixes missing export / “not a function” at runtime).
- **Mobile:** Home loads active episode and passes **Resume** vs start; navigation to `SymptomPrompt` with `resume: true`; exit **persists** session instead of clearing it; same resume / ref-sync behavior as web where applicable.

## How to test

1. Sign in, start an episode, advance at least one symptom, exit, then use **Resume episode** on home — should open the flow at the expected step (not always the first).
2. With no active episode (`ended_at` set or none), home should still offer **I'm having an episode** / start flow.
3. Quick smoke: screen reader / VoiceOver on CTA and exit confirmation copy.

## Out of scope (unchanged here)

Episode cancel/delete, full episodes management UI.