### PR TITLE
feat(episodes): add active and ended episode lists on web and mobile

### DIFF
--- a/apps/mobile/src/app/App.tsx
+++ b/apps/mobile/src/app/App.tsx
@@ -12,6 +12,7 @@ import { MainTabNavigator } from './navigation/MainTabNavigator';
 import type { MainStackParamList } from './navigation/types';
 import { LoginScreen } from './screens/LoginScreen';
 import { EpisodeStartScreen } from './screens/EpisodeStartScreen';
+import { EpisodesScreen } from './screens/EpisodesScreen';
 import { SymptomPromptScreen } from './screens/SymptomPromptScreen';
 import { SettingsScreen } from './screens/SettingsScreen';
 import { SignupScreen } from './screens/SignupScreen';
@@ -382,6 +383,14 @@ function AppBootstrap() {
               name="MainTabs"
               component={MainTabNavigator}
               options={{ headerShown: false }}
+            />
+            <MainStack.Screen
+              name="Episodes"
+              component={EpisodesScreen}
+              options={{
+                title: 'Episodes',
+                headerBackTitle: 'Home',
+              }}
             />
             <MainStack.Screen
               name="EpisodeStart"

--- a/apps/mobile/src/app/navigation/MainTabNavigator.tsx
+++ b/apps/mobile/src/app/navigation/MainTabNavigator.tsx
@@ -67,6 +67,19 @@ function navigateFromHomeTabToSymptomPromptResume(
   });
 }
 
+function navigateFromHomeTabToEpisodes(
+  navigation: BottomTabNavigationProp<MainTabParamList, 'Home'>,
+) {
+  const stackNavigation =
+    navigation.getParent<NativeStackNavigationProp<MainStackParamList>>();
+  if (stackNavigation == null) {
+    throw new Error(
+      'MainTabNavigator: expected native stack parent (MainStack) to open Episodes.',
+    );
+  }
+  stackNavigation.navigate('Episodes');
+}
+
 type IonName = React.ComponentProps<typeof Ionicons>['name'];
 
 /**
@@ -128,6 +141,9 @@ export function MainTabNavigator() {
             <HomeScreen
               onGoToSettings={() => {
                 navigateFromHomeTabToSettings(navigation);
+              }}
+              onGoToEpisodes={() => {
+                navigateFromHomeTabToEpisodes(navigation);
               }}
               onStartEpisode={() => {
                 navigateFromHomeTabToEpisodeStart(navigation);

--- a/apps/mobile/src/app/navigation/types.ts
+++ b/apps/mobile/src/app/navigation/types.ts
@@ -32,6 +32,8 @@ export type MainTabParamList = {
 
 export type MainStackParamList = {
   MainTabs: undefined;
+  /** Active and recent episodes with resume for the in-progress row. */
+  Episodes: undefined;
   /** Episode logging entry: shell until template selection and prompts ship. */
   EpisodeStart: undefined;
   /** Linear symptom prompts for the active episode (preset lines). */

--- a/apps/mobile/src/app/screens/EpisodesScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/EpisodesScreen.spec.tsx
@@ -1,0 +1,187 @@
+import * as React from 'react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
+import { useNavigation } from '@react-navigation/native';
+import {
+  getActiveEpisodeForUser,
+  listCompletedEpisodesForUser,
+} from '@abstrack/supabase';
+import type { EpisodeRow } from '@abstrack/types';
+
+import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
+import { EpisodesScreen } from './EpisodesScreen';
+
+jest.mock('@react-navigation/native', () => {
+  const ReactNav = require('react');
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: jest.fn(),
+    useFocusEffect: (fn: () => void | (() => void)) => {
+      ReactNav.useEffect(() => {
+        const cleanup = fn();
+        return typeof cleanup === 'function' ? cleanup : undefined;
+      }, [fn]);
+    },
+  };
+});
+
+jest.mock('@abstrack/supabase', () => ({
+  getActiveEpisodeForUser: jest.fn(),
+  listCompletedEpisodesForUser: jest.fn(),
+}));
+
+jest.mock('../../lib/supabase-wiring', () => ({
+  getMobileSupabaseClient: jest.fn(),
+}));
+
+function makeEpisodeRow(overrides: Partial<EpisodeRow> = {}): EpisodeRow {
+  return {
+    id: 'ep-1',
+    user_id: 'user-1',
+    symptom_preset_id: 'sym-1',
+    health_marker_preset_id: null,
+    episode_type: 'ABS',
+    episode_label: null,
+    note: null,
+    started_at: '2026-04-20T10:00:00.000Z',
+    ended_at: null,
+    created_at: '2026-04-20T10:00:00.000Z',
+    updated_at: '2026-04-20T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('EpisodesScreen', () => {
+  const mockNavigate = jest.fn();
+  const mockGetUser = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.mocked(useNavigation).mockReturnValue({
+      navigate: mockNavigate,
+    } as never);
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } } });
+    jest.mocked(getMobileSupabaseClient).mockReturnValue({
+      auth: {
+        getUser: mockGetUser,
+      },
+    } as never);
+
+    jest.mocked(getActiveEpisodeForUser).mockResolvedValue({
+      ok: true,
+      data: null,
+    });
+    jest.mocked(listCompletedEpisodesForUser).mockResolvedValue({
+      ok: true,
+      data: [],
+    });
+  });
+
+  it('shows loading text until load finishes', async () => {
+    let resolveGetUser!: (v: { data: { user: { id: string } | null } }) => void;
+    const getUserPromise = new Promise<{
+      data: { user: { id: string } | null };
+    }>((resolve) => {
+      resolveGetUser = resolve;
+    });
+    mockGetUser.mockReturnValue(getUserPromise);
+
+    render(<EpisodesScreen />);
+
+    expect(screen.getByText('Loading…')).toBeTruthy();
+
+    await act(async () => {
+      resolveGetUser({ data: { user: null } });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading…')).toBeNull();
+    });
+
+    expect(await screen.findByText('No episode in progress.')).toBeTruthy();
+  });
+
+  it('shows empty signed-out-style copy when user is null', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    render(<EpisodesScreen />);
+
+    expect(await screen.findByText('No episode in progress.')).toBeTruthy();
+    expect(
+      await screen.findByText('No ended episodes in your history yet.'),
+    ).toBeTruthy();
+  });
+
+  it('surfaces active and recent API errors', async () => {
+    jest.mocked(getActiveEpisodeForUser).mockResolvedValue({
+      ok: false,
+      error: { message: 'Active query failed' } as never,
+    });
+    jest.mocked(listCompletedEpisodesForUser).mockResolvedValue({
+      ok: false,
+      error: { message: 'Recent query failed' } as never,
+    });
+
+    render(<EpisodesScreen />);
+
+    expect(await screen.findByText('Active query failed')).toBeTruthy();
+    expect(await screen.findByText('Recent query failed')).toBeTruthy();
+  });
+
+  it('surfaces unified error when load throws', async () => {
+    mockGetUser.mockRejectedValue(new Error('network'));
+
+    render(<EpisodesScreen />);
+
+    const alerts = await screen.findAllByText('Unable to load episodes.');
+    expect(alerts).toHaveLength(2);
+  });
+
+  it('navigates to SymptomPrompt with resume when Resume is pressed', async () => {
+    const active = makeEpisodeRow({
+      id: 'ep-resume',
+      symptom_preset_id: 'preset-99',
+    });
+    jest.mocked(getActiveEpisodeForUser).mockResolvedValue({
+      ok: true,
+      data: active,
+    });
+
+    render(<EpisodesScreen />);
+
+    expect(await screen.findByLabelText('Resume this episode')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Resume this episode'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('SymptomPrompt', {
+      episodeId: 'ep-resume',
+      symptomPresetId: 'preset-99',
+      resume: true,
+    });
+  });
+
+  it('renders recent ended episodes when list returns rows', async () => {
+    const ended = makeEpisodeRow({
+      id: 'ep-ended',
+      ended_at: '2026-04-21T12:00:00.000Z',
+      episode_label: 'Test label',
+    });
+    jest.mocked(listCompletedEpisodesForUser).mockResolvedValue({
+      ok: true,
+      data: [ended],
+    });
+
+    render(<EpisodesScreen />);
+
+    expect(await screen.findByText('ABS — Test label')).toBeTruthy();
+    expect(screen.getByText('Ended')).toBeTruthy();
+  });
+});

--- a/apps/mobile/src/app/screens/EpisodesScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodesScreen.tsx
@@ -23,8 +23,13 @@ function episodeSummaryLine(ep: {
   return label ? `${ep.episode_type} — ${label}` : ep.episode_type;
 }
 
+/** Localized instant for display; returns the raw `iso` (or em dash when empty) if parsing fails. */
 function formatInstant(iso: string): string {
-  return new Date(iso).toLocaleString(undefined, {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) {
+    return iso.trim() === '' ? '—' : iso;
+  }
+  return d.toLocaleString(undefined, {
     dateStyle: 'medium',
     timeStyle: 'short',
   });

--- a/apps/mobile/src/app/screens/EpisodesScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodesScreen.tsx
@@ -91,7 +91,10 @@ export function EpisodesScreen() {
       }
     } catch {
       if (!stale()) {
-        setActiveError('Unable to load episodes.');
+        const message = 'Unable to load episodes.';
+        setActiveError(message);
+        setRecentError(message);
+        setActive(null);
         setRecent([]);
       }
     } finally {

--- a/apps/mobile/src/app/screens/EpisodesScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodesScreen.tsx
@@ -1,0 +1,280 @@
+import React, { useCallback, useRef, useState } from 'react';
+import { Pressable, ScrollView, Text, View } from 'react-native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { EpisodeRow } from '@abstrack/types';
+import {
+  getActiveEpisodeForUser,
+  listCompletedEpisodesForUser,
+} from '@abstrack/supabase';
+import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
+import { ScreenShell } from '../components/ScreenShell';
+import type { MainStackParamList } from '../navigation/types';
+import type { ActiveEpisodeHomeSummary } from '../components/episode-flow/EpisodeStartHomeCta';
+import { nw } from '../theme/app-nativewind-classes';
+
+type EpisodesNav = NativeStackNavigationProp<MainStackParamList, 'Episodes'>;
+
+function episodeSummaryLine(ep: {
+  episode_type: string;
+  episode_label: string | null;
+}): string {
+  const label = ep.episode_label?.trim();
+  return label ? `${ep.episode_type} — ${label}` : ep.episode_type;
+}
+
+function formatInstant(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
+/**
+ * Secondary surface for episode lifecycle: active row (with resume) and ended history.
+ *
+ * @returns Episodes list screen.
+ */
+export function EpisodesScreen() {
+  const navigation = useNavigation<EpisodesNav>();
+  const loadGenRef = useRef(0);
+  const [loading, setLoading] = useState(true);
+  const [activeError, setActiveError] = useState<string | null>(null);
+  const [recentError, setRecentError] = useState<string | null>(null);
+  const [active, setActive] = useState<EpisodeRow | null>(null);
+  const [recent, setRecent] = useState<EpisodeRow[]>([]);
+
+  const load = useCallback(async (cancel?: { cancelled: boolean }) => {
+    const generation = ++loadGenRef.current;
+    const stale = () =>
+      cancel?.cancelled === true || generation !== loadGenRef.current;
+
+    setLoading(true);
+    setActiveError(null);
+    setRecentError(null);
+
+    try {
+      const client = getMobileSupabaseClient();
+      const {
+        data: { user },
+      } = await client.auth.getUser();
+      if (stale()) {
+        return;
+      }
+      if (!user) {
+        setActive(null);
+        setRecent([]);
+        return;
+      }
+
+      const [activeRes, recentRes] = await Promise.all([
+        getActiveEpisodeForUser(client, user.id),
+        listCompletedEpisodesForUser(client, user.id, { limit: 25 }),
+      ]);
+
+      if (stale()) {
+        return;
+      }
+
+      if (!activeRes.ok) {
+        setActiveError(activeRes.error.message);
+        setActive(null);
+      } else {
+        setActive(activeRes.data);
+      }
+
+      if (!recentRes.ok) {
+        setRecentError(recentRes.error.message);
+        setRecent([]);
+      } else {
+        setRecent(recentRes.data);
+      }
+    } catch {
+      if (!stale()) {
+        setActiveError('Unable to load episodes.');
+        setRecent([]);
+      }
+    } finally {
+      if (!stale()) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      const cancel = { cancelled: false };
+      void load(cancel);
+      return () => {
+        cancel.cancelled = true;
+        loadGenRef.current += 1;
+      };
+    }, [load]),
+  );
+
+  const onResume = (episode: ActiveEpisodeHomeSummary) => {
+    navigation.navigate('SymptomPrompt', {
+      episodeId: episode.episodeId,
+      symptomPresetId: episode.symptomPresetId,
+      resume: true,
+    });
+  };
+
+  const resumeSummary: ActiveEpisodeHomeSummary | null =
+    active && active.symptom_preset_id
+      ? {
+          episodeId: active.id,
+          symptomPresetId: active.symptom_preset_id,
+        }
+      : null;
+
+  return (
+    <ScreenShell contentAlign="stretch">
+      <ScrollView
+        className="min-h-0 flex-1"
+        keyboardShouldPersistTaps="handled"
+        contentContainerStyle={{ paddingBottom: 24, gap: 16 }}
+      >
+        <Text
+          className={`text-[22px] font-semibold ${nw.textInk}`}
+          accessibilityRole="header"
+          maxFontSizeMultiplier={2}
+        >
+          Episodes
+        </Text>
+        <Text className={`text-base ${nw.textMuted}`} maxFontSizeMultiplier={2}>
+          Active and recent episodes. Resume continues the guided symptom flow.
+        </Text>
+
+        <View>
+          <Text
+            className={`text-lg font-semibold ${nw.textInk}`}
+            accessibilityRole="header"
+            maxFontSizeMultiplier={2}
+          >
+            Active episode
+          </Text>
+          {loading ? (
+            <Text className={`mt-2 text-sm ${nw.textMuted}`}>Loading…</Text>
+          ) : null}
+          {activeError ? (
+            <Text
+              className={`mt-2 text-sm ${nw.textError}`}
+              accessibilityRole="alert"
+              maxFontSizeMultiplier={2}
+            >
+              {activeError}
+            </Text>
+          ) : null}
+          {!loading && !activeError && active === null ? (
+            <Text className={`mt-2 text-sm ${nw.textMuted}`}>
+              No episode in progress.
+            </Text>
+          ) : null}
+          {!loading && !activeError && active !== null ? (
+            <View
+              className={`mt-3 gap-2 rounded-2xl border-2 border-emerald-600/45 bg-emerald-50 p-4 dark:border-emerald-500/45 dark:bg-emerald-950/50`}
+              accessibilityLabel="Active episode"
+            >
+              <Text
+                className="text-xs font-semibold uppercase text-emerald-800 dark:text-emerald-200"
+                maxFontSizeMultiplier={2}
+              >
+                In progress
+              </Text>
+              <Text
+                className={`text-base font-semibold ${nw.textInk}`}
+                maxFontSizeMultiplier={2}
+              >
+                {episodeSummaryLine(active)}
+              </Text>
+              <Text
+                className={`text-sm ${nw.textMuted}`}
+                maxFontSizeMultiplier={2}
+              >
+                Started {formatInstant(active.started_at)}
+              </Text>
+              <Text
+                className={`text-sm ${nw.textMuted}`}
+                maxFontSizeMultiplier={2}
+              >
+                Ended —
+              </Text>
+              {resumeSummary ? (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Resume this episode"
+                  onPress={() => onResume(resumeSummary)}
+                  className={`mt-2 min-h-[52px] items-center justify-center rounded-xl bg-emerald-700 px-4 py-3 dark:bg-emerald-600`}
+                >
+                  <Text className="text-center text-[17px] font-semibold text-white">
+                    Resume this episode
+                  </Text>
+                </Pressable>
+              ) : (
+                <Text className={`mt-1 text-sm ${nw.textMuted}`}>
+                  No symptom preset linked yet. Start or configure an episode
+                  from the episode start screen.
+                </Text>
+              )}
+            </View>
+          ) : null}
+        </View>
+
+        <View>
+          <Text
+            className={`text-lg font-semibold ${nw.textInk}`}
+            accessibilityRole="header"
+            maxFontSizeMultiplier={2}
+          >
+            Recent episodes
+          </Text>
+          {recentError ? (
+            <Text
+              className={`mt-2 text-sm ${nw.textError}`}
+              accessibilityRole="alert"
+              maxFontSizeMultiplier={2}
+            >
+              {recentError}
+            </Text>
+          ) : null}
+          {!loading && !recentError && recent.length === 0 ? (
+            <Text className={`mt-2 text-sm ${nw.textMuted}`}>
+              No ended episodes in your history yet.
+            </Text>
+          ) : null}
+          {!loading && recent.length > 0 ? (
+            <View className="mt-3 gap-3" accessibilityRole="list">
+              {recent.map((ep) => (
+                <View
+                  key={ep.id}
+                  className={`rounded-xl border border-app-border bg-app-surface p-4 dark:border-app-border-dark dark:bg-app-surface-dark`}
+                  accessibilityRole="none"
+                >
+                  <Text
+                    className="text-xs font-semibold uppercase text-app-muted"
+                    maxFontSizeMultiplier={2}
+                  >
+                    Ended
+                  </Text>
+                  <Text
+                    className={`mt-1 text-base font-semibold ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    {episodeSummaryLine(ep)}
+                  </Text>
+                  <Text className={`mt-2 text-sm ${nw.textMuted}`}>
+                    Started {formatInstant(ep.started_at)}
+                  </Text>
+                  <Text className={`text-sm ${nw.textMuted}`}>
+                    Ended {ep.ended_at ? formatInstant(ep.ended_at) : '—'}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          ) : null}
+        </View>
+      </ScrollView>
+    </ScreenShell>
+  );
+}

--- a/apps/mobile/src/app/screens/HomeScreen.tsx
+++ b/apps/mobile/src/app/screens/HomeScreen.tsx
@@ -24,12 +24,14 @@ interface HealthCheckResult {
 
 type HomeScreenProps = {
   onGoToSettings: () => void;
+  onGoToEpisodes: () => void;
   onStartEpisode: () => void;
   onResumeEpisode: (episode: ActiveEpisodeHomeSummary) => void;
 };
 
 export function HomeScreen({
   onGoToSettings,
+  onGoToEpisodes,
   onStartEpisode,
   onResumeEpisode,
 }: HomeScreenProps) {
@@ -224,6 +226,20 @@ export function HomeScreen({
           activeEpisode={activeEpisode}
           activeEpisodeLoading={activeEpisodeLoading}
         />
+
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Open episodes list"
+          onPress={onGoToEpisodes}
+          className={`mb-1 min-h-[48px] justify-center rounded-xl border border-app-border bg-app-surface px-4 py-3 dark:border-app-border-dark dark:bg-app-surface-dark`}
+        >
+          <Text
+            className={`text-center text-base font-semibold ${nw.textPrimary}`}
+            maxFontSizeMultiplier={2}
+          >
+            Episodes
+          </Text>
+        </Pressable>
 
         <View className={`gap-3 rounded-xl p-4 ${nw.card} ${nw.cardShadow}`}>
           <Text

--- a/apps/mobile/src/app/screens/SettingsScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/SettingsScreen.spec.tsx
@@ -6,6 +6,16 @@ import { useAppTheme } from '../theme/AppThemeContext';
 import { lightAppColors } from '../theme/app-colors';
 import { SettingsScreen } from './SettingsScreen';
 
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({
+      navigate: jest.fn(),
+    }),
+  };
+});
+
 jest.mock('../reauth-preference', () => ({
   getRequireReauthOnOpenPreference: jest.fn(() => Promise.resolve(false)),
   setRequireReauthOnOpenPreference: jest.fn(() => Promise.resolve()),

--- a/apps/mobile/src/app/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/app/screens/SettingsScreen.tsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Pressable, Switch, Text, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import {
   getRequireReauthOnOpenPreference,
   setRequireReauthOnOpenPreference,
 } from '../reauth-preference';
 import { ScreenShell } from '../components/ScreenShell';
+import type { MainStackParamList } from '../navigation/types';
 import { useAppTheme } from '../theme/AppThemeContext';
 import { nw } from '../theme/app-nativewind-classes';
 import type { ThemePreference } from '../theme-preference';
@@ -32,6 +35,8 @@ const THEME_OPTIONS: {
 ];
 
 export function SettingsScreen() {
+  const navigation =
+    useNavigation<NativeStackNavigationProp<MainStackParamList>>();
   const { colors, themePreference, setThemePreference } = useAppTheme();
   const isMountedRef = useRef(true);
   const [requireReauth, setRequireReauth] = useState(false);
@@ -153,6 +158,22 @@ export function SettingsScreen() {
           {themeError}
         </Text>
       ) : null}
+
+      <View className="my-2 h-px bg-app-border dark:bg-app-border-dark" />
+
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Open episodes list"
+        onPress={() => navigation.navigate('Episodes')}
+        className={`min-h-[52px] justify-center rounded-xl border border-app-border bg-app-surface px-4 py-3 dark:border-app-border-dark dark:bg-app-surface-dark`}
+      >
+        <Text className={`text-base font-semibold ${nw.textInk}`}>
+          Episodes
+        </Text>
+        <Text className={`mt-0.5 text-sm ${nw.textMuted}`}>
+          Active and recent episodes, resume an in-progress episode.
+        </Text>
+      </Pressable>
 
       <View className="my-2 h-px bg-app-border dark:bg-app-border-dark" />
 

--- a/apps/web/src/app/(app)/episodes/page.tsx
+++ b/apps/web/src/app/(app)/episodes/page.tsx
@@ -1,0 +1,209 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import type { EpisodeRow } from '@abstrack/types';
+import {
+  getActiveEpisodeForUser,
+  listCompletedEpisodesForUser,
+} from '@abstrack/supabase';
+import {
+  formatEpisodeInstant,
+  formatEpisodeTypeSummary,
+} from '@/lib/episodes/format-episode-meta';
+import { buildResumeEpisodeHref } from '@/lib/episode-flow/resume-episode-href';
+import { createServerClient } from '@/lib/supabase/server-client';
+
+const resumeLinkClass =
+  'inline-flex min-h-[48px] w-full items-center justify-center rounded-xl bg-emerald-700 px-4 py-3 text-center text-sm font-semibold text-white shadow-sm outline-none ring-2 ring-transparent transition hover:bg-emerald-800 focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-emerald-50 dark:bg-emerald-600 dark:hover:bg-emerald-500 dark:focus-visible:ring-offset-emerald-950';
+
+/**
+ * Lists active and recently ended episodes with metadata; resume navigates into the symptom
+ * flow when a symptom preset is present.
+ *
+ * @returns Episodes management page.
+ */
+export default async function EpisodesPage() {
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+    error: getUserError,
+  } = await supabase.auth.getUser();
+
+  const allowDevAuthErrorDebugView =
+    process.env.NODE_ENV !== 'production' && !!getUserError;
+
+  if (getUserError) {
+    console.error('Failed to fetch user for episodes page', getUserError);
+  }
+
+  if (!user && !allowDevAuthErrorDebugView) {
+    redirect('/login');
+  }
+
+  let activeError: string | null = null;
+  let recentError: string | null = null;
+  let active: EpisodeRow | null = null;
+  let recent: EpisodeRow[] = [];
+
+  if (user) {
+    const [activeRes, recentRes] = await Promise.all([
+      getActiveEpisodeForUser(supabase, user.id),
+      listCompletedEpisodesForUser(supabase, user.id, { limit: 25 }),
+    ]);
+    if (!activeRes.ok) {
+      activeError = activeRes.error.message;
+    } else {
+      active = activeRes.data;
+    }
+    if (!recentRes.ok) {
+      recentError = recentRes.error.message;
+    } else {
+      recent = recentRes.data;
+    }
+  }
+
+  return (
+    <div className="w-full space-y-10">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Episodes
+        </h1>
+        <p className="mt-1 text-sm text-app-muted">
+          Review your active episode and recent history. Resume continues the
+          guided symptom flow.
+        </p>
+      </div>
+
+      <section aria-labelledby="episodes-active-heading">
+        <h2
+          id="episodes-active-heading"
+          className="text-lg font-semibold text-app-ink"
+        >
+          Active episode
+        </h2>
+        {activeError ? (
+          <p
+            className="mt-2 text-sm text-red-700 dark:text-red-300"
+            role="alert"
+          >
+            {activeError}
+          </p>
+        ) : null}
+        {!user && allowDevAuthErrorDebugView ? (
+          <p className="mt-3 text-sm text-app-muted">
+            Sign in to load episodes (development: no session).
+          </p>
+        ) : null}
+        {user && !activeError && active === null ? (
+          <p className="mt-3 rounded-xl border border-dashed border-app-border/90 bg-app-surface/60 p-4 text-sm text-app-muted">
+            No episode in progress.{' '}
+            <Link
+              href="/episode/start"
+              className="font-semibold text-app-primary underline underline-offset-2"
+            >
+              Start an episode
+            </Link>{' '}
+            from the guided flow when you need to log symptoms.
+          </p>
+        ) : null}
+        {user && !activeError && active !== null ? (
+          <div
+            className="mt-3 rounded-2xl border-2 border-emerald-600/45 bg-emerald-50 p-5 shadow-sm ring-1 ring-emerald-900/10 dark:border-emerald-500/45 dark:bg-emerald-950/40 dark:ring-emerald-950/35 sm:p-6"
+            aria-label="Active episode"
+          >
+            <p className="text-xs font-semibold uppercase tracking-wide text-emerald-800 dark:text-emerald-200">
+              In progress
+            </p>
+            <p className="mt-2 text-base font-semibold text-app-ink">
+              {formatEpisodeTypeSummary(active)}
+            </p>
+            <dl className="mt-3 space-y-1.5 text-sm text-app-muted">
+              <div className="flex flex-wrap gap-x-2">
+                <dt className="font-medium text-app-ink/80">Started</dt>
+                <dd>{formatEpisodeInstant(active.started_at)}</dd>
+              </div>
+              <div className="flex flex-wrap gap-x-2">
+                <dt className="font-medium text-app-ink/80">Ended</dt>
+                <dd>—</dd>
+              </div>
+            </dl>
+            <div className="mt-5">
+              {active.symptom_preset_id ? (
+                <Link
+                  href={buildResumeEpisodeHref(
+                    active.id,
+                    active.symptom_preset_id,
+                  )}
+                  className={resumeLinkClass}
+                >
+                  Resume this episode
+                </Link>
+              ) : (
+                <p className="text-sm text-app-muted">
+                  This episode has no symptom preset linked yet.{' '}
+                  <Link
+                    href="/episode/start"
+                    className="font-semibold text-app-primary underline underline-offset-2"
+                  >
+                    Open episode start
+                  </Link>{' '}
+                  to continue setup.
+                </p>
+              )}
+            </div>
+          </div>
+        ) : null}
+      </section>
+
+      <section aria-labelledby="episodes-recent-heading">
+        <h2
+          id="episodes-recent-heading"
+          className="text-lg font-semibold text-app-ink"
+        >
+          Recent episodes
+        </h2>
+        {recentError ? (
+          <p
+            className="mt-2 text-sm text-red-700 dark:text-red-300"
+            role="alert"
+          >
+            {recentError}
+          </p>
+        ) : null}
+        {user && !recentError && recent.length === 0 ? (
+          <p className="mt-3 text-sm text-app-muted">
+            No ended episodes in your history yet. When you end an episode, it
+            appears here.
+          </p>
+        ) : null}
+        {user && !recentError && recent.length > 0 ? (
+          <ul className="mt-3 space-y-3" role="list">
+            {recent.map((ep) => (
+              <li key={ep.id}>
+                <div className="rounded-xl border border-app-border/90 bg-app-surface p-4 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-app-muted">
+                    Ended
+                  </p>
+                  <p className="mt-1.5 text-base font-semibold text-app-ink">
+                    {formatEpisodeTypeSummary(ep)}
+                  </p>
+                  <dl className="mt-2 space-y-1 text-sm text-app-muted">
+                    <div className="flex flex-wrap gap-x-2">
+                      <dt className="font-medium text-app-ink/80">Started</dt>
+                      <dd>{formatEpisodeInstant(ep.started_at)}</dd>
+                    </div>
+                    <div className="flex flex-wrap gap-x-2">
+                      <dt className="font-medium text-app-ink/80">Ended</dt>
+                      <dd>
+                        {ep.ended_at ? formatEpisodeInstant(ep.ended_at) : '—'}
+                      </dd>
+                    </div>
+                  </dl>
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/episodes/page.tsx
+++ b/apps/web/src/app/(app)/episodes/page.tsx
@@ -5,10 +5,8 @@ import {
   getActiveEpisodeForUser,
   listCompletedEpisodesForUser,
 } from '@abstrack/supabase';
-import {
-  formatEpisodeInstant,
-  formatEpisodeTypeSummary,
-} from '@/lib/episodes/format-episode-meta';
+import { EpisodeLocaleInstant } from '@/components/episodes/EpisodeLocaleInstant';
+import { formatEpisodeTypeSummary } from '@/lib/episodes/format-episode-meta';
 import { buildResumeEpisodeHref } from '@/lib/episode-flow/resume-episode-href';
 import { createServerClient } from '@/lib/supabase/server-client';
 
@@ -119,7 +117,9 @@ export default async function EpisodesPage() {
             <dl className="mt-3 space-y-1.5 text-sm text-app-muted">
               <div className="flex flex-wrap gap-x-2">
                 <dt className="font-medium text-app-ink/80">Started</dt>
-                <dd>{formatEpisodeInstant(active.started_at)}</dd>
+                <dd>
+                  <EpisodeLocaleInstant iso={active.started_at} />
+                </dd>
               </div>
               <div className="flex flex-wrap gap-x-2">
                 <dt className="font-medium text-app-ink/80">Ended</dt>
@@ -189,12 +189,18 @@ export default async function EpisodesPage() {
                   <dl className="mt-2 space-y-1 text-sm text-app-muted">
                     <div className="flex flex-wrap gap-x-2">
                       <dt className="font-medium text-app-ink/80">Started</dt>
-                      <dd>{formatEpisodeInstant(ep.started_at)}</dd>
+                      <dd>
+                        <EpisodeLocaleInstant iso={ep.started_at} />
+                      </dd>
                     </div>
                     <div className="flex flex-wrap gap-x-2">
                       <dt className="font-medium text-app-ink/80">Ended</dt>
                       <dd>
-                        {ep.ended_at ? formatEpisodeInstant(ep.ended_at) : '—'}
+                        {ep.ended_at ? (
+                          <EpisodeLocaleInstant iso={ep.ended_at} />
+                        ) : (
+                          '—'
+                        )}
                       </dd>
                     </div>
                   </dl>

--- a/apps/web/src/components/app-shell/AuthenticatedShell.tsx
+++ b/apps/web/src/components/app-shell/AuthenticatedShell.tsx
@@ -16,6 +16,11 @@ const NAV_ITEMS: {
     match: (path) => path === '/dashboard' || path.startsWith('/dashboard/'),
   },
   {
+    href: '/episodes',
+    label: 'Episodes',
+    match: (path) => path === '/episodes' || path.startsWith('/episodes/'),
+  },
+  {
     href: '/presets/symptoms',
     label: 'Symptom presets',
     match: (path) =>

--- a/apps/web/src/components/episodes/EpisodeLocaleInstant.tsx
+++ b/apps/web/src/components/episodes/EpisodeLocaleInstant.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export type EpisodeLocaleInstantProps = {
+  /** `IsoTimestamptz` string. */
+  iso: string;
+  /** Optional class for the wrapping `time` element. */
+  className?: string;
+};
+
+/**
+ * Displays an episode instant in the viewer&apos;s locale and time zone. Formatting runs after
+ * mount so it is not tied to the server&apos;s locale (unlike calling `toLocaleString` in an RSC).
+ *
+ * @param props - ISO timestamp and optional styling.
+ * @returns A `time` element with a localized label.
+ */
+export function EpisodeLocaleInstant({
+  iso,
+  className,
+}: EpisodeLocaleInstantProps) {
+  const [label, setLabel] = useState('');
+
+  useEffect(() => {
+    setLabel(
+      new Date(iso).toLocaleString(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+      }),
+    );
+  }, [iso]);
+
+  return (
+    <time className={className} dateTime={iso} suppressHydrationWarning>
+      {label || '…'}
+    </time>
+  );
+}

--- a/apps/web/src/components/episodes/EpisodeLocaleInstant.tsx
+++ b/apps/web/src/components/episodes/EpisodeLocaleInstant.tsx
@@ -48,8 +48,13 @@ export function EpisodeLocaleInstant({
 
   useEffect(() => {
     const id = requestAnimationFrame(() => {
+      const d = new Date(iso);
+      if (Number.isNaN(d.getTime())) {
+        setLocaleLabel(null);
+        return;
+      }
       setLocaleLabel(
-        new Date(iso).toLocaleString(undefined, {
+        d.toLocaleString(undefined, {
           dateStyle: 'medium',
           timeStyle: 'short',
         }),

--- a/apps/web/src/components/episodes/EpisodeLocaleInstant.tsx
+++ b/apps/web/src/components/episodes/EpisodeLocaleInstant.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 
 export type EpisodeLocaleInstantProps = {
   /** `IsoTimestamptz` string. */
@@ -10,30 +10,59 @@ export type EpisodeLocaleInstantProps = {
 };
 
 /**
- * Displays an episode instant in the viewer&apos;s locale and time zone. Formatting runs after
- * mount so it is not tied to the server&apos;s locale (unlike calling `toLocaleString` in an RSC).
+ * Deterministic, locale-agnostic text for an instant (UTC wall time). Used for SSR, no-JS, and
+ * until localized formatting runs in the browser.
+ *
+ * @param iso - `IsoTimestamptz` string.
+ * @returns Readable UTC string, or `iso` when invalid.
+ */
+function utcIsoFallbackLabel(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) {
+    return iso;
+  }
+  return d
+    .toISOString()
+    .replace('T', ' ')
+    .replace(/\.\d{3}Z$/, ' UTC');
+}
+
+/**
+ * Displays an episode instant in the viewer&apos;s locale and time zone after hydration. Until
+ * then, shows a deterministic UTC string so assistive tech and no-JS users still get a
+ * meaningful value (not an ellipsis). {@link EpisodeLocaleInstantProps.iso} is exposed on
+ * `dateTime` and `title`.
  *
  * @param props - ISO timestamp and optional styling.
- * @returns A `time` element with a localized label.
+ * @returns A `time` element with a localized or fallback label.
  */
 export function EpisodeLocaleInstant({
   iso,
   className,
 }: EpisodeLocaleInstantProps) {
-  const [label, setLabel] = useState('');
+  const [localeLabel, setLocaleLabel] = useState<string | null>(null);
 
-  useEffect(() => {
-    setLabel(
-      new Date(iso).toLocaleString(undefined, {
-        dateStyle: 'medium',
-        timeStyle: 'short',
-      }),
-    );
+  useLayoutEffect(() => {
+    setLocaleLabel(null);
   }, [iso]);
 
+  useEffect(() => {
+    const id = requestAnimationFrame(() => {
+      setLocaleLabel(
+        new Date(iso).toLocaleString(undefined, {
+          dateStyle: 'medium',
+          timeStyle: 'short',
+        }),
+      );
+    });
+    return () => cancelAnimationFrame(id);
+  }, [iso]);
+
+  const display = localeLabel ?? utcIsoFallbackLabel(iso);
+
   return (
-    <time className={className} dateTime={iso} suppressHydrationWarning>
-      {label || '…'}
+    <time className={className} dateTime={iso} title={iso}>
+      {display}
     </time>
   );
 }

--- a/apps/web/src/lib/episodes/format-episode-meta.ts
+++ b/apps/web/src/lib/episodes/format-episode-meta.ts
@@ -1,0 +1,27 @@
+import type { EpisodeRow } from '@abstrack/types';
+
+/**
+ * User-facing line for episode type and optional custom label.
+ *
+ * @param episode - Episode row fields used for display.
+ * @returns e.g. `ABS` or `ABS — label`.
+ */
+export function formatEpisodeTypeSummary(
+  episode: Pick<EpisodeRow, 'episode_type' | 'episode_label'>,
+): string {
+  const label = episode.episode_label?.trim();
+  return label ? `${episode.episode_type} — ${label}` : episode.episode_type;
+}
+
+/**
+ * Formats an ISO timestamp for the user’s locale in the browser.
+ *
+ * @param iso - `IsoTimestamptz` string.
+ * @returns Localized date and short time.
+ */
+export function formatEpisodeInstant(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}

--- a/apps/web/src/lib/episodes/format-episode-meta.ts
+++ b/apps/web/src/lib/episodes/format-episode-meta.ts
@@ -1,6 +1,13 @@
 import type { EpisodeRow } from '@abstrack/types';
 
 /**
+ * Pure string helpers for episode rows safe to run in Server Components.
+ * For localized date/time strings, use {@link EpisodeLocaleInstant} from
+ * `@/components/episodes/EpisodeLocaleInstant` so formatting uses the viewer’s locale and time zone
+ * in the browser (not Node).
+ */
+
+/**
  * User-facing line for episode type and optional custom label.
  *
  * @param episode - Episode row fields used for display.
@@ -11,17 +18,4 @@ export function formatEpisodeTypeSummary(
 ): string {
   const label = episode.episode_label?.trim();
   return label ? `${episode.episode_type} — ${label}` : episode.episode_type;
-}
-
-/**
- * Formats an ISO timestamp for the user’s locale in the browser.
- *
- * @param iso - `IsoTimestamptz` string.
- * @returns Localized date and short time.
- */
-export function formatEpisodeInstant(iso: string): string {
-  return new Date(iso).toLocaleString(undefined, {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  });
 }

--- a/apps/web/src/proxy.spec.ts
+++ b/apps/web/src/proxy.spec.ts
@@ -146,6 +146,25 @@ describe('web auth proxy', () => {
     );
   });
 
+  it('redirects unauthenticated user from /episodes to /login', async () => {
+    createServerClientMock.mockImplementation(() =>
+      Promise.resolve({
+        auth: {
+          getUser: jest.fn(async () => ({ data: { user: null } })),
+        },
+      } as unknown as ServerClient),
+    );
+
+    const result = await proxy(makeRequest('/episodes'));
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        type: 'redirect',
+        location: 'https://example.com/login',
+      }),
+    );
+  });
+
   it('redirects unauthenticated user from preset routes to /login', async () => {
     createServerClientMock.mockImplementation(() =>
       Promise.resolve({
@@ -213,6 +232,25 @@ describe('web auth proxy', () => {
     );
 
     const result = await proxy(makeRequest('/presets-foo'));
+
+    expect(getUser).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(
+      expect.objectContaining({
+        type: 'next',
+      }),
+    );
+  });
+
+  it('does not treat lookalike paths as protected (e.g. /episodes-foo)', async () => {
+    const getUser = jest.fn(async () => ({ data: { user: null } }));
+
+    createServerClientMock.mockReturnValue(
+      Promise.resolve({
+        auth: { getUser },
+      } as unknown as ServerClient),
+    );
+
+    const result = await proxy(makeRequest('/episodes-foo'));
 
     expect(getUser).toHaveBeenCalledTimes(1);
     expect(result).toEqual(

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from './lib/supabase/server-client';
 
 // Protected routes that require authentication
-const protectedRoutes = ['/dashboard', '/presets', '/episode'];
+const protectedRoutes = ['/dashboard', '/presets', '/episode', '/episodes'];
 
 /**
  * True when `pathname` is exactly `route` or a nested path under it (e.g. `/presets/x`), not

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -80,6 +80,7 @@ export {
   endEpisodeIfStillActive,
   getActiveEpisodeForUser,
   getEpisodeById,
+  listCompletedEpisodesForUser,
 } from './lib/episode-data.js';
 export {
   deleteEpisodeSymptomAnswer,

--- a/packages/supabase/src/lib/episode-data.spec.ts
+++ b/packages/supabase/src/lib/episode-data.spec.ts
@@ -162,7 +162,7 @@ describe('getActiveEpisodeForUser', () => {
 });
 
 describe('listCompletedEpisodesForUser', () => {
-  it('returns completed episodes ordered by ended_at desc', async () => {
+  it('returns completed episodes ordered by ended_at desc, id desc', async () => {
     const rows: EpisodeRow[] = [
       {
         id: 'ep-2',
@@ -192,8 +192,11 @@ describe('listCompletedEpisodesForUser', () => {
       },
     ];
     const limit = vi.fn(async () => ({ data: rows, error: null }));
-    const order = vi.fn(() => ({ limit }));
-    const notFn = vi.fn(() => ({ order }));
+    const queryBuilder = {
+      order: vi.fn(() => queryBuilder),
+      limit,
+    };
+    const notFn = vi.fn(() => queryBuilder);
     const eq = vi.fn(() => ({ not: notFn }));
     const select = vi.fn(() => ({ eq }));
     const client = {
@@ -212,7 +215,12 @@ describe('listCompletedEpisodesForUser', () => {
     expect(client.from).toHaveBeenCalledWith('episodes');
     expect(eq).toHaveBeenCalledWith('user_id', 'user-1');
     expect(notFn).toHaveBeenCalledWith('ended_at', 'is', null);
-    expect(order).toHaveBeenCalledWith('ended_at', { ascending: false });
+    expect(queryBuilder.order).toHaveBeenNthCalledWith(1, 'ended_at', {
+      ascending: false,
+    });
+    expect(queryBuilder.order).toHaveBeenNthCalledWith(2, 'id', {
+      ascending: false,
+    });
     expect(limit).toHaveBeenCalledWith(25);
   });
 });

--- a/packages/supabase/src/lib/episode-data.spec.ts
+++ b/packages/supabase/src/lib/episode-data.spec.ts
@@ -5,6 +5,7 @@ import {
   endEpisodeIfStillActive,
   getActiveEpisodeForUser,
   getEpisodeById,
+  listCompletedEpisodesForUser,
 } from './episode-data.js';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
 
@@ -157,6 +158,62 @@ describe('getActiveEpisodeForUser', () => {
     if (result.ok) {
       expect(result.data).toBeNull();
     }
+  });
+});
+
+describe('listCompletedEpisodesForUser', () => {
+  it('returns completed episodes ordered by ended_at desc', async () => {
+    const rows: EpisodeRow[] = [
+      {
+        id: 'ep-2',
+        user_id: 'user-1',
+        symptom_preset_id: 'sym-1',
+        health_marker_preset_id: null,
+        episode_type: 'ABS',
+        episode_label: 'Morning',
+        note: null,
+        started_at: '2026-04-19T10:00:00.000Z',
+        ended_at: '2026-04-19T11:00:00.000Z',
+        created_at: '2026-04-19T10:00:00.000Z',
+        updated_at: '2026-04-19T11:00:00.000Z',
+      },
+      {
+        id: 'ep-1',
+        user_id: 'user-1',
+        symptom_preset_id: 'sym-1',
+        health_marker_preset_id: null,
+        episode_type: 'Other',
+        episode_label: null,
+        note: null,
+        started_at: '2026-04-18T08:00:00.000Z',
+        ended_at: '2026-04-18T09:30:00.000Z',
+        created_at: '2026-04-18T08:00:00.000Z',
+        updated_at: '2026-04-18T09:30:00.000Z',
+      },
+    ];
+    const limit = vi.fn(async () => ({ data: rows, error: null }));
+    const order = vi.fn(() => ({ limit }));
+    const notFn = vi.fn(() => ({ order }));
+    const eq = vi.fn(() => ({ not: notFn }));
+    const select = vi.fn(() => ({ eq }));
+    const client = {
+      from: vi.fn(() => ({ select })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await listCompletedEpisodesForUser(client, 'user-1', {
+      limit: 25,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0]?.id).toBe('ep-2');
+    }
+    expect(client.from).toHaveBeenCalledWith('episodes');
+    expect(eq).toHaveBeenCalledWith('user_id', 'user-1');
+    expect(notFn).toHaveBeenCalledWith('ended_at', 'is', null);
+    expect(order).toHaveBeenCalledWith('ended_at', { ascending: false });
+    expect(limit).toHaveBeenCalledWith(25);
   });
 });
 

--- a/packages/supabase/src/lib/episode-data.ts
+++ b/packages/supabase/src/lib/episode-data.ts
@@ -81,6 +81,38 @@ export async function getActiveEpisodeForUser(
 }
 
 /**
+ * Lists the caller’s completed episodes (`ended_at IS NOT NULL`), newest first. Uses the same RLS
+ * as other `episodes` reads.
+ *
+ * @param client - Supabase client (RLS applies).
+ * @param userId - `auth.users.id` / `episodes.user_id`.
+ * @param options - `limit` caps rows (default 25).
+ * @returns Completed episode rows, or a {@link PresetDataError} on failure.
+ */
+export async function listCompletedEpisodesForUser(
+  client: AbstrackSupabaseClient,
+  userId: Uuid,
+  options: { limit?: number } = {},
+): Promise<PresetDataResult<EpisodeRow[]>> {
+  const limit = options.limit ?? 25;
+  try {
+    const { data, error } = await client
+      .from('episodes')
+      .select('*')
+      .eq('user_id', userId)
+      .not('ended_at', 'is', null)
+      .order('ended_at', { ascending: false })
+      .limit(limit);
+    if (error) {
+      return { ok: false, error: toPresetDataError(error) };
+    }
+    return { ok: true, data: (data ?? []) as EpisodeRow[] };
+  } catch (caught) {
+    return { ok: false, error: toPresetDataError(caught) };
+  }
+}
+
+/**
  * Sets `ended_at` on an episode that is still active (`ended_at IS NULL`). Uses the same RLS as
  * other `episodes` updates.
  *

--- a/packages/supabase/src/lib/episode-data.ts
+++ b/packages/supabase/src/lib/episode-data.ts
@@ -81,8 +81,8 @@ export async function getActiveEpisodeForUser(
 }
 
 /**
- * Lists the caller’s completed episodes (`ended_at IS NOT NULL`), newest first. Uses the same RLS
- * as other `episodes` reads.
+ * Lists the caller’s completed episodes (`ended_at IS NOT NULL`), newest first, then by `id`
+ * descending for a stable order when `ended_at` ties. Uses the same RLS as other `episodes` reads.
  *
  * @param client - Supabase client (RLS applies).
  * @param userId - `auth.users.id` / `episodes.user_id`.
@@ -102,6 +102,7 @@ export async function listCompletedEpisodesForUser(
       .eq('user_id', userId)
       .not('ended_at', 'is', null)
       .order('ended_at', { ascending: false })
+      .order('id', { ascending: false })
       .limit(limit);
     if (error) {
       return { ok: false, error: toPresetDataError(error) };


### PR DESCRIPTION
Closes #103

## Summary

Adds a secondary **Episodes** management surface on web and mobile: **active** episode (with resume when a symptom preset exists) and **recent ended** episodes, without changing the impaired-use home flow beyond compact entry points.

## Changes

- **Web**
  - New authenticated route `/episodes` listing active vs ended rows with `started_at` / `ended_at`, type + optional label, and **Resume this episode** via existing `buildResumeEpisodeHref` when applicable.
  - Primary nav item **Episodes** in `AuthenticatedShell`.
  - Shared display helpers in `apps/web/src/lib/episodes/format-episode-meta.ts`.
- **Mobile**
  - New stack screen `Episodes` (`EpisodesScreen`) with the same sections and resume → `SymptomPrompt` with `resume: true`.
  - Entry points: **Episodes** control on Home (below episode CTA) and **Episodes** row in Settings.
  - `SettingsScreen.spec.tsx`: `useNavigation` mock so tests run without a `NavigationContainer`.
- **Data**
  - `listCompletedEpisodesForUser` in `@abstrack/supabase` (ended episodes only, ordered by `ended_at` desc, default limit 25) with unit coverage.

## Issue / acceptance

Tracks the “Episodes management surface” issue: reachable from both apps, active vs ended visually distinct, resume from this surface works when a symptom preset is present.

**Not in this PR:** schema migrations (none in this diff vs `main`).