### PR TITLE
feat(episodes): add destructive active-episode cancel flow with state cleanup on web and mobile

### DIFF
--- a/apps/mobile/src/app/screens/EpisodesScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/EpisodesScreen.spec.tsx
@@ -8,11 +8,14 @@ import {
 } from '@testing-library/react-native';
 import { useNavigation } from '@react-navigation/native';
 import {
+  cancelActiveEpisodeById,
   getActiveEpisodeForUser,
   listCompletedEpisodesForUser,
 } from '@abstrack/supabase';
 import type { EpisodeRow } from '@abstrack/types';
+import { announce } from '@abstrack/ui/native';
 
+import { clearSymptomPromptSession } from '../../lib/episodes/symptom-prompt-session-store';
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { EpisodesScreen } from './EpisodesScreen';
 
@@ -32,8 +35,17 @@ jest.mock('@react-navigation/native', () => {
 });
 
 jest.mock('@abstrack/supabase', () => ({
+  cancelActiveEpisodeById: jest.fn(),
   getActiveEpisodeForUser: jest.fn(),
   listCompletedEpisodesForUser: jest.fn(),
+}));
+
+jest.mock('@abstrack/ui/native', () => ({
+  announce: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../lib/episodes/symptom-prompt-session-store', () => ({
+  clearSymptomPromptSession: jest.fn(),
 }));
 
 jest.mock('../../lib/supabase-wiring', () => ({
@@ -82,6 +94,10 @@ describe('EpisodesScreen', () => {
     jest.mocked(listCompletedEpisodesForUser).mockResolvedValue({
       ok: true,
       data: [],
+    });
+    jest.mocked(cancelActiveEpisodeById).mockResolvedValue({
+      ok: true,
+      data: { didCancel: true },
     });
   });
 
@@ -183,5 +199,49 @@ describe('EpisodesScreen', () => {
 
     expect(await screen.findByText('ABS — Test label')).toBeTruthy();
     expect(screen.getByText('Ended')).toBeTruthy();
+  });
+
+  it('confirms and cancels active episode', async () => {
+    const alertSpy = jest.spyOn(require('react-native').Alert, 'alert');
+    const active = makeEpisodeRow({
+      id: 'ep-cancel',
+      symptom_preset_id: 'preset-1',
+    });
+    jest.mocked(getActiveEpisodeForUser).mockResolvedValue({
+      ok: true,
+      data: active,
+    });
+
+    render(<EpisodesScreen />);
+
+    expect(await screen.findByLabelText('Cancel episode')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Cancel episode'));
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Cancel this active episode?',
+      'Canceling will permanently remove this in-progress episode and any linked symptom or media entries. This cannot be undone.',
+      expect.any(Array),
+    );
+
+    const [, , buttons] = alertSpy.mock.calls[0] as [
+      string,
+      string,
+      Array<{ onPress?: () => void }>,
+    ];
+    await act(async () => {
+      buttons[1]?.onPress?.();
+    });
+
+    await waitFor(() => {
+      expect(cancelActiveEpisodeById).toHaveBeenCalledWith(
+        expect.anything(),
+        'ep-cancel',
+      );
+    });
+    expect(clearSymptomPromptSession).toHaveBeenCalledWith('ep-cancel');
+    expect(announce).toHaveBeenCalledWith(
+      'Episode canceled. Resume is no longer available.',
+      { politeness: 'polite' },
+    );
   });
 });

--- a/apps/mobile/src/app/screens/EpisodesScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/EpisodesScreen.spec.tsx
@@ -202,46 +202,52 @@ describe('EpisodesScreen', () => {
   });
 
   it('confirms and cancels active episode', async () => {
-    const alertSpy = jest.spyOn(require('react-native').Alert, 'alert');
-    const active = makeEpisodeRow({
-      id: 'ep-cancel',
-      symptom_preset_id: 'preset-1',
-    });
-    jest.mocked(getActiveEpisodeForUser).mockResolvedValue({
-      ok: true,
-      data: active,
-    });
+    const alertSpy = jest
+      .spyOn(require('react-native').Alert, 'alert')
+      .mockImplementation(() => undefined);
+    try {
+      const active = makeEpisodeRow({
+        id: 'ep-cancel',
+        symptom_preset_id: 'preset-1',
+      });
+      jest.mocked(getActiveEpisodeForUser).mockResolvedValue({
+        ok: true,
+        data: active,
+      });
 
-    render(<EpisodesScreen />);
+      render(<EpisodesScreen />);
 
-    expect(await screen.findByLabelText('Cancel episode')).toBeTruthy();
-    fireEvent.press(screen.getByLabelText('Cancel episode'));
+      expect(await screen.findByLabelText('Cancel episode')).toBeTruthy();
+      fireEvent.press(screen.getByLabelText('Cancel episode'));
 
-    expect(alertSpy).toHaveBeenCalledWith(
-      'Cancel this active episode?',
-      'Canceling will permanently remove this in-progress episode and any linked symptom or media entries. This cannot be undone.',
-      expect.any(Array),
-    );
-
-    const [, , buttons] = alertSpy.mock.calls[0] as [
-      string,
-      string,
-      Array<{ onPress?: () => void }>,
-    ];
-    await act(async () => {
-      buttons[1]?.onPress?.();
-    });
-
-    await waitFor(() => {
-      expect(cancelActiveEpisodeById).toHaveBeenCalledWith(
-        expect.anything(),
-        'ep-cancel',
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Cancel this active episode?',
+        'Canceling will permanently remove this in-progress episode and any linked symptom or media entries. This cannot be undone.',
+        expect.any(Array),
       );
-    });
-    expect(clearSymptomPromptSession).toHaveBeenCalledWith('ep-cancel');
-    expect(announce).toHaveBeenCalledWith(
-      'Episode canceled. Resume is no longer available.',
-      { politeness: 'polite' },
-    );
+
+      const [, , buttons] = alertSpy.mock.calls[0] as [
+        string,
+        string,
+        Array<{ onPress?: () => void }>,
+      ];
+      await act(async () => {
+        buttons[1]?.onPress?.();
+      });
+
+      await waitFor(() => {
+        expect(cancelActiveEpisodeById).toHaveBeenCalledWith(
+          expect.anything(),
+          'ep-cancel',
+        );
+      });
+      expect(clearSymptomPromptSession).toHaveBeenCalledWith('ep-cancel');
+      expect(announce).toHaveBeenCalledWith(
+        'Episode canceled. Resume is no longer available.',
+        { politeness: 'polite' },
+      );
+    } finally {
+      alertSpy.mockRestore();
+    }
   });
 });

--- a/apps/mobile/src/app/screens/EpisodesScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodesScreen.tsx
@@ -1,12 +1,15 @@
 import React, { useCallback, useRef, useState } from 'react';
-import { Pressable, ScrollView, Text, View } from 'react-native';
+import { Alert, Pressable, ScrollView, Text, View } from 'react-native';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { EpisodeRow } from '@abstrack/types';
+import { announce } from '@abstrack/ui/native';
 import {
+  cancelActiveEpisodeById,
   getActiveEpisodeForUser,
   listCompletedEpisodesForUser,
 } from '@abstrack/supabase';
+import { clearSymptomPromptSession } from '../../lib/episodes/symptom-prompt-session-store';
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { ScreenShell } from '../components/ScreenShell';
 import type { MainStackParamList } from '../navigation/types';
@@ -48,6 +51,7 @@ export function EpisodesScreen() {
   const [recentError, setRecentError] = useState<string | null>(null);
   const [active, setActive] = useState<EpisodeRow | null>(null);
   const [recent, setRecent] = useState<EpisodeRow[]>([]);
+  const [cancelingActiveEpisode, setCancelingActiveEpisode] = useState(false);
 
   const load = useCallback(async (cancel?: { cancelled: boolean }) => {
     const generation = ++loadGenRef.current;
@@ -127,6 +131,54 @@ export function EpisodesScreen() {
       resume: true,
     });
   };
+
+  const onCancelEpisode = useCallback(() => {
+    if (!active || cancelingActiveEpisode) {
+      return;
+    }
+    Alert.alert(
+      'Cancel this active episode?',
+      'Canceling will permanently remove this in-progress episode and any linked symptom or media entries. This cannot be undone.',
+      [
+        { text: 'Keep episode', style: 'cancel' },
+        {
+          text: 'Cancel episode',
+          style: 'destructive',
+          onPress: () => {
+            void (async () => {
+              setCancelingActiveEpisode(true);
+              try {
+                const client = getMobileSupabaseClient();
+                const result = await cancelActiveEpisodeById(client, active.id);
+                if (!result.ok) {
+                  await announce(result.error.message, {
+                    politeness: 'assertive',
+                  });
+                  return;
+                }
+                clearSymptomPromptSession(active.id);
+                if (result.data.didCancel) {
+                  await announce(
+                    'Episode canceled. Resume is no longer available.',
+                    {
+                      politeness: 'polite',
+                    },
+                  );
+                } else {
+                  await announce('This episode is no longer active.', {
+                    politeness: 'polite',
+                  });
+                }
+                await load();
+              } finally {
+                setCancelingActiveEpisode(false);
+              }
+            })();
+          },
+        },
+      ],
+    );
+  }, [active, cancelingActiveEpisode, load]);
 
   const resumeSummary: ActiveEpisodeHomeSummary | null =
     active && active.symptom_preset_id
@@ -225,6 +277,24 @@ export function EpisodesScreen() {
                   from the episode start screen.
                 </Text>
               )}
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Cancel episode"
+                accessibilityHint="Permanently removes this in-progress episode"
+                accessibilityState={{ disabled: cancelingActiveEpisode }}
+                onPress={onCancelEpisode}
+                disabled={cancelingActiveEpisode}
+                className={`mt-2 min-h-[52px] items-center justify-center rounded-xl border border-red-300 bg-red-50 px-4 py-3 dark:border-red-800/80 dark:bg-red-950/30`}
+              >
+                <Text
+                  className="text-center text-[17px] font-semibold text-red-800 dark:text-red-200"
+                  maxFontSizeMultiplier={2}
+                >
+                  {cancelingActiveEpisode
+                    ? 'Canceling episode…'
+                    : 'Cancel episode'}
+                </Text>
+              </Pressable>
             </View>
           ) : null}
         </View>

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
@@ -4,6 +4,7 @@ import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import { CommonActions, DefaultTheme } from '@react-navigation/native';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import {
+  cancelActiveEpisodeById,
   deleteEpisodeSymptomAnswer,
   listEpisodeSymptomsForEpisode,
   listPresetSymptomsForPreset,
@@ -29,6 +30,7 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 jest.mock('@abstrack/supabase', () => ({
+  cancelActiveEpisodeById: jest.fn(),
   deleteEpisodeSymptomAnswer: jest.fn(),
   listPresetSymptomsForPreset: jest.fn(),
   listEpisodeSymptomsForEpisode: jest.fn(),
@@ -155,6 +157,10 @@ describe('SymptomPromptScreen', () => {
     jest.mocked(deleteEpisodeSymptomAnswer).mockResolvedValue({
       ok: true,
       data: true,
+    });
+    jest.mocked(cancelActiveEpisodeById).mockResolvedValue({
+      ok: true,
+      data: { didCancel: true },
     });
   });
 
@@ -613,6 +619,51 @@ describe('SymptomPromptScreen', () => {
       expect.any(Array),
     );
     expect(mockGoBack).not.toHaveBeenCalled();
+    alertSpy.mockRestore();
+  });
+
+  test('Cancel episode asks for confirmation and cancels episode', async () => {
+    const screen = render(<SymptomPromptScreen />);
+    const alertSpy = jest
+      .spyOn(Alert, 'alert')
+      .mockImplementation(() => undefined);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Cancel episode')).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByLabelText('Cancel episode'));
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Cancel this active episode?',
+      'Canceling will permanently remove this in-progress episode and any linked symptom or media entries. This cannot be undone.',
+      expect.any(Array),
+    );
+
+    const [, , actions] = alertSpy.mock.calls[0] as [
+      string,
+      string,
+      Array<{ onPress?: () => void }>,
+    ];
+    await act(async () => {
+      actions[1]?.onPress?.();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(cancelActiveEpisodeById).toHaveBeenCalledWith(
+        expect.objectContaining({ mockClient: true }),
+        episodeId,
+      );
+    });
+    expect(clearSymptomPromptSession).toHaveBeenCalledWith(episodeId);
+    expect(mockDispatch).toHaveBeenCalledWith(
+      CommonActions.reset({
+        index: 0,
+        routes: [{ name: 'MainTabs' }],
+      }),
+    );
+
     alertSpy.mockRestore();
   });
 

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -25,6 +25,7 @@ import {
   symptomPromptAnswerHasValue,
 } from '@abstrack/types';
 import {
+  cancelActiveEpisodeById,
   deleteEpisodeSymptomAnswer,
   listEpisodeSymptomsForEpisode,
   listPresetSymptomsForPreset,
@@ -595,6 +596,55 @@ export function SymptomPromptScreen() {
     requestExitToHome();
   };
 
+  const onCancelEpisodePress = useCallback(() => {
+    Alert.alert(
+      'Cancel this active episode?',
+      'Canceling will permanently remove this in-progress episode and any linked symptom or media entries. This cannot be undone.',
+      [
+        { text: 'Keep episode', style: 'cancel' },
+        {
+          text: 'Cancel episode',
+          style: 'destructive',
+          onPress: () => {
+            void (async () => {
+              cancelPendingServerPersist();
+              const result = await cancelActiveEpisodeById(
+                getMobileSupabaseClient(),
+                episodeIdRef.current,
+              );
+              if (!result.ok) {
+                await announce(result.error.message, {
+                  politeness: 'assertive',
+                });
+                return;
+              }
+              clearSymptomPromptSession(episodeIdRef.current);
+              if (result.data.didCancel) {
+                await announce(
+                  'Episode canceled. Resume is no longer available.',
+                  {
+                    politeness: 'polite',
+                  },
+                );
+              } else {
+                await announce('This episode is no longer active.', {
+                  politeness: 'polite',
+                });
+              }
+              allowRemovalRef.current = true;
+              navigation.dispatch(
+                CommonActions.reset({
+                  index: 0,
+                  routes: [{ name: 'MainTabs' }],
+                }),
+              );
+            })();
+          },
+        },
+      ],
+    );
+  }, [cancelPendingServerPersist, navigation]);
+
   const advanceToNextStep = () => {
     if (lines.length === 0) {
       setPhase('complete');
@@ -823,6 +873,20 @@ export function SymptomPromptScreen() {
                 maxFontSizeMultiplier={2}
               >
                 Exit symptom flow
+              </Text>
+            </Pressable>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Cancel episode"
+              onPress={onCancelEpisodePress}
+              style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+              className="w-full items-center justify-center rounded-lg px-3 py-3 active:opacity-80"
+            >
+              <Text
+                className="text-sm font-medium text-red-700 dark:text-red-300"
+                maxFontSizeMultiplier={2}
+              >
+                Cancel episode
               </Text>
             </Pressable>
           </>

--- a/apps/web/src/app/(app)/episodes/page.tsx
+++ b/apps/web/src/app/(app)/episodes/page.tsx
@@ -5,13 +5,10 @@ import {
   getActiveEpisodeForUser,
   listCompletedEpisodesForUser,
 } from '@abstrack/supabase';
+import { ActiveEpisodeCard } from '@/components/episodes/ActiveEpisodeCard';
 import { EpisodeLocaleInstant } from '@/components/episodes/EpisodeLocaleInstant';
 import { formatEpisodeTypeSummary } from '@/lib/episodes/format-episode-meta';
-import { buildResumeEpisodeHref } from '@/lib/episode-flow/resume-episode-href';
 import { createServerClient } from '@/lib/supabase/server-client';
-
-const resumeLinkClass =
-  'inline-flex min-h-[48px] w-full items-center justify-center rounded-xl bg-emerald-700 px-4 py-3 text-center text-sm font-semibold text-white shadow-sm outline-none ring-2 ring-transparent transition hover:bg-emerald-800 focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-emerald-50 dark:bg-emerald-600 dark:hover:bg-emerald-500 dark:focus-visible:ring-offset-emerald-950';
 
 /**
  * Lists active and recently ended episodes with metadata; resume navigates into the symptom
@@ -104,53 +101,7 @@ export default async function EpisodesPage() {
           </p>
         ) : null}
         {user && !activeError && active !== null ? (
-          <div
-            className="mt-3 rounded-2xl border-2 border-emerald-600/45 bg-emerald-50 p-5 shadow-sm ring-1 ring-emerald-900/10 dark:border-emerald-500/45 dark:bg-emerald-950/40 dark:ring-emerald-950/35 sm:p-6"
-            aria-label="Active episode"
-          >
-            <p className="text-xs font-semibold uppercase tracking-wide text-emerald-800 dark:text-emerald-200">
-              In progress
-            </p>
-            <p className="mt-2 text-base font-semibold text-app-ink">
-              {formatEpisodeTypeSummary(active)}
-            </p>
-            <dl className="mt-3 space-y-1.5 text-sm text-app-muted">
-              <div className="flex flex-wrap gap-x-2">
-                <dt className="font-medium text-app-ink/80">Started</dt>
-                <dd>
-                  <EpisodeLocaleInstant iso={active.started_at} />
-                </dd>
-              </div>
-              <div className="flex flex-wrap gap-x-2">
-                <dt className="font-medium text-app-ink/80">Ended</dt>
-                <dd>—</dd>
-              </div>
-            </dl>
-            <div className="mt-5">
-              {active.symptom_preset_id ? (
-                <Link
-                  href={buildResumeEpisodeHref(
-                    active.id,
-                    active.symptom_preset_id,
-                  )}
-                  className={resumeLinkClass}
-                >
-                  Resume this episode
-                </Link>
-              ) : (
-                <p className="text-sm text-app-muted">
-                  This episode has no symptom preset linked yet.{' '}
-                  <Link
-                    href="/episode/start"
-                    className="font-semibold text-app-primary underline underline-offset-2"
-                  >
-                    Open episode start
-                  </Link>{' '}
-                  to continue setup.
-                </p>
-              )}
-            </div>
-          </div>
+          <ActiveEpisodeCard episode={active} />
         ) : null}
       </section>
 

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -965,9 +965,6 @@ export function SymptomPromptFlow({
         cancelLabel="Keep episode"
         onConfirm={handleCancelEpisodeConfirm}
         onClose={() => {
-          if (cancelingEpisode) {
-            return;
-          }
           setCancelDialogOpen(false);
         }}
       />

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -22,6 +22,7 @@ import {
   symptomPromptAnswerHasValue,
 } from '@abstrack/types';
 import {
+  cancelActiveEpisodeById,
   deleteEpisodeSymptomAnswer,
   listEpisodeSymptomsForEpisode,
   listPresetSymptomsForPreset,
@@ -148,6 +149,8 @@ export function SymptomPromptFlow({
   const isMountedRef = useRef(true);
 
   const [discardDialogOpen, setDiscardDialogOpen] = useState(false);
+  const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
+  const [cancelingEpisode, setCancelingEpisode] = useState(false);
   const pendingLeaveRef = useRef<PendingLeaveAction | null>(null);
   /**
    * When `episodeId` / `symptomPresetId` change, the layout reset syncs this to `resumeFromEntry` so a
@@ -682,6 +685,52 @@ export function SymptomPromptFlow({
     setDiscardDialogOpen(true);
   }, []);
 
+  const confirmCancelEpisode = useCallback(() => {
+    setCancelDialogOpen(true);
+  }, []);
+
+  const handleCancelEpisodeConfirm = useCallback(async (): Promise<
+    void | false
+  > => {
+    if (cancelingEpisode) {
+      return false;
+    }
+    setCancelingEpisode(true);
+    try {
+      if (textPersistTimerRef.current !== null) {
+        clearTimeout(textPersistTimerRef.current);
+        textPersistTimerRef.current = null;
+      }
+      cancelPendingServerPersist();
+      const result = await cancelActiveEpisodeById(
+        supabase,
+        episodeIdRef.current,
+      );
+      if (!result.ok) {
+        announce(result.error.message, { politeness: 'assertive' });
+        return false;
+      }
+      clearSymptomPromptSession(episodeIdRef.current);
+      if (result.data.didCancel) {
+        announce('Episode canceled. Resume is no longer available.', {
+          politeness: 'polite',
+        });
+      } else {
+        announce('This episode is no longer active.', { politeness: 'polite' });
+      }
+      router.push('/dashboard');
+      return;
+    } finally {
+      setCancelingEpisode(false);
+    }
+  }, [
+    announce,
+    cancelPendingServerPersist,
+    cancelingEpisode,
+    router,
+    supabase,
+  ]);
+
   const goNext = () => {
     flushPendingTextPersist();
     flushPendingServerPersist();
@@ -884,6 +933,13 @@ export function SymptomPromptFlow({
         >
           Exit symptom flow
         </button>
+        <button
+          type="button"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-3 py-2 text-sm font-medium text-red-700 transition hover:text-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:text-red-300 dark:hover:text-red-200"
+          onClick={confirmCancelEpisode}
+        >
+          Cancel episode
+        </button>
       </div>
 
       <ConfirmDialog
@@ -898,6 +954,21 @@ export function SymptomPromptFlow({
         onClose={() => {
           pendingLeaveRef.current = null;
           setDiscardDialogOpen(false);
+        }}
+      />
+      <ConfirmDialog
+        open={cancelDialogOpen}
+        title="Cancel this active episode?"
+        description="Canceling will permanently remove this in-progress episode and any linked symptom or media entries. This cannot be undone."
+        confirmLabel="Cancel episode"
+        confirmBusyLabel="Canceling episode…"
+        cancelLabel="Keep episode"
+        onConfirm={handleCancelEpisodeConfirm}
+        onClose={() => {
+          if (cancelingEpisode) {
+            return;
+          }
+          setCancelDialogOpen(false);
         }}
       />
     </>

--- a/apps/web/src/components/episodes/ActiveEpisodeCard.tsx
+++ b/apps/web/src/components/episodes/ActiveEpisodeCard.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { cancelActiveEpisodeById } from '@abstrack/supabase';
+import type { EpisodeRow } from '@abstrack/types';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import { buildResumeEpisodeHref } from '@/lib/episode-flow/resume-episode-href';
+import { clearSymptomPromptSession } from '@/lib/episode-flow/symptom-prompt-session-store';
+import { createBrowserClient } from '@/lib/supabase/browser-client';
+import { formatEpisodeTypeSummary } from '@/lib/episodes/format-episode-meta';
+import { ConfirmDialog } from '../symptom-presets/ConfirmDialog';
+import { EpisodeLocaleInstant } from './EpisodeLocaleInstant';
+
+const resumeLinkClass =
+  'inline-flex min-h-[48px] w-full items-center justify-center rounded-xl bg-emerald-700 px-4 py-3 text-center text-sm font-semibold text-white shadow-sm outline-none ring-2 ring-transparent transition hover:bg-emerald-800 focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-emerald-50 dark:bg-emerald-600 dark:hover:bg-emerald-500 dark:focus-visible:ring-offset-emerald-950';
+
+/**
+ * Active-episode management card with resume and destructive cancel action.
+ *
+ * @param props - Active episode row.
+ * @returns Interactive card for an in-progress episode.
+ */
+export function ActiveEpisodeCard({ episode }: { episode: EpisodeRow }) {
+  const router = useRouter();
+  const { announce } = useAnnounce();
+  const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
+
+  const handleConfirmCancel = async (): Promise<void | false> => {
+    if (cancelling) {
+      return false;
+    }
+    setCancelling(true);
+    try {
+      const supabase = createBrowserClient();
+      const result = await cancelActiveEpisodeById(supabase, episode.id);
+      if (!result.ok) {
+        announce(result.error.message, { politeness: 'assertive' });
+        return false;
+      }
+      clearSymptomPromptSession(episode.id);
+      if (result.data.didCancel) {
+        announce('Episode canceled. Resume is no longer available.', {
+          politeness: 'polite',
+        });
+      } else {
+        announce('This episode is no longer active.', { politeness: 'polite' });
+      }
+      router.refresh();
+      return;
+    } finally {
+      setCancelling(false);
+    }
+  };
+
+  return (
+    <>
+      <div
+        className="mt-3 rounded-2xl border-2 border-emerald-600/45 bg-emerald-50 p-5 shadow-sm ring-1 ring-emerald-900/10 dark:border-emerald-500/45 dark:bg-emerald-950/40 dark:ring-emerald-950/35 sm:p-6"
+        aria-label="Active episode"
+      >
+        <p className="text-xs font-semibold uppercase tracking-wide text-emerald-800 dark:text-emerald-200">
+          In progress
+        </p>
+        <p className="mt-2 text-base font-semibold text-app-ink">
+          {formatEpisodeTypeSummary(episode)}
+        </p>
+        <dl className="mt-3 space-y-1.5 text-sm text-app-muted">
+          <div className="flex flex-wrap gap-x-2">
+            <dt className="font-medium text-app-ink/80">Started</dt>
+            <dd>
+              <EpisodeLocaleInstant iso={episode.started_at} />
+            </dd>
+          </div>
+          <div className="flex flex-wrap gap-x-2">
+            <dt className="font-medium text-app-ink/80">Ended</dt>
+            <dd>—</dd>
+          </div>
+        </dl>
+        <div className="mt-5 space-y-3">
+          {episode.symptom_preset_id ? (
+            <Link
+              href={buildResumeEpisodeHref(
+                episode.id,
+                episode.symptom_preset_id,
+              )}
+              className={resumeLinkClass}
+            >
+              Resume this episode
+            </Link>
+          ) : (
+            <p className="text-sm text-app-muted">
+              This episode has no symptom preset linked yet.{' '}
+              <Link
+                href="/episode/start"
+                className="font-semibold text-app-primary underline underline-offset-2"
+              >
+                Open episode start
+              </Link>{' '}
+              to continue setup.
+            </p>
+          )}
+          <button
+            type="button"
+            className="inline-flex min-h-[44px] w-full items-center justify-center rounded-xl border border-red-300 bg-red-50 px-4 py-3 text-sm font-semibold text-red-800 shadow-sm transition hover:bg-red-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-red-50 dark:border-red-800/80 dark:bg-red-950/30 dark:text-red-200 dark:hover:bg-red-950/45"
+            onClick={() => {
+              setShowCancelDialog(true);
+            }}
+            disabled={cancelling}
+          >
+            Cancel episode
+          </button>
+        </div>
+      </div>
+      <ConfirmDialog
+        open={showCancelDialog}
+        title="Cancel this active episode?"
+        description="Canceling will permanently remove this in-progress episode and any linked symptom or media entries. This cannot be undone."
+        confirmLabel="Cancel episode"
+        cancelLabel="Keep episode"
+        confirmBusyLabel="Canceling episode…"
+        onConfirm={handleConfirmCancel}
+        onClose={() => {
+          if (cancelling) {
+            return;
+          }
+          setShowCancelDialog(false);
+        }}
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/episodes/ActiveEpisodeCard.tsx
+++ b/apps/web/src/components/episodes/ActiveEpisodeCard.tsx
@@ -26,13 +26,13 @@ export function ActiveEpisodeCard({ episode }: { episode: EpisodeRow }) {
   const router = useRouter();
   const { announce } = useAnnounce();
   const [showCancelDialog, setShowCancelDialog] = useState(false);
-  const [cancelling, setCancelling] = useState(false);
+  const [canceling, setCanceling] = useState(false);
 
   const handleConfirmCancel = async (): Promise<void | false> => {
-    if (cancelling) {
+    if (canceling) {
       return false;
     }
-    setCancelling(true);
+    setCanceling(true);
     try {
       const supabase = createBrowserClient();
       const result = await cancelActiveEpisodeById(supabase, episode.id);
@@ -51,7 +51,7 @@ export function ActiveEpisodeCard({ episode }: { episode: EpisodeRow }) {
       router.refresh();
       return;
     } finally {
-      setCancelling(false);
+      setCanceling(false);
     }
   };
 
@@ -108,7 +108,7 @@ export function ActiveEpisodeCard({ episode }: { episode: EpisodeRow }) {
             onClick={() => {
               setShowCancelDialog(true);
             }}
-            disabled={cancelling}
+            disabled={canceling}
           >
             Cancel episode
           </button>

--- a/apps/web/src/components/episodes/ActiveEpisodeCard.tsx
+++ b/apps/web/src/components/episodes/ActiveEpisodeCard.tsx
@@ -123,9 +123,6 @@ export function ActiveEpisodeCard({ episode }: { episode: EpisodeRow }) {
         confirmBusyLabel="Canceling episode…"
         onConfirm={handleConfirmCancel}
         onClose={() => {
-          if (cancelling) {
-            return;
-          }
           setShowCancelDialog(false);
         }}
       />

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -76,6 +76,7 @@ export {
   updateEpisodeTemplate,
 } from './lib/episode-template-data.js';
 export {
+  cancelActiveEpisodeById,
   createEpisode,
   endEpisodeIfStillActive,
   getActiveEpisodeForUser,

--- a/packages/supabase/src/lib/episode-data.spec.ts
+++ b/packages/supabase/src/lib/episode-data.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { EpisodeInsert, EpisodeRow } from '@abstrack/types';
 import {
+  cancelActiveEpisodeById,
   createEpisode,
   endEpisodeIfStillActive,
   getActiveEpisodeForUser,
@@ -279,6 +280,60 @@ describe('endEpisodeIfStillActive', () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.data.didEnd).toBe(false);
+    }
+  });
+});
+
+describe('cancelActiveEpisodeById', () => {
+  it('deletes the row when it is still active', async () => {
+    const maybeSingle = vi.fn(async () => ({
+      data: { id: 'ep-1' },
+      error: null,
+    }));
+    const client = {
+      from: vi.fn(() => ({
+        delete: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            is: vi.fn(() => ({
+              select: vi.fn(() => ({
+                maybeSingle,
+              })),
+            })),
+          })),
+        })),
+      })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await cancelActiveEpisodeById(client, 'ep-1');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.didCancel).toBe(true);
+    }
+    expect(client.from).toHaveBeenCalledWith('episodes');
+  });
+
+  it('returns didCancel false when the row was already ended (no row returned)', async () => {
+    const maybeSingle = vi.fn(async () => ({ data: null, error: null }));
+    const client = {
+      from: vi.fn(() => ({
+        delete: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            is: vi.fn(() => ({
+              select: vi.fn(() => ({
+                maybeSingle,
+              })),
+            })),
+          })),
+        })),
+      })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await cancelActiveEpisodeById(client, 'ep-1');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.didCancel).toBe(false);
     }
   });
 });

--- a/packages/supabase/src/lib/episode-data.ts
+++ b/packages/supabase/src/lib/episode-data.ts
@@ -146,3 +146,34 @@ export async function endEpisodeIfStillActive(
     return { ok: false, error: toPresetDataError(caught) };
   }
 }
+
+/**
+ * Permanently removes an episode only when it is still active (`ended_at IS NULL`). Uses the same
+ * RLS as other `episodes` deletes. Cascading foreign keys remove linked episode-scoped rows.
+ *
+ * @param client - Supabase client (RLS applies).
+ * @param episodeId - `episodes.id` to cancel.
+ * @returns On success, `didCancel` is `true` when one active row was deleted. `didCancel` is
+ * `false` when no active row matched: e.g. the episode was already ended, does not exist, or RLS
+ * prevented visibility.
+ */
+export async function cancelActiveEpisodeById(
+  client: AbstrackSupabaseClient,
+  episodeId: Uuid,
+): Promise<PresetDataResult<{ didCancel: boolean }>> {
+  try {
+    const { data, error } = await client
+      .from('episodes')
+      .delete()
+      .eq('id', episodeId)
+      .is('ended_at', null)
+      .select('id')
+      .maybeSingle();
+    if (error) {
+      return { ok: false, error: toPresetDataError(error) };
+    }
+    return { ok: true, data: { didCancel: data != null } };
+  } catch (caught) {
+    return { ok: false, error: toPresetDataError(caught) };
+  }
+}

--- a/packages/supabase/src/lib/episode-data.ts
+++ b/packages/supabase/src/lib/episode-data.ts
@@ -149,7 +149,8 @@ export async function endEpisodeIfStillActive(
 
 /**
  * Permanently removes an episode only when it is still active (`ended_at IS NULL`). Uses the same
- * RLS as other `episodes` deletes. Cascading foreign keys remove linked episode-scoped rows.
+ * RLS as other `episodes` deletes. Related rows follow schema foreign-key behavior: some
+ * episode-scoped tables cascade-delete, while others are unlinked via `SET NULL`.
  *
  * @param client - Supabase client (RLS applies).
  * @param episodeId - `episodes.id` to cancel.


### PR DESCRIPTION
Closes #104

## Summary
- add active-episode cancellation support in the shared Supabase data layer via a safe, active-only delete helper (`cancelActiveEpisodeById`) and export it for app use
- implement destructive **Cancel episode** actions on web and mobile episode management surfaces, including clear irreversible-consequence confirmation copy
- add a low-prominence **Cancel episode** action to symptom flow screens (web + mobile) with confirmation, and clear local symptom prompt session state after cancel so resume no longer appears
- update tests for the new cancel behavior (shared data helper + mobile screen flows)

## Why
Users can accidentally start an episode and currently only have resume/end paths. This adds an explicit, safe cancel path for **active episodes only**, with unambiguous destructive confirmation and cleanup of linked prompt session state to prevent stale resume UX.

## Scope
- in scope:
  - active episode cancel action
  - destructive confirmation UX/copy
  - RLS-safe active-only cancel write path
  - linked prompt/session cleanup after cancel
  - consistency across web and mobile
- out of scope:
  - deleting completed episodes
  - bulk actions

## User-facing behavior
- users can cancel an active episode from:
  - episodes management screen (web + mobile)
  - symptom flow screen (web + mobile), as a secondary low-prominence action
- confirmation clearly states cancellation is permanent and removes linked in-progress data
- after cancel, returning home/management no longer shows resume state for that episode

## Technical changes
- `packages/supabase/src/lib/episode-data.ts`
  - add `cancelActiveEpisodeById(client, episodeId)`:
    - deletes from `episodes` where `id = episodeId` and `ended_at IS NULL`
    - returns `{ didCancel: boolean }`
- `packages/supabase/src/index.ts`
  - export `cancelActiveEpisodeById`
- web:
  - `apps/web/src/components/episodes/ActiveEpisodeCard.tsx` (new)
    - adds cancel action + destructive confirm dialog
    - clears symptom prompt session and refreshes state after cancel
  - `apps/web/src/app/(app)/episodes/page.tsx`
    - use `ActiveEpisodeCard` for active episode management UI
  - `apps/web/src/components/episode-flow/SymptomPromptFlow.tsx`
    - add low-prominence cancel action and destructive confirm dialog
- mobile:
  - `apps/mobile/src/app/screens/EpisodesScreen.tsx`
    - add cancel action + destructive confirmation for active episode
  - `apps/mobile/src/app/screens/SymptomPromptScreen.tsx`
    - add low-prominence cancel action + destructive confirmation
- tests:
  - `packages/supabase/src/lib/episode-data.spec.ts`
    - add unit coverage for cancel helper success/no-op paths
  - `apps/mobile/src/app/screens/EpisodesScreen.spec.tsx`
    - add cancel flow coverage
  - `apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx`
    - add cancel confirmation and cancel execution coverage

## Test plan
- automated:
  - [x] `pnpm supabase:test`
  - [x] `pnpm mobile:test`
  - [x] `pnpm web:test`
- manual:
  - [ ] web: start an episode, cancel from episodes page, verify active card/resume disappears
  - [ ] web: start/resume symptom flow, cancel from flow page, verify redirect and no resume CTA
  - [ ] mobile: start an episode, cancel from episodes screen, verify active/resume state clears
  - [ ] mobile: cancel from symptom prompt screen, verify return home and no resume state

## Risk / rollback
- risk is low-to-moderate and localized to active-episode lifecycle actions and symptom-flow UX
- rollback path: revert helper + UI integration commits; existing end/resume flows remain unaffected