### PR TITLE
feat(episodes): guard start flow against duplicate active episodes with resume-or-end UI and DB index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ dist
 tmp
 out-tsc
 
+# TypeScript incremental build caches (noisy; do not commit)
+*.tsbuildinfo
+
 # dependencies
 node_modules
 

--- a/apps/mobile/src/app/components/episode-flow/EpisodeStartHomeCta.tsx
+++ b/apps/mobile/src/app/components/episode-flow/EpisodeStartHomeCta.tsx
@@ -24,7 +24,7 @@ export type EpisodeStartHomeCtaProps = {
  * Prominent home entry point for episode logging: large touch target, high-contrast primary
  * control, and supporting copy for VoiceOver and TalkBack. CTA mode updates use
  * `accessibilityLiveRegion` on Android only and `announce()` elsewhere so assistive output is not
- * duplicated. Shows **Resume episode** when {@link ActiveEpisodeHomeSummary} is provided.
+ * duplicated. Shows **Continue this episode** when {@link ActiveEpisodeHomeSummary} is provided.
  *
  * @param props - Props.
  * @returns Episode CTA section for the home screen.
@@ -54,7 +54,7 @@ export function EpisodeStartHomeCta({
     }
     if (hasResume) {
       void announce(
-        'You have an episode in progress. Resume episode is the primary action.',
+        'You have an episode in progress. Continue this episode is the primary action.',
         { politeness: 'polite' },
       );
     } else {
@@ -90,7 +90,7 @@ export function EpisodeStartHomeCta({
         {activeEpisodeLoading && 'Checking for an episode in progress…'}
         {!activeEpisodeLoading &&
           showResume &&
-          'You have an episode in progress. Continue where you left off in the guided symptom flow.'}
+          'You have an episode in progress. Continue this episode to pick up where you left off in the guided symptom flow.'}
         {!activeEpisodeLoading &&
           !showResume &&
           'Opens the guided flow to record what you are experiencing during this episode.'}
@@ -111,7 +111,7 @@ export function EpisodeStartHomeCta({
       ) : showResume && activeEpisode ? (
         <Pressable
           accessibilityRole="button"
-          accessibilityLabel="Resume episode"
+          accessibilityLabel="Continue this episode"
           accessibilityHint="Opens your in-progress episode at the next symptom step"
           accessibilityState={{ disabled: false }}
           onPress={() => onResumeEpisode(activeEpisode)}
@@ -121,7 +121,7 @@ export function EpisodeStartHomeCta({
             className="text-center text-[18px] font-semibold text-white"
             maxFontSizeMultiplier={2}
           >
-            Resume episode
+            Continue this episode
           </Text>
         </Pressable>
       ) : (

--- a/apps/mobile/src/app/navigation/types.ts
+++ b/apps/mobile/src/app/navigation/types.ts
@@ -38,7 +38,7 @@ export type MainStackParamList = {
   SymptomPrompt: {
     episodeId: string;
     symptomPresetId: string;
-    /** When true, initial step is derived from saved answers (e.g. home “Resume episode”). */
+    /** When true, initial step is derived from saved answers (e.g. home “Continue this episode”). */
     resume?: boolean;
   };
   Settings: undefined;

--- a/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
@@ -2,12 +2,20 @@ import React, { useCallback, useRef, useState } from 'react';
 import { Pressable, ScrollView, Text, View } from 'react-native';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import type { EpisodeTemplateWithPresetsRow } from '@abstrack/types';
+import type {
+  EpisodeRow,
+  EpisodeTemplateWithPresetsRow,
+} from '@abstrack/types';
+import {
+  endEpisodeIfStillActive,
+  getActiveEpisodeForUser,
+} from '@abstrack/supabase';
 import { announce } from '@abstrack/ui/native';
 import {
   fetchEpisodeTemplates,
   getCurrentUserId,
 } from '../../lib/episode-templates/episode-template-service';
+import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { saveEpisodeWithTemplatePresets } from '../../lib/episodes/episode-start-service';
 import { AsyncScreenContainer } from '../components/AsyncScreenContainer';
 import { ScreenShell } from '../components/ScreenShell';
@@ -51,6 +59,10 @@ export function EpisodeStartScreen() {
   const [rows, setRows] = useState<EpisodeTemplateWithPresetsRow[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  /** Open episode blocks starting another until resume or explicit end. */
+  const [blockingActiveEpisode, setBlockingActiveEpisode] =
+    useState<EpisodeRow | null>(null);
+  const [resolvingActiveGate, setResolvingActiveGate] = useState(false);
 
   const load = useCallback(
     async (focusCancel?: FocusLoadCancel, focusCycle?: number) => {
@@ -60,6 +72,7 @@ export function EpisodeStartScreen() {
       setStatus('loading');
       setErrorMessage(null);
       setEpisodeStartError(null);
+      setBlockingActiveEpisode(null);
       const authResult = await getCurrentUserId();
       if (stale()) {
         return;
@@ -75,6 +88,25 @@ export function EpisodeStartScreen() {
         return;
       }
       const userId = authResult.data;
+
+      const supabase = getMobileSupabaseClient();
+      const activeResult = await getActiveEpisodeForUser(supabase, userId);
+      if (stale()) {
+        return;
+      }
+      if (!activeResult.ok) {
+        setErrorMessage(activeResult.error.message);
+        setStatus('error');
+        return;
+      }
+      if (activeResult.data) {
+        setBlockingActiveEpisode(activeResult.data);
+        setRows([]);
+        setSubmitting(false);
+        setStatus('ready');
+        return;
+      }
+
       const result = await fetchEpisodeTemplates();
       if (stale()) {
         return;
@@ -213,6 +245,48 @@ export function EpisodeStartScreen() {
     }
   };
 
+  const onResumeActiveEpisode = useCallback(() => {
+    const row = blockingActiveEpisode;
+    const presetId = row?.symptom_preset_id;
+    if (!row || typeof presetId !== 'string' || !presetId) {
+      return;
+    }
+    navigation.replace('SymptomPrompt', {
+      episodeId: row.id,
+      symptomPresetId: presetId,
+      resume: true,
+    });
+  }, [blockingActiveEpisode, navigation]);
+
+  const onEndActiveEpisodeAndStartNew = useCallback(async () => {
+    const row = blockingActiveEpisode;
+    if (!row || resolvingActiveGate) {
+      return;
+    }
+    setResolvingActiveGate(true);
+    setEpisodeStartError(null);
+    try {
+      const supabase = getMobileSupabaseClient();
+      const end = await endEpisodeIfStillActive(supabase, row.id);
+      if (!end.ok) {
+        setEpisodeStartError(end.error.message);
+        announce(end.error.message);
+        return;
+      }
+      announce('Previous episode closed. You can start a new one.');
+      const token = focusCancelRef.current;
+      if (token != null) {
+        void load(token, focusCycleIdRef.current);
+      }
+    } finally {
+      setResolvingActiveGate(false);
+    }
+  }, [blockingActiveEpisode, load, resolvingActiveGate]);
+
+  const gatePresetId = blockingActiveEpisode?.symptom_preset_id;
+  const canResumeFromGate =
+    typeof gatePresetId === 'string' && gatePresetId.length > 0;
+
   return (
     <ScreenShell contentAlign="stretch">
       <View className="min-h-0 flex-1 gap-4">
@@ -222,141 +296,220 @@ export function EpisodeStartScreen() {
           className={`text-[22px] font-semibold ${nw.textInk}`}
           maxFontSizeMultiplier={2}
         >
-          Start an episode
+          {blockingActiveEpisode
+            ? 'Episode already in progress'
+            : 'Start an episode'}
         </Text>
 
-        <AsyncScreenContainer
-          status={status}
-          loadingAccessibilityLabel={
-            submitting ? 'Starting episode' : 'Loading episode templates'
-          }
-          errorTitle="Could not load templates"
-          errorMessage={errorMessage ?? undefined}
-          onRetry={() => {
-            const token = focusCancelRef.current;
-            if (token == null) {
-              return;
-            }
-            void load(token, focusCycleIdRef.current);
-          }}
-        >
-          <ScrollView
-            testID="episode-start-template-scroll"
-            className="flex-1"
-            keyboardShouldPersistTaps="handled"
-            contentContainerStyle={{ paddingBottom: 16 }}
-          >
-            {rows.length === 1 ? (
+        {blockingActiveEpisode ? (
+          <View className="gap-4">
+            <Text
+              className={`text-base leading-relaxed ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+              accessibilityLiveRegion="polite"
+            >
+              You already have one episode open that is not finished. Only one
+              episode can be open at a time. Choose what to do next.
+            </Text>
+            {!canResumeFromGate ? (
               <Text
-                className={`mb-4 text-base leading-relaxed ${nw.textMuted}`}
+                className={`text-base leading-relaxed ${nw.textMuted}`}
                 maxFontSizeMultiplier={2}
               >
-                Your episode uses the template below for symptoms and health
-                markers.
-              </Text>
-            ) : rows.length > 1 ? (
-              <Text
-                className={`mb-4 text-base leading-relaxed ${nw.textMuted}`}
-                maxFontSizeMultiplier={2}
-              >
-                Tap one template for this episode. It sets both your symptom
-                list and health markers for this episode.
+                This episode is missing preset data, so it cannot be resumed.
+                End this episode to start a new one.
               </Text>
             ) : null}
-
             {episodeStartError ? (
               <Text
                 accessibilityRole="alert"
-                className={`mb-4 text-base leading-relaxed ${nw.textError}`}
+                className={`text-base leading-relaxed ${nw.textError}`}
                 maxFontSizeMultiplier={2}
               >
                 {episodeStartError}
               </Text>
             ) : null}
-
-            {rows.length === 0 ? (
-              <View
-                className="rounded-xl bg-app-bg p-4 dark:bg-app-bg-dark"
-                accessibilityRole="text"
-              >
-                <Text
-                  className={`text-base leading-relaxed ${nw.textInk}`}
-                  maxFontSizeMultiplier={2}
-                >
-                  You do not have any episode templates yet. Open the Templates
-                  tab, create a template, then come back here.
-                </Text>
-              </View>
-            ) : (
-              <View
-                accessibilityRole="radiogroup"
-                accessibilityLabel="Episode templates"
-              >
-                {rows.map((row) => {
-                  const selected = selectedId === row.id;
-                  return (
-                    <Pressable
-                      key={row.id}
-                      testID={`episode-start-template-option-${row.id}`}
-                      accessibilityRole="radio"
-                      accessibilityState={{ selected, disabled: submitting }}
-                      accessibilityLabel={`${row.name}. Symptoms: ${row.symptom_preset.name}. Health markers: ${row.health_marker_preset.name}.`}
-                      onPress={() => {
-                        if (!submitting) {
-                          onSelectTemplate(row.id);
-                        }
-                      }}
-                      className={`mb-3 rounded-2xl border-2 p-4 active:opacity-90 ${
-                        selected
-                          ? 'border-red-600 bg-red-50 dark:border-red-500 dark:bg-red-950/40'
-                          : 'border-app-border bg-app-bg dark:border-app-border-dark dark:bg-app-bg-dark'
-                      }`}
-                    >
-                      <Text
-                        className={`text-[18px] font-semibold ${nw.textInk}`}
-                        maxFontSizeMultiplier={2}
-                      >
-                        {row.name}
-                      </Text>
-                      <Text
-                        className={`mt-2 text-sm leading-relaxed ${nw.textMuted}`}
-                        maxFontSizeMultiplier={2}
-                      >
-                        Symptoms: {row.symptom_preset.name}
-                      </Text>
-                      <Text
-                        className={`mt-1 text-sm leading-relaxed ${nw.textMuted}`}
-                        maxFontSizeMultiplier={2}
-                      >
-                        Markers: {row.health_marker_preset.name}
-                      </Text>
-                    </Pressable>
-                  );
-                })}
-              </View>
-            )}
-
-            {rows.length > 0 ? (
+            {canResumeFromGate ? (
               <Pressable
-                testID="episode-start-submit"
                 accessibilityRole="button"
-                accessibilityLabel="Start episode with selected template"
-                accessibilityState={{
-                  disabled: selectedId === null || submitting,
-                }}
-                disabled={selectedId === null || submitting}
-                onPress={() => {
-                  void onStartEpisode();
-                }}
-                className={`mt-4 min-h-[56px] items-center justify-center rounded-xl bg-red-700 px-4 py-4 active:opacity-90 disabled:opacity-50 dark:bg-red-600`}
+                accessibilityLabel="Continue this episode"
+                accessibilityHint="Opens your in-progress episode at the next symptom step"
+                accessibilityState={{ disabled: resolvingActiveGate }}
+                disabled={resolvingActiveGate}
+                onPress={onResumeActiveEpisode}
+                className="min-h-[56px] items-center justify-center rounded-xl bg-red-700 px-4 py-4 active:opacity-90 dark:bg-red-600"
               >
                 <Text className="text-center text-[18px] font-semibold text-white">
-                  {submitting ? 'Starting…' : 'Start episode'}
+                  Continue this episode
                 </Text>
               </Pressable>
             ) : null}
-          </ScrollView>
-        </AsyncScreenContainer>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={
+                resolvingActiveGate
+                  ? 'Closing episode'
+                  : 'End this episode and start a new one'
+              }
+              accessibilityHint="Closes the open episode so you can start a new one"
+              accessibilityState={{ disabled: resolvingActiveGate }}
+              disabled={resolvingActiveGate}
+              onPress={() => {
+                void onEndActiveEpisodeAndStartNew();
+              }}
+              className={`min-h-[56px] items-center justify-center rounded-xl border-2 border-app-border bg-app-bg px-4 py-4 active:opacity-90 dark:border-app-border-dark dark:bg-app-bg-dark ${
+                canResumeFromGate
+                  ? ''
+                  : 'bg-red-700 dark:bg-red-600 border-transparent'
+              }`}
+            >
+              <Text
+                className={`text-center text-[18px] font-semibold ${
+                  canResumeFromGate ? nw.textInk : 'text-white'
+                }`}
+              >
+                {resolvingActiveGate
+                  ? 'Closing episode…'
+                  : 'End this episode and start a new one'}
+              </Text>
+            </Pressable>
+          </View>
+        ) : null}
+
+        {!blockingActiveEpisode ? (
+          <AsyncScreenContainer
+            status={status}
+            loadingAccessibilityLabel={
+              submitting ? 'Starting episode' : 'Loading episode templates'
+            }
+            errorTitle="Could not load templates"
+            errorMessage={errorMessage ?? undefined}
+            onRetry={() => {
+              const token = focusCancelRef.current;
+              if (token == null) {
+                return;
+              }
+              void load(token, focusCycleIdRef.current);
+            }}
+          >
+            <ScrollView
+              testID="episode-start-template-scroll"
+              className="flex-1"
+              keyboardShouldPersistTaps="handled"
+              contentContainerStyle={{ paddingBottom: 16 }}
+            >
+              {rows.length === 1 ? (
+                <Text
+                  className={`mb-4 text-base leading-relaxed ${nw.textMuted}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  Your episode uses the template below for symptoms and health
+                  markers.
+                </Text>
+              ) : rows.length > 1 ? (
+                <Text
+                  className={`mb-4 text-base leading-relaxed ${nw.textMuted}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  Tap one template for this episode. It sets both your symptom
+                  list and health markers for this episode.
+                </Text>
+              ) : null}
+
+              {episodeStartError ? (
+                <Text
+                  accessibilityRole="alert"
+                  className={`mb-4 text-base leading-relaxed ${nw.textError}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  {episodeStartError}
+                </Text>
+              ) : null}
+
+              {rows.length === 0 ? (
+                <View
+                  className="rounded-xl bg-app-bg p-4 dark:bg-app-bg-dark"
+                  accessibilityRole="text"
+                >
+                  <Text
+                    className={`text-base leading-relaxed ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    You do not have any episode templates yet. Open the
+                    Templates tab, create a template, then come back here.
+                  </Text>
+                </View>
+              ) : (
+                <View
+                  accessibilityRole="radiogroup"
+                  accessibilityLabel="Episode templates"
+                >
+                  {rows.map((row) => {
+                    const selected = selectedId === row.id;
+                    return (
+                      <Pressable
+                        key={row.id}
+                        testID={`episode-start-template-option-${row.id}`}
+                        accessibilityRole="radio"
+                        accessibilityState={{ selected, disabled: submitting }}
+                        accessibilityLabel={`${row.name}. Symptoms: ${row.symptom_preset.name}. Health markers: ${row.health_marker_preset.name}.`}
+                        onPress={() => {
+                          if (!submitting) {
+                            onSelectTemplate(row.id);
+                          }
+                        }}
+                        className={`mb-3 rounded-2xl border-2 p-4 active:opacity-90 ${
+                          selected
+                            ? 'border-red-600 bg-red-50 dark:border-red-500 dark:bg-red-950/40'
+                            : 'border-app-border bg-app-bg dark:border-app-border-dark dark:bg-app-bg-dark'
+                        }`}
+                      >
+                        <Text
+                          className={`text-[18px] font-semibold ${nw.textInk}`}
+                          maxFontSizeMultiplier={2}
+                        >
+                          {row.name}
+                        </Text>
+                        <Text
+                          className={`mt-2 text-sm leading-relaxed ${nw.textMuted}`}
+                          maxFontSizeMultiplier={2}
+                        >
+                          Symptoms: {row.symptom_preset.name}
+                        </Text>
+                        <Text
+                          className={`mt-1 text-sm leading-relaxed ${nw.textMuted}`}
+                          maxFontSizeMultiplier={2}
+                        >
+                          Markers: {row.health_marker_preset.name}
+                        </Text>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              )}
+
+              {rows.length > 0 ? (
+                <Pressable
+                  testID="episode-start-submit"
+                  accessibilityRole="button"
+                  accessibilityLabel="Start episode with selected template"
+                  accessibilityState={{
+                    disabled: selectedId === null || submitting,
+                  }}
+                  disabled={selectedId === null || submitting}
+                  onPress={() => {
+                    void onStartEpisode();
+                  }}
+                  className={`mt-4 min-h-[56px] items-center justify-center rounded-xl bg-red-700 px-4 py-4 active:opacity-90 disabled:opacity-50 dark:bg-red-600`}
+                >
+                  <Text className="text-center text-[18px] font-semibold text-white">
+                    {submitting ? 'Starting…' : 'Start episode'}
+                  </Text>
+                </Pressable>
+              ) : null}
+            </ScrollView>
+          </AsyncScreenContainer>
+        ) : null}
       </View>
     </ScreenShell>
   );

--- a/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
@@ -273,10 +273,26 @@ export function EpisodeStartScreen() {
         announce(end.error.message);
         return;
       }
-      announce('Previous episode closed. You can start a new one.');
-      const token = focusCancelRef.current;
-      if (token != null) {
-        void load(token, focusCycleIdRef.current);
+      // Reload start flow before any success announcement so UI matches server state; always await
+      // `load` (fallback cancel token if focus ref is unset).
+      await load(
+        focusCancelRef.current ?? { cancelled: false },
+        focusCycleIdRef.current,
+      );
+      if (!end.data.didEnd) {
+        return;
+      }
+      const verify = await getActiveEpisodeForUser(supabase, row.user_id);
+      if (!verify.ok) {
+        setEpisodeStartError(verify.error.message);
+        return;
+      }
+      if (!verify.data) {
+        announce('Previous episode closed. You can start a new one.');
+      } else {
+        setEpisodeStartError(
+          'We could not confirm your previous episode is closed. Try Continue this episode or try again.',
+        );
       }
     } finally {
       setResolvingActiveGate(false);

--- a/apps/mobile/tsconfig.tsbuildinfo
+++ b/apps/mobile/tsconfig.tsbuildinfo
@@ -1,0 +1,1 @@
+{"fileNames":[],"fileInfos":[],"root":[],"options":{"composite":true,"declarationMap":true,"emitDeclarationOnly":true,"importHelpers":true,"module":199,"noEmitOnError":true,"noFallthroughCasesInSwitch":true,"noImplicitOverride":true,"noImplicitReturns":true,"noUnusedLocals":true,"skipLibCheck":true,"strict":true,"target":9},"version":"5.9.3"}

--- a/apps/mobile/tsconfig.tsbuildinfo
+++ b/apps/mobile/tsconfig.tsbuildinfo
@@ -1,1 +1,0 @@
-{"fileNames":[],"fileInfos":[],"root":[],"options":{"composite":true,"declarationMap":true,"emitDeclarationOnly":true,"importHelpers":true,"module":199,"noEmitOnError":true,"noFallthroughCasesInSwitch":true,"noImplicitOverride":true,"noImplicitReturns":true,"noUnusedLocals":true,"skipLibCheck":true,"strict":true,"target":9},"version":"5.9.3"}

--- a/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
@@ -14,25 +14,10 @@ import {
   listEpisodeTemplates,
 } from '@abstrack/supabase';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
+import { buildResumeEpisodeHref } from '@/lib/episode-flow/resume-episode-href';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { useAuth } from '@/lib/auth-provider';
 import { PageLoading } from '@/components/page-states/PageLoading';
-
-/**
- * Builds the `/episode/[id]/symptoms` URL for continuing an active episode (matches home CTA).
- *
- * @param episodeId - `episodes.id`.
- * @param symptomPresetId - `symptom_presets.id` on the episode row.
- */
-function buildResumeEpisodeHref(
-  episodeId: string,
-  symptomPresetId: string,
-): string {
-  const q = new URLSearchParams();
-  q.set('symptomPresetId', symptomPresetId);
-  q.set('resume', '1');
-  return `/episode/${episodeId}/symptoms?${q.toString()}`;
-}
 
 /**
  * Impaired-friendly episode start: load templates; if there is exactly one template, create the
@@ -171,10 +156,24 @@ export function EpisodeStartFlow() {
         announce(end.error.message, { politeness: 'assertive' });
         return;
       }
-      announce('Previous episode closed. You can start a new one.', {
-        politeness: 'polite',
-      });
       await refresh();
+      if (!end.data.didEnd) {
+        return;
+      }
+      const verify = await getActiveEpisodeForUser(supabase, session.user.id);
+      if (!verify.ok) {
+        setSubmitError(verify.error.message);
+        return;
+      }
+      if (!verify.data) {
+        announce('Previous episode closed. You can start a new one.', {
+          politeness: 'polite',
+        });
+      } else {
+        setSubmitError(
+          'We could not confirm your previous episode is closed. Try Continue this episode or try again.',
+        );
+      }
     } finally {
       setResolvingActiveBlock(false);
     }
@@ -277,8 +276,9 @@ export function EpisodeStartFlow() {
           role="status"
           aria-live="polite"
         >
-          An unfinished episode is already open. Use Continue this episode or
-          End this episode and start a new one.
+          {canResume
+            ? 'An unfinished episode is already open. Actions: Continue this episode, or End this episode and start a new one.'
+            : 'An unfinished episode is already open. Preset data is missing, so you cannot continue. Action: End this episode and start a new one.'}
         </p>
         {submitError ? (
           <p className="text-sm text-red-700 dark:text-red-300" role="alert">

--- a/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
@@ -3,12 +3,36 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
-import type { EpisodeTemplateWithPresetsRow } from '@abstrack/types';
-import { createEpisode, listEpisodeTemplates } from '@abstrack/supabase';
+import type {
+  EpisodeRow,
+  EpisodeTemplateWithPresetsRow,
+} from '@abstrack/types';
+import {
+  createEpisode,
+  endEpisodeIfStillActive,
+  getActiveEpisodeForUser,
+  listEpisodeTemplates,
+} from '@abstrack/supabase';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { useAuth } from '@/lib/auth-provider';
 import { PageLoading } from '@/components/page-states/PageLoading';
+
+/**
+ * Builds the `/episode/[id]/symptoms` URL for continuing an active episode (matches home CTA).
+ *
+ * @param episodeId - `episodes.id`.
+ * @param symptomPresetId - `symptom_presets.id` on the episode row.
+ */
+function buildResumeEpisodeHref(
+  episodeId: string,
+  symptomPresetId: string,
+): string {
+  const q = new URLSearchParams();
+  q.set('symptomPresetId', symptomPresetId);
+  q.set('resume', '1');
+  return `/episode/${episodeId}/symptoms?${q.toString()}`;
+}
 
 /**
  * Impaired-friendly episode start: load templates; if there is exactly one template, create the
@@ -34,6 +58,10 @@ export function EpisodeStartFlow() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  /** Open episode (`ended_at` null) — blocks starting another until resume or explicit end. */
+  const [blockingActiveEpisode, setBlockingActiveEpisode] =
+    useState<EpisodeRow | null>(null);
+  const [resolvingActiveBlock, setResolvingActiveBlock] = useState(false);
 
   const refresh = useCallback(async (): Promise<void> => {
     const userId = session?.user?.id;
@@ -44,6 +72,20 @@ export function EpisodeStartFlow() {
     setLoadState('loading');
     setLoadError(null);
     setSubmitError(null);
+    setBlockingActiveEpisode(null);
+
+    const activeResult = await getActiveEpisodeForUser(supabase, userId);
+    if (!activeResult.ok) {
+      setLoadState('error');
+      setLoadError(activeResult.error.message);
+      return;
+    }
+    if (activeResult.data) {
+      setBlockingActiveEpisode(activeResult.data);
+      setLoadState('idle');
+      return;
+    }
+
     const result = await listEpisodeTemplates(supabase);
     if (!result.ok) {
       setLoadState('error');
@@ -112,6 +154,38 @@ export function EpisodeStartFlow() {
     void refresh();
   }, [authLoading, session?.user?.id, refresh]);
 
+  const onEndActiveEpisodeAndStartNew = useCallback(async (): Promise<void> => {
+    if (!session?.user?.id || !blockingActiveEpisode || resolvingActiveBlock) {
+      return;
+    }
+    setResolvingActiveBlock(true);
+    setSubmitError(null);
+    try {
+      const supabase = createBrowserClient();
+      const end = await endEpisodeIfStillActive(
+        supabase,
+        blockingActiveEpisode.id,
+      );
+      if (!end.ok) {
+        setSubmitError(end.error.message);
+        announce(end.error.message, { politeness: 'assertive' });
+        return;
+      }
+      announce('Previous episode closed. You can start a new one.', {
+        politeness: 'polite',
+      });
+      await refresh();
+    } finally {
+      setResolvingActiveBlock(false);
+    }
+  }, [
+    announce,
+    blockingActiveEpisode,
+    refresh,
+    resolvingActiveBlock,
+    session?.user?.id,
+  ]);
+
   const onSubmit = async (): Promise<void> => {
     if (!session?.user?.id || selectedId === null || submitting) {
       return;
@@ -167,6 +241,74 @@ export function EpisodeStartFlow() {
         >
           Sign in
         </Link>
+      </div>
+    );
+  }
+
+  if (blockingActiveEpisode) {
+    const presetId = blockingActiveEpisode.symptom_preset_id;
+    const canResume = typeof presetId === 'string' && presetId.length > 0;
+    const gateStatusId = `episode-start-active-gate-status${groupLegendId}`;
+    const primaryLinkClass =
+      'inline-flex min-h-[56px] w-full items-center justify-center rounded-xl bg-red-700 px-5 py-4 text-center text-base font-semibold leading-snug text-white shadow-md outline-none ring-2 ring-transparent transition hover:bg-red-800 focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-red-50 dark:bg-red-600 dark:hover:bg-red-500 dark:focus-visible:ring-offset-red-950';
+    const secondaryButtonClass =
+      'inline-flex min-h-[56px] w-full items-center justify-center rounded-xl border-2 border-app-border bg-app-surface px-5 py-4 text-center text-base font-semibold leading-snug text-app-ink shadow-sm outline-none transition hover:bg-app-surface/80 focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-600 dark:bg-neutral-900/60';
+
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+            Episode already in progress
+          </h1>
+          <p className="mt-2 text-base leading-relaxed text-app-ink">
+            You already have one episode open that is not finished. Only one
+            episode can be open at a time. Choose what to do next.
+          </p>
+          {!canResume ? (
+            <p className="mt-3 text-sm leading-relaxed text-app-muted">
+              This episode is missing preset data, so it cannot be resumed. End
+              this episode to start a new one.
+            </p>
+          ) : null}
+        </div>
+        <p
+          id={gateStatusId}
+          className="sr-only"
+          role="status"
+          aria-live="polite"
+        >
+          An unfinished episode is already open. Use Continue this episode or
+          End this episode and start a new one.
+        </p>
+        {submitError ? (
+          <p className="text-sm text-red-700 dark:text-red-300" role="alert">
+            {submitError}
+          </p>
+        ) : null}
+        <div className="flex flex-col gap-3 sm:max-w-md">
+          {canResume ? (
+            <Link
+              href={buildResumeEpisodeHref(blockingActiveEpisode.id, presetId)}
+              className={primaryLinkClass}
+              aria-describedby={gateStatusId}
+            >
+              Continue this episode
+            </Link>
+          ) : null}
+          <button
+            type="button"
+            className={canResume ? secondaryButtonClass : primaryLinkClass}
+            disabled={resolvingActiveBlock}
+            aria-describedby={gateStatusId}
+            onClick={() => {
+              void onEndActiveEpisodeAndStartNew();
+            }}
+          >
+            {resolvingActiveBlock
+              ? 'Closing episode…'
+              : 'End this episode and start a new one'}
+          </button>
+        </div>
       </div>
     );
   }

--- a/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useEffect, useId, useState } from 'react';
 import { getActiveEpisodeForUser } from '@abstrack/supabase';
+import { buildResumeEpisodeHref } from '@/lib/episode-flow/resume-episode-href';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { useAuth } from '@/lib/auth-provider';
 
@@ -12,26 +13,6 @@ export type EpisodeStartHomeCtaProps = {
 };
 
 type CtaMode = 'loading' | 'resume' | 'start';
-
-/**
- * Builds the `/episode/[id]/symptoms` URL for continuing an active episode: `symptomPresetId`
- * selects the preset, and `resume=1` tells {@link SymptomPromptFlow} to hydrate with resume logic.
- * The step index is **not** in the query string; it is computed in the flow from merged server +
- * session answers (and related resume handling).
- *
- * @param episodeId - `episodes.id`.
- * @param symptomPresetId - `symptom_presets.id` on the episode row.
- * @returns Path under `/episode/[id]/symptoms`.
- */
-function buildResumeEpisodeHref(
-  episodeId: string,
-  symptomPresetId: string,
-): string {
-  const q = new URLSearchParams();
-  q.set('symptomPresetId', symptomPresetId);
-  q.set('resume', '1');
-  return `/episode/${episodeId}/symptoms?${q.toString()}`;
-}
 
 /**
  * Prominent home entry for episode logging: detects an active episode and offers **Continue this

--- a/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
@@ -34,8 +34,9 @@ function buildResumeEpisodeHref(
 }
 
 /**
- * Prominent home entry for episode logging: detects an active episode and offers **Resume** as the
- * primary action; otherwise **I'm having an episode** starts a new flow. CTA mode is conveyed to
+ * Prominent home entry for episode logging: detects an active episode and offers **Continue this
+ * episode** as the primary action; otherwise **I'm having an episode** starts a new flow. CTA mode
+ * is conveyed to
  * assistive technologies via a single `aria-live` status region (no duplicate transient announce).
  *
  * @param props - Props.
@@ -115,14 +116,14 @@ export function EpisodeStartHomeCta({
       <p id={descId} className="mt-1.5 text-sm leading-relaxed text-app-muted">
         {ctaMode === 'loading' && 'Checking for an episode in progress…'}
         {ctaMode === 'resume' &&
-          'You have an episode in progress. Continue where you left off in the guided symptom flow.'}
+          'You have an episode in progress. Continue this episode to pick up where you left off in the guided symptom flow.'}
         {ctaMode === 'start' &&
           'Opens the guided flow to record what you are experiencing during this episode.'}
       </p>
       <p id={statusId} className="sr-only" role="status" aria-live="polite">
         {ctaMode === 'loading' && 'Checking for an in-progress episode.'}
         {ctaMode === 'resume' &&
-          'An episode is in progress. Primary action: Resume episode.'}
+          'An episode is in progress. Primary action: Continue this episode.'}
         {ctaMode === 'start' &&
           'No episode in progress. Primary action: start a new episode.'}
       </p>
@@ -141,7 +142,7 @@ export function EpisodeStartHomeCta({
             className={primaryLinkClass}
             aria-describedby={`${descId} ${statusId}`}
           >
-            Resume episode
+            Continue this episode
           </Link>
         )}
         {ctaMode === 'start' && (

--- a/apps/web/src/lib/episode-flow/resume-episode-href.spec.ts
+++ b/apps/web/src/lib/episode-flow/resume-episode-href.spec.ts
@@ -1,0 +1,10 @@
+import { buildResumeEpisodeHref } from './resume-episode-href';
+
+describe('buildResumeEpisodeHref', () => {
+  it('includes episode id, symptomPresetId, and resume=1', () => {
+    const href = buildResumeEpisodeHref('ep-uuid', 'sym-uuid');
+    expect(href).toBe(
+      '/episode/ep-uuid/symptoms?symptomPresetId=sym-uuid&resume=1',
+    );
+  });
+});

--- a/apps/web/src/lib/episode-flow/resume-episode-href.ts
+++ b/apps/web/src/lib/episode-flow/resume-episode-href.ts
@@ -1,0 +1,19 @@
+/**
+ * Builds the `/episode/[id]/symptoms` URL for continuing an active episode: `symptomPresetId`
+ * selects the preset, and `resume=1` tells the symptom prompt flow to hydrate with resume logic.
+ * The step index is **not** in the query string; it is computed in the flow from merged server +
+ * session answers (and related resume handling).
+ *
+ * @param episodeId - `episodes.id`.
+ * @param symptomPresetId - `symptom_presets.id` on the episode row.
+ * @returns Path under `/episode/[id]/symptoms`.
+ */
+export function buildResumeEpisodeHref(
+  episodeId: string,
+  symptomPresetId: string,
+): string {
+  const q = new URLSearchParams();
+  q.set('symptomPresetId', symptomPresetId);
+  q.set('resume', '1');
+  return `/episode/${episodeId}/symptoms?${q.toString()}`;
+}

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -77,6 +77,7 @@ export {
 } from './lib/episode-template-data.js';
 export {
   createEpisode,
+  endEpisodeIfStillActive,
   getActiveEpisodeForUser,
   getEpisodeById,
 } from './lib/episode-data.js';

--- a/packages/supabase/src/lib/episode-data.spec.ts
+++ b/packages/supabase/src/lib/episode-data.spec.ts
@@ -187,10 +187,13 @@ describe('endEpisodeIfStillActive', () => {
     );
 
     expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.didEnd).toBe(true);
+    }
     expect(client.from).toHaveBeenCalledWith('episodes');
   });
 
-  it('succeeds when the row was already ended (no row returned)', async () => {
+  it('returns didEnd false when the row was already ended (no row returned)', async () => {
     const maybeSingle = vi.fn(async () => ({ data: null, error: null }));
     const client = {
       from: vi.fn(() => ({
@@ -209,5 +212,8 @@ describe('endEpisodeIfStillActive', () => {
     const result = await endEpisodeIfStillActive(client, 'ep-1');
 
     expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.didEnd).toBe(false);
+    }
   });
 });

--- a/packages/supabase/src/lib/episode-data.spec.ts
+++ b/packages/supabase/src/lib/episode-data.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { EpisodeInsert, EpisodeRow } from '@abstrack/types';
 import {
   createEpisode,
+  endEpisodeIfStillActive,
   getActiveEpisodeForUser,
   getEpisodeById,
 } from './episode-data.js';
@@ -156,5 +157,57 @@ describe('getActiveEpisodeForUser', () => {
     if (result.ok) {
       expect(result.data).toBeNull();
     }
+  });
+});
+
+describe('endEpisodeIfStillActive', () => {
+  it('updates ended_at when the row is still active', async () => {
+    const maybeSingle = vi.fn(async () => ({
+      data: { id: 'ep-1' },
+      error: null,
+    }));
+    const client = {
+      from: vi.fn(() => ({
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            is: vi.fn(() => ({
+              select: vi.fn(() => ({
+                maybeSingle,
+              })),
+            })),
+          })),
+        })),
+      })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await endEpisodeIfStillActive(
+      client,
+      'ep-1',
+      '2026-04-20T12:00:00.000Z',
+    );
+
+    expect(result.ok).toBe(true);
+    expect(client.from).toHaveBeenCalledWith('episodes');
+  });
+
+  it('succeeds when the row was already ended (no row returned)', async () => {
+    const maybeSingle = vi.fn(async () => ({ data: null, error: null }));
+    const client = {
+      from: vi.fn(() => ({
+        update: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            is: vi.fn(() => ({
+              select: vi.fn(() => ({
+                maybeSingle,
+              })),
+            })),
+          })),
+        })),
+      })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await endEpisodeIfStillActive(client, 'ep-1');
+
+    expect(result.ok).toBe(true);
   });
 });

--- a/packages/supabase/src/lib/episode-data.ts
+++ b/packages/supabase/src/lib/episode-data.ts
@@ -81,21 +81,24 @@ export async function getActiveEpisodeForUser(
 }
 
 /**
- * Sets `ended_at` on an episode that is still active (`ended_at IS NULL`). If the row is already
- * ended, the update is a no-op and the call still succeeds — callers can proceed to start a new
- * episode. Uses the same RLS as other `episodes` updates.
+ * Sets `ended_at` on an episode that is still active (`ended_at IS NULL`). Uses the same RLS as
+ * other `episodes` updates.
  *
  * @param client - Supabase client (RLS applies).
  * @param episodeId - `episodes.id` to close.
  * @param endedAt - Timestamp for `ended_at` (defaults to now, ISO string).
+ * @returns On success, `didEnd` is `true` if exactly one active row was updated. `didEnd` is
+ * `false` when the update matched no rows: e.g. the episode was already ended, `episodeId` does
+ * not exist, or RLS hid the row from the update. Callers must not treat `didEnd: false` as proof
+ * the episode was closed.
  */
 export async function endEpisodeIfStillActive(
   client: AbstrackSupabaseClient,
   episodeId: Uuid,
   endedAt: string = new Date().toISOString(),
-): Promise<PresetDataResult<void>> {
+): Promise<PresetDataResult<{ didEnd: boolean }>> {
   try {
-    const { error } = await client
+    const { data, error } = await client
       .from('episodes')
       .update({ ended_at: endedAt })
       .eq('id', episodeId)
@@ -105,9 +108,7 @@ export async function endEpisodeIfStillActive(
     if (error) {
       return { ok: false, error: toPresetDataError(error) };
     }
-    // When the row was already ended (or not visible under RLS), the update matches no rows — still
-    // OK for “start a new episode” flows that assume no active row remains.
-    return { ok: true, data: undefined };
+    return { ok: true, data: { didEnd: data != null } };
   } catch (caught) {
     return { ok: false, error: toPresetDataError(caught) };
   }

--- a/packages/supabase/src/lib/episode-data.ts
+++ b/packages/supabase/src/lib/episode-data.ts
@@ -79,3 +79,36 @@ export async function getActiveEpisodeForUser(
     return { ok: false, error: toPresetDataError(caught) };
   }
 }
+
+/**
+ * Sets `ended_at` on an episode that is still active (`ended_at IS NULL`). If the row is already
+ * ended, the update is a no-op and the call still succeeds — callers can proceed to start a new
+ * episode. Uses the same RLS as other `episodes` updates.
+ *
+ * @param client - Supabase client (RLS applies).
+ * @param episodeId - `episodes.id` to close.
+ * @param endedAt - Timestamp for `ended_at` (defaults to now, ISO string).
+ */
+export async function endEpisodeIfStillActive(
+  client: AbstrackSupabaseClient,
+  episodeId: Uuid,
+  endedAt: string = new Date().toISOString(),
+): Promise<PresetDataResult<void>> {
+  try {
+    const { error } = await client
+      .from('episodes')
+      .update({ ended_at: endedAt })
+      .eq('id', episodeId)
+      .is('ended_at', null)
+      .select('id')
+      .maybeSingle();
+    if (error) {
+      return { ok: false, error: toPresetDataError(error) };
+    }
+    // When the row was already ended (or not visible under RLS), the update matches no rows — still
+    // OK for “start a new episode” flows that assume no active row remains.
+    return { ok: true, data: undefined };
+  } catch (caught) {
+    return { ok: false, error: toPresetDataError(caught) };
+  }
+}

--- a/supabase/migrations/20260420120000_episodes_one_active_per_user.sql
+++ b/supabase/migrations/20260420120000_episodes_one_active_per_user.sql
@@ -1,0 +1,31 @@
+-- At most one active (ended_at IS NULL) episode per user. Deduplicate existing rows first so the
+-- index can be created on existing databases.
+
+WITH ranked AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY user_id
+      ORDER BY
+        started_at DESC,
+        id DESC
+    ) AS rn
+  FROM
+    public.episodes
+  WHERE
+    ended_at IS NULL
+)
+UPDATE public.episodes e
+SET
+  ended_at = now()
+FROM
+  ranked r
+WHERE
+  e.id = r.id
+  AND r.rn > 1;
+
+CREATE UNIQUE INDEX episodes_one_active_per_user_idx ON public.episodes (user_id)
+WHERE
+  ended_at IS NULL;
+
+COMMENT ON INDEX public.episodes_one_active_per_user_idx IS 'Ensures at most one open episode per user; aligns with app-layer start guards.';

--- a/supabase/migrations/20260420120000_episodes_one_active_per_user.sql
+++ b/supabase/migrations/20260420120000_episodes_one_active_per_user.sql
@@ -1,6 +1,16 @@
 -- At most one active (ended_at IS NULL) episode per user. Deduplicate existing rows first so the
 -- index can be created on existing databases.
 
+-- Explicit transaction: LOCK TABLE requires a transaction block (SQLSTATE 25P01 if applied
+-- statement-by-statement). The lock blocks concurrent inserts on `episodes` so a new active row
+-- cannot appear between the dedupe UPDATE and CREATE UNIQUE INDEX.
+BEGIN;
+
+-- Hold an exclusive lock on the table for this transaction so no concurrent writer can create a
+-- second active episode (ended_at IS NULL) for the same user between deduplication and index
+-- creation.
+LOCK TABLE public.episodes IN EXCLUSIVE MODE;
+
 WITH ranked AS (
   SELECT
     id,
@@ -24,8 +34,10 @@ WHERE
   e.id = r.id
   AND r.rn > 1;
 
-CREATE UNIQUE INDEX episodes_one_active_per_user_idx ON public.episodes (user_id)
+CREATE UNIQUE INDEX IF NOT EXISTS episodes_one_active_per_user_idx ON public.episodes (user_id)
 WHERE
   ended_at IS NULL;
 
 COMMENT ON INDEX public.episodes_one_active_per_user_idx IS 'Ensures at most one open episode per user; aligns with app-layer start guards.';
+
+COMMIT;


### PR DESCRIPTION
Closes #102

## Summary

Prevents accidentally creating more than one **active** episode (`ended_at IS NULL`) per user by adding app-layer checks at episode start, a clear **resume vs end and start new** path, and a database unique partial index for defense in depth.

## Changes

- **Web (`/episode/start`)**: Before loading templates or inserting, checks for an active episode. If present, shows an impaired-friendly gate with **Continue this episode** (resume with `resume=1`) or **End this episode and start a new one** (closes the row, then continues the normal start flow). Handles episodes missing `symptom_preset_id` with copy that only allows ending and starting new.
- **Mobile (`EpisodeStartScreen`)**: Same behavior and copy, using navigation to `SymptomPrompt` with `resume: true` or `endEpisodeIfStillActive` + reload of the start flow.
- **`@abstrack/supabase`**: Adds `endEpisodeIfStillActive` for RLS-safe closure of an active episode before a new insert.
- **Migration**: Deduplicates legacy multiple active rows per user (keeps newest), then adds `episodes_one_active_per_user_idx` — unique on `user_id` where `ended_at IS NULL`.
- **Home CTAs**: Aligns primary action label to **Continue this episode** for consistency with the start gate.

## Post-merge / deploy notes

- Apply the new migration to Supabase (e.g. `supabase db push` on the linked project) and regenerate `database.types.ts` if that’s part of your workflow.

## Testing

- Unit tests for `endEpisodeIfStillActive` in `packages/supabase`.
- Manual: open `/episode/start` or mobile Episode Start with an active episode — should not create a second row without explicitly ending the first; **End…** then start should succeed; unique index blocks races once migration is applied.