### PR TITLE
feat(episodes): allow deleting completed episodes with explicit data-impact confirmations

### DIFF
--- a/apps/mobile/src/app/screens/EpisodesScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/EpisodesScreen.spec.tsx
@@ -9,6 +9,7 @@ import {
 import { useNavigation } from '@react-navigation/native';
 import {
   cancelActiveEpisodeById,
+  deleteEpisodeById,
   getActiveEpisodeForUser,
   listCompletedEpisodesForUser,
 } from '@abstrack/supabase';
@@ -36,6 +37,7 @@ jest.mock('@react-navigation/native', () => {
 
 jest.mock('@abstrack/supabase', () => ({
   cancelActiveEpisodeById: jest.fn(),
+  deleteEpisodeById: jest.fn(),
   getActiveEpisodeForUser: jest.fn(),
   listCompletedEpisodesForUser: jest.fn(),
 }));
@@ -98,6 +100,10 @@ describe('EpisodesScreen', () => {
     jest.mocked(cancelActiveEpisodeById).mockResolvedValue({
       ok: true,
       data: { didCancel: true },
+    });
+    jest.mocked(deleteEpisodeById).mockResolvedValue({
+      ok: true,
+      data: { didDelete: true },
     });
   });
 
@@ -201,6 +207,55 @@ describe('EpisodesScreen', () => {
     expect(screen.getByText('Ended')).toBeTruthy();
   });
 
+  it('confirms and deletes a completed episode from history', async () => {
+    const alertSpy = jest
+      .spyOn(require('react-native').Alert, 'alert')
+      .mockImplementation(() => undefined);
+    try {
+      const ended = makeEpisodeRow({
+        id: 'ep-ended-delete',
+        ended_at: '2026-04-21T12:00:00.000Z',
+        episode_label: 'History row',
+      });
+      jest.mocked(listCompletedEpisodesForUser).mockResolvedValue({
+        ok: true,
+        data: [ended],
+      });
+
+      render(<EpisodesScreen />);
+
+      expect(await screen.findByText('ABS — History row')).toBeTruthy();
+      fireEvent.press(screen.getByText('Delete episode'));
+
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Delete this episode from history?',
+        'Deleting permanently removes this episode, its symptom answers, health markers, and media metadata. Food diary entries are kept, but this episode link is removed. This cannot be undone.',
+        expect.any(Array),
+      );
+
+      const [, , buttons] = alertSpy.mock.calls[0] as [
+        string,
+        string,
+        Array<{ onPress?: () => void }>,
+      ];
+      await act(async () => {
+        buttons[1]?.onPress?.();
+      });
+
+      await waitFor(() => {
+        expect(deleteEpisodeById).toHaveBeenCalledWith(
+          expect.anything(),
+          'ep-ended-delete',
+        );
+      });
+      expect(announce).toHaveBeenCalledWith('Episode deleted from history.', {
+        politeness: 'polite',
+      });
+    } finally {
+      alertSpy.mockRestore();
+    }
+  });
+
   it('confirms and cancels active episode', async () => {
     const alertSpy = jest
       .spyOn(require('react-native').Alert, 'alert')
@@ -222,7 +277,7 @@ describe('EpisodesScreen', () => {
 
       expect(alertSpy).toHaveBeenCalledWith(
         'Cancel this active episode?',
-        'Canceling will permanently remove this in-progress episode and any linked symptom or media entries. This cannot be undone.',
+        'Canceling permanently deletes this in-progress episode, its symptom answers, health markers, and media metadata. Food diary entries are kept, but this episode link is removed. This cannot be undone.',
         expect.any(Array),
       );
 

--- a/apps/mobile/src/app/screens/EpisodesScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodesScreen.tsx
@@ -6,6 +6,7 @@ import type { EpisodeRow } from '@abstrack/types';
 import { announce } from '@abstrack/ui/native';
 import {
   cancelActiveEpisodeById,
+  deleteEpisodeById,
   getActiveEpisodeForUser,
   listCompletedEpisodesForUser,
 } from '@abstrack/supabase';
@@ -52,6 +53,9 @@ export function EpisodesScreen() {
   const [active, setActive] = useState<EpisodeRow | null>(null);
   const [recent, setRecent] = useState<EpisodeRow[]>([]);
   const [cancelingActiveEpisode, setCancelingActiveEpisode] = useState(false);
+  const [deletingEpisodeId, setDeletingEpisodeId] = useState<string | null>(
+    null,
+  );
 
   const load = useCallback(async (cancel?: { cancelled: boolean }) => {
     const generation = ++loadGenRef.current;
@@ -138,7 +142,7 @@ export function EpisodesScreen() {
     }
     Alert.alert(
       'Cancel this active episode?',
-      'Canceling will permanently remove this in-progress episode and any linked symptom or media entries. This cannot be undone.',
+      'Canceling permanently deletes this in-progress episode, its symptom answers, health markers, and media metadata. Food diary entries are kept, but this episode link is removed. This cannot be undone.',
       [
         { text: 'Keep episode', style: 'cancel' },
         {
@@ -179,6 +183,53 @@ export function EpisodesScreen() {
       ],
     );
   }, [active, cancelingActiveEpisode, load]);
+
+  const onDeleteEpisode = useCallback(
+    (episode: EpisodeRow) => {
+      if (deletingEpisodeId) {
+        return;
+      }
+      Alert.alert(
+        'Delete this episode from history?',
+        'Deleting permanently removes this episode, its symptom answers, health markers, and media metadata. Food diary entries are kept, but this episode link is removed. This cannot be undone.',
+        [
+          { text: 'Keep episode', style: 'cancel' },
+          {
+            text: 'Delete episode',
+            style: 'destructive',
+            onPress: () => {
+              void (async () => {
+                setDeletingEpisodeId(episode.id);
+                try {
+                  const client = getMobileSupabaseClient();
+                  const result = await deleteEpisodeById(client, episode.id);
+                  if (!result.ok) {
+                    await announce(result.error.message, {
+                      politeness: 'assertive',
+                    });
+                    return;
+                  }
+                  if (result.data.didDelete) {
+                    await announce('Episode deleted from history.', {
+                      politeness: 'polite',
+                    });
+                  } else {
+                    await announce('This episode is no longer available.', {
+                      politeness: 'polite',
+                    });
+                  }
+                  await load();
+                } finally {
+                  setDeletingEpisodeId(null);
+                }
+              })();
+            },
+          },
+        ],
+      );
+    },
+    [deletingEpisodeId, load],
+  );
 
   const resumeSummary: ActiveEpisodeHomeSummary | null =
     active && active.symptom_preset_id
@@ -347,6 +398,23 @@ export function EpisodesScreen() {
                   <Text className={`text-sm ${nw.textMuted}`}>
                     Ended {ep.ended_at ? formatInstant(ep.ended_at) : '—'}
                   </Text>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel={`Delete ${episodeSummaryLine(ep)} episode`}
+                    accessibilityHint="Permanently removes this episode from history"
+                    accessibilityState={{
+                      disabled: deletingEpisodeId === ep.id,
+                    }}
+                    onPress={() => onDeleteEpisode(ep)}
+                    disabled={deletingEpisodeId === ep.id}
+                    className="mt-2 items-start justify-center rounded-lg px-1 py-2"
+                  >
+                    <Text className="text-sm font-medium text-red-700 dark:text-red-300">
+                      {deletingEpisodeId === ep.id
+                        ? 'Deleting episode…'
+                        : 'Delete episode'}
+                    </Text>
+                  </Pressable>
                 </View>
               ))}
             </View>

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
@@ -636,7 +636,7 @@ describe('SymptomPromptScreen', () => {
 
     expect(alertSpy).toHaveBeenCalledWith(
       'Cancel this active episode?',
-      'Canceling will permanently remove this in-progress episode and any linked symptom or media entries. This cannot be undone.',
+      'Canceling permanently deletes this in-progress episode, its symptom answers, health markers, and media metadata. Food diary entries are kept, but this episode link is removed. This cannot be undone.',
       expect.any(Array),
     );
 

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -599,7 +599,7 @@ export function SymptomPromptScreen() {
   const onCancelEpisodePress = useCallback(() => {
     Alert.alert(
       'Cancel this active episode?',
-      'Canceling will permanently remove this in-progress episode and any linked symptom or media entries. This cannot be undone.',
+      'Canceling permanently deletes this in-progress episode, its symptom answers, health markers, and media metadata. Food diary entries are kept, but this episode link is removed. This cannot be undone.',
       [
         { text: 'Keep episode', style: 'cancel' },
         {

--- a/apps/web/src/app/(app)/episodes/page.tsx
+++ b/apps/web/src/app/(app)/episodes/page.tsx
@@ -6,8 +6,7 @@ import {
   listCompletedEpisodesForUser,
 } from '@abstrack/supabase';
 import { ActiveEpisodeCard } from '@/components/episodes/ActiveEpisodeCard';
-import { EpisodeLocaleInstant } from '@/components/episodes/EpisodeLocaleInstant';
-import { formatEpisodeTypeSummary } from '@/lib/episodes/format-episode-meta';
+import { RecentEpisodesList } from '@/components/episodes/RecentEpisodesList';
 import { createServerClient } from '@/lib/supabase/server-client';
 
 /**
@@ -127,38 +126,7 @@ export default async function EpisodesPage() {
           </p>
         ) : null}
         {user && !recentError && recent.length > 0 ? (
-          <ul className="mt-3 space-y-3" role="list">
-            {recent.map((ep) => (
-              <li key={ep.id}>
-                <div className="rounded-xl border border-app-border/90 bg-app-surface p-4 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]">
-                  <p className="text-xs font-semibold uppercase tracking-wide text-app-muted">
-                    Ended
-                  </p>
-                  <p className="mt-1.5 text-base font-semibold text-app-ink">
-                    {formatEpisodeTypeSummary(ep)}
-                  </p>
-                  <dl className="mt-2 space-y-1 text-sm text-app-muted">
-                    <div className="flex flex-wrap gap-x-2">
-                      <dt className="font-medium text-app-ink/80">Started</dt>
-                      <dd>
-                        <EpisodeLocaleInstant iso={ep.started_at} />
-                      </dd>
-                    </div>
-                    <div className="flex flex-wrap gap-x-2">
-                      <dt className="font-medium text-app-ink/80">Ended</dt>
-                      <dd>
-                        {ep.ended_at ? (
-                          <EpisodeLocaleInstant iso={ep.ended_at} />
-                        ) : (
-                          '—'
-                        )}
-                      </dd>
-                    </div>
-                  </dl>
-                </div>
-              </li>
-            ))}
-          </ul>
+          <RecentEpisodesList episodes={recent} />
         ) : null}
       </section>
     </div>

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -959,7 +959,7 @@ export function SymptomPromptFlow({
       <ConfirmDialog
         open={cancelDialogOpen}
         title="Cancel this active episode?"
-        description="Canceling will permanently remove this in-progress episode and any linked symptom or media entries. This cannot be undone."
+        description="Canceling permanently deletes this in-progress episode, its symptom answers, health markers, and media metadata. Food diary entries are kept, but this episode link is removed. This cannot be undone."
         confirmLabel="Cancel episode"
         confirmBusyLabel="Canceling episode…"
         cancelLabel="Keep episode"

--- a/apps/web/src/components/episodes/ActiveEpisodeCard.tsx
+++ b/apps/web/src/components/episodes/ActiveEpisodeCard.tsx
@@ -117,7 +117,7 @@ export function ActiveEpisodeCard({ episode }: { episode: EpisodeRow }) {
       <ConfirmDialog
         open={showCancelDialog}
         title="Cancel this active episode?"
-        description="Canceling will permanently remove this in-progress episode and any linked symptom or media entries. This cannot be undone."
+        description="Canceling permanently deletes this in-progress episode, its symptom answers, health markers, and media metadata. Food diary entries are kept, but this episode link is removed. This cannot be undone."
         confirmLabel="Cancel episode"
         cancelLabel="Keep episode"
         confirmBusyLabel="Canceling episode…"

--- a/apps/web/src/components/episodes/RecentEpisodesList.tsx
+++ b/apps/web/src/components/episodes/RecentEpisodesList.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { deleteEpisodeById } from '@abstrack/supabase';
+import type { EpisodeRow } from '@abstrack/types';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import { createBrowserClient } from '@/lib/supabase/browser-client';
+import { formatEpisodeTypeSummary } from '@/lib/episodes/format-episode-meta';
+import { ConfirmDialog } from '../symptom-presets/ConfirmDialog';
+import { EpisodeLocaleInstant } from './EpisodeLocaleInstant';
+
+type RecentEpisodesListProps = {
+  episodes: EpisodeRow[];
+};
+
+/**
+ * Client-side list for ended episodes with explicit destructive delete confirmation.
+ *
+ * @param props - Ended episode rows shown on the Episodes page.
+ * @returns Interactive list with per-episode delete action.
+ */
+export function RecentEpisodesList({ episodes }: RecentEpisodesListProps) {
+  const router = useRouter();
+  const { announce } = useAnnounce();
+  const [pendingDeleteEpisodeId, setPendingDeleteEpisodeId] = useState<
+    string | null
+  >(null);
+  const [deletingEpisodeId, setDeletingEpisodeId] = useState<string | null>(
+    null,
+  );
+
+  const pendingEpisode =
+    episodes.find((ep) => ep.id === pendingDeleteEpisodeId) ?? null;
+
+  const handleConfirmDelete = async (): Promise<void | false> => {
+    if (!pendingEpisode || deletingEpisodeId) {
+      return false;
+    }
+    setDeletingEpisodeId(pendingEpisode.id);
+    try {
+      const supabase = createBrowserClient();
+      const result = await deleteEpisodeById(supabase, pendingEpisode.id);
+      if (!result.ok) {
+        announce(result.error.message, { politeness: 'assertive' });
+        return false;
+      }
+      if (result.data.didDelete) {
+        announce('Episode deleted from history.', { politeness: 'polite' });
+      } else {
+        announce('This episode is no longer available.', {
+          politeness: 'polite',
+        });
+      }
+      router.refresh();
+      return;
+    } finally {
+      setDeletingEpisodeId(null);
+    }
+  };
+
+  return (
+    <>
+      <ul className="mt-3 space-y-3" role="list">
+        {episodes.map((ep) => (
+          <li key={ep.id}>
+            <div className="rounded-xl border border-app-border/90 bg-app-surface p-4 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]">
+              <p className="text-xs font-semibold uppercase tracking-wide text-app-muted">
+                Ended
+              </p>
+              <p className="mt-1.5 text-base font-semibold text-app-ink">
+                {formatEpisodeTypeSummary(ep)}
+              </p>
+              <dl className="mt-2 space-y-1 text-sm text-app-muted">
+                <div className="flex flex-wrap gap-x-2">
+                  <dt className="font-medium text-app-ink/80">Started</dt>
+                  <dd>
+                    <EpisodeLocaleInstant iso={ep.started_at} />
+                  </dd>
+                </div>
+                <div className="flex flex-wrap gap-x-2">
+                  <dt className="font-medium text-app-ink/80">Ended</dt>
+                  <dd>
+                    {ep.ended_at ? (
+                      <EpisodeLocaleInstant iso={ep.ended_at} />
+                    ) : (
+                      '—'
+                    )}
+                  </dd>
+                </div>
+              </dl>
+              <button
+                type="button"
+                className="mt-3 inline-flex min-h-[44px] items-center justify-center rounded-lg px-3 py-2 text-sm font-medium text-red-700 transition hover:text-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:text-red-300 dark:hover:text-red-200"
+                onClick={() => {
+                  setPendingDeleteEpisodeId(ep.id);
+                }}
+                disabled={deletingEpisodeId === ep.id}
+              >
+                Delete episode
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <ConfirmDialog
+        open={pendingEpisode !== null}
+        title="Delete this episode from history?"
+        description="Deleting permanently removes this episode, its symptom answers, health markers, and media metadata. Food diary entries are kept, but this episode link is removed. This cannot be undone."
+        confirmLabel="Delete episode"
+        confirmBusyLabel="Deleting episode…"
+        cancelLabel="Keep episode"
+        onConfirm={handleConfirmDelete}
+        onClose={() => {
+          setPendingDeleteEpisodeId(null);
+        }}
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/episodes/RecentEpisodesList.tsx
+++ b/apps/web/src/components/episodes/RecentEpisodesList.tsx
@@ -32,6 +32,7 @@ export function RecentEpisodesList({ episodes }: RecentEpisodesListProps) {
 
   const pendingEpisode =
     episodes.find((ep) => ep.id === pendingDeleteEpisodeId) ?? null;
+  const isDeletingEpisode = deletingEpisodeId !== null;
 
   const handleConfirmDelete = async (): Promise<void | false> => {
     if (!pendingEpisode || deletingEpisodeId) {
@@ -93,11 +94,16 @@ export function RecentEpisodesList({ episodes }: RecentEpisodesListProps) {
                 type="button"
                 className="mt-3 inline-flex min-h-[44px] items-center justify-center rounded-lg px-3 py-2 text-sm font-medium text-red-700 transition hover:text-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:text-red-300 dark:hover:text-red-200"
                 onClick={() => {
+                  if (isDeletingEpisode) {
+                    return;
+                  }
                   setPendingDeleteEpisodeId(ep.id);
                 }}
-                disabled={deletingEpisodeId === ep.id}
+                disabled={isDeletingEpisode}
               >
-                Delete episode
+                {deletingEpisodeId === ep.id
+                  ? 'Deleting episode…'
+                  : 'Delete episode'}
               </button>
             </div>
           </li>

--- a/docs/EPISODE_DELETION_POLICY.md
+++ b/docs/EPISODE_DELETION_POLICY.md
@@ -9,7 +9,7 @@ ABStrack supports deliberate episode removal while preserving clear data-impact 
 
 ## Data Impact When Deleting Any Episode
 
-Deleting an active episode applies these foreign-key rules:
+Deleting any episode applies these foreign-key rules:
 
 - `episode_symptoms`: deleted (`ON DELETE CASCADE`)
 - `health_markers`: deleted (`ON DELETE CASCADE`)

--- a/docs/EPISODE_DELETION_POLICY.md
+++ b/docs/EPISODE_DELETION_POLICY.md
@@ -1,0 +1,23 @@
+# Episode Deletion Policy
+
+ABStrack supports deliberate episode removal while preserving clear data-impact messaging.
+
+## Policy
+
+- Patients (and linked caretakers under RLS) can permanently remove **active or completed** episodes.
+- There is currently no automated retention window; episodes persist until a user deletes them.
+
+## Data Impact When Deleting Any Episode
+
+Deleting an active episode applies these foreign-key rules:
+
+- `episode_symptoms`: deleted (`ON DELETE CASCADE`)
+- `health_markers`: deleted (`ON DELETE CASCADE`)
+- `episode_media` metadata rows: deleted (`ON DELETE CASCADE`)
+- `food_diary_entries`: kept, but `episode_id` is set to `NULL` (`ON DELETE SET NULL`)
+
+This behavior prevents orphaned rows while preserving standalone food entries.
+
+## RLS and Authorization
+
+Deletion uses standard `episodes` delete RLS (`user_id = auth.uid()` or linked caretaker access). Practitioners do not have delete access.

--- a/packages/supabase/src/episode-foundation.integration.spec.ts
+++ b/packages/supabase/src/episode-foundation.integration.spec.ts
@@ -11,7 +11,12 @@ import type { Database } from './lib/database.types.js';
 import { getSupabasePublishableKey, getSupabaseUrl } from './lib/env-public.js';
 import type { AbstrackSupabaseClient } from './lib/supabase-client-type.js';
 import { getSupabaseAdminClient } from './admin.js';
-import { createEpisode, getEpisodeById } from './lib/episode-data.js';
+import {
+  cancelActiveEpisodeById,
+  createEpisode,
+  deleteEpisodeById,
+  getEpisodeById,
+} from './lib/episode-data.js';
 import {
   listEpisodeSymptomsForEpisode,
   upsertEpisodeSymptomAnswer,
@@ -264,6 +269,131 @@ describe.skipIf(!episodeFoundationReady)(
         expect(error).toBeNull();
         expect(data?.response_text).toBe('mild cramping');
       });
+
+      it('cascades or unlinks related rows when canceling an active episode', async () => {
+        const symptomInsert = await clientA
+          .from('episode_symptoms')
+          .insert({
+            user_id: userAId,
+            episode_id: episodeId,
+            symptom_name: 'Nausea',
+            response_type: 'yes_no',
+            response_boolean: true,
+            sort_order: 1,
+          })
+          .select('id')
+          .single();
+        expect(symptomInsert.error).toBeNull();
+        const insertedSymptomId = symptomInsert.data?.id;
+        expect(insertedSymptomId).toBeTruthy();
+
+        const markerInsert = await clientA
+          .from('health_markers')
+          .insert({
+            user_id: userAId,
+            episode_id: episodeId,
+            marker_kind: 'heart_rate',
+            value_numeric: 88,
+            recorded_at: new Date().toISOString(),
+          })
+          .select('id')
+          .single();
+        expect(markerInsert.error).toBeNull();
+
+        const foodInsert = await clientA
+          .from('food_diary_entries')
+          .insert({
+            user_id: userAId,
+            episode_id: episodeId,
+            meal_tag: 'Snack',
+            food_note: 'Banana and water',
+            logged_at: new Date().toISOString(),
+          })
+          .select('id')
+          .single();
+        expect(foodInsert.error).toBeNull();
+        const foodEntryId = foodInsert.data?.id;
+        expect(foodEntryId).toBeTruthy();
+
+        const mediaInsert = await clientA
+          .from('episode_media')
+          .insert({
+            user_id: userAId,
+            episode_id: episodeId,
+            episode_symptom_id: insertedSymptomId ?? null,
+            storage_object_key: `episode-media/${episodeId}/clip.mp4`,
+            media_type: 'video',
+          })
+          .select('id')
+          .single();
+        expect(mediaInsert.error).toBeNull();
+
+        const canceled = await cancelActiveEpisodeById(clientA, episodeId);
+        expect(canceled.ok).toBe(true);
+        if (!canceled.ok) {
+          return;
+        }
+        expect(canceled.data.didCancel).toBe(true);
+
+        const symptomsAfter = await clientA
+          .from('episode_symptoms')
+          .select('id')
+          .eq('episode_id', episodeId);
+        expect(symptomsAfter.error).toBeNull();
+        expect(symptomsAfter.data ?? []).toHaveLength(0);
+
+        const markersAfter = await clientA
+          .from('health_markers')
+          .select('id')
+          .eq('episode_id', episodeId);
+        expect(markersAfter.error).toBeNull();
+        expect(markersAfter.data ?? []).toHaveLength(0);
+
+        const mediaAfter = await clientA
+          .from('episode_media')
+          .select('id')
+          .eq('episode_id', episodeId);
+        expect(mediaAfter.error).toBeNull();
+        expect(mediaAfter.data ?? []).toHaveLength(0);
+
+        const foodAfter = await clientA
+          .from('food_diary_entries')
+          .select('episode_id')
+          .eq('id', foodEntryId as string)
+          .single();
+        expect(foodAfter.error).toBeNull();
+        expect(foodAfter.data?.episode_id).toBeNull();
+      });
+
+      it('deletes completed episodes via the general delete helper', async () => {
+        const startedAt = new Date(Date.now() - 60_000).toISOString();
+        const endedAt = new Date().toISOString();
+        const ep = await createEpisode(clientA, {
+          user_id: userAId,
+          started_at: startedAt,
+          ended_at: endedAt,
+          symptom_preset_id: symptomPresetId,
+          health_marker_preset_id: healthMarkerPresetId,
+        });
+        expect(ep.ok).toBe(true);
+        if (!ep.ok) {
+          return;
+        }
+
+        const deleted = await deleteEpisodeById(clientA, ep.data.id);
+        expect(deleted.ok).toBe(true);
+        if (!deleted.ok) {
+          return;
+        }
+        expect(deleted.data.didDelete).toBe(true);
+
+        const nowMissing = await getEpisodeById(clientA, ep.data.id);
+        expect(nowMissing.ok).toBe(true);
+        if (!nowMissing.ok) {
+          return;
+        }
+        expect(nowMissing.data).toBeNull();
+      });
     });
 
     describe('cross-user denial', () => {
@@ -357,6 +487,15 @@ describe.skipIf(!episodeFoundationReady)(
           return;
         }
         expect(got.data).toBeNull();
+      });
+
+      it('does not allow deleting other user episode rows', async () => {
+        const deleted = await deleteEpisodeById(clientB, victimEpisodeId);
+        expect(deleted.ok).toBe(true);
+        if (!deleted.ok) {
+          return;
+        }
+        expect(deleted.data.didDelete).toBe(false);
       });
     });
   },

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -78,6 +78,7 @@ export {
 export {
   cancelActiveEpisodeById,
   createEpisode,
+  deleteEpisodeById,
   endEpisodeIfStillActive,
   getActiveEpisodeForUser,
   getEpisodeById,

--- a/packages/supabase/src/lib/episode-data.spec.ts
+++ b/packages/supabase/src/lib/episode-data.spec.ts
@@ -3,6 +3,7 @@ import type { EpisodeInsert, EpisodeRow } from '@abstrack/types';
 import {
   cancelActiveEpisodeById,
   createEpisode,
+  deleteEpisodeById,
   endEpisodeIfStillActive,
   getActiveEpisodeForUser,
   getEpisodeById,
@@ -290,15 +291,16 @@ describe('cancelActiveEpisodeById', () => {
       data: { id: 'ep-1' },
       error: null,
     }));
+    const is = vi.fn(() => ({
+      select: vi.fn(() => ({
+        maybeSingle,
+      })),
+    }));
     const client = {
       from: vi.fn(() => ({
         delete: vi.fn(() => ({
           eq: vi.fn(() => ({
-            is: vi.fn(() => ({
-              select: vi.fn(() => ({
-                maybeSingle,
-              })),
-            })),
+            is,
           })),
         })),
       })),
@@ -311,19 +313,21 @@ describe('cancelActiveEpisodeById', () => {
       expect(result.data.didCancel).toBe(true);
     }
     expect(client.from).toHaveBeenCalledWith('episodes');
+    expect(is).toHaveBeenCalledWith('ended_at', null);
   });
 
   it('returns didCancel false when the row was already ended (no row returned)', async () => {
     const maybeSingle = vi.fn(async () => ({ data: null, error: null }));
+    const is = vi.fn(() => ({
+      select: vi.fn(() => ({
+        maybeSingle,
+      })),
+    }));
     const client = {
       from: vi.fn(() => ({
         delete: vi.fn(() => ({
           eq: vi.fn(() => ({
-            is: vi.fn(() => ({
-              select: vi.fn(() => ({
-                maybeSingle,
-              })),
-            })),
+            is,
           })),
         })),
       })),
@@ -334,6 +338,57 @@ describe('cancelActiveEpisodeById', () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.data.didCancel).toBe(false);
+    }
+    expect(is).toHaveBeenCalledWith('ended_at', null);
+  });
+});
+
+describe('deleteEpisodeById', () => {
+  it('deletes the row regardless of ended_at state', async () => {
+    const maybeSingle = vi.fn(async () => ({
+      data: { id: 'ep-2' },
+      error: null,
+    }));
+    const client = {
+      from: vi.fn(() => ({
+        delete: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: vi.fn(() => ({
+              maybeSingle,
+            })),
+          })),
+        })),
+      })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await deleteEpisodeById(client, 'ep-2');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.didDelete).toBe(true);
+    }
+    expect(client.from).toHaveBeenCalledWith('episodes');
+  });
+
+  it('returns didDelete false when no row is visible/matched', async () => {
+    const maybeSingle = vi.fn(async () => ({ data: null, error: null }));
+    const client = {
+      from: vi.fn(() => ({
+        delete: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: vi.fn(() => ({
+              maybeSingle,
+            })),
+          })),
+        })),
+      })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await deleteEpisodeById(client, 'ep-missing');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.didDelete).toBe(false);
     }
   });
 });

--- a/packages/supabase/src/lib/episode-data.ts
+++ b/packages/supabase/src/lib/episode-data.ts
@@ -148,9 +148,14 @@ export async function endEpisodeIfStillActive(
 }
 
 /**
- * Permanently removes an episode only when it is still active (`ended_at IS NULL`). Uses the same
- * RLS as other `episodes` deletes. Related rows follow schema foreign-key behavior: some
- * episode-scoped tables cascade-delete, while others are unlinked via `SET NULL`.
+ * Permanently removes an episode only when it is still active (`ended_at IS NULL`). Use this for
+ * "cancel active episode" UX; completed rows can be removed with {@link deleteEpisodeById}.
+ *
+ * Uses the same RLS as other `episodes` deletes. Data impact is driven by schema foreign keys:
+ * - `episode_symptoms` rows for the episode are deleted (`ON DELETE CASCADE`).
+ * - `health_markers` rows linked to the episode are deleted (`ON DELETE CASCADE`).
+ * - `episode_media` metadata rows linked to the episode are deleted (`ON DELETE CASCADE`).
+ * - `food_diary_entries` rows are kept, but `episode_id` is cleared (`ON DELETE SET NULL`).
  *
  * @param client - Supabase client (RLS applies).
  * @param episodeId - `episodes.id` to cancel.
@@ -174,6 +179,40 @@ export async function cancelActiveEpisodeById(
       return { ok: false, error: toPresetDataError(error) };
     }
     return { ok: true, data: { didCancel: data != null } };
+  } catch (caught) {
+    return { ok: false, error: toPresetDataError(caught) };
+  }
+}
+
+/**
+ * Permanently removes an episode regardless of active/completed status when RLS allows.
+ *
+ * Data impact is driven by schema foreign keys:
+ * - `episode_symptoms` rows for the episode are deleted (`ON DELETE CASCADE`).
+ * - `health_markers` rows linked to the episode are deleted (`ON DELETE CASCADE`).
+ * - `episode_media` metadata rows linked to the episode are deleted (`ON DELETE CASCADE`).
+ * - `food_diary_entries` rows are kept, but `episode_id` is cleared (`ON DELETE SET NULL`).
+ *
+ * @param client - Supabase client (RLS applies).
+ * @param episodeId - `episodes.id` to delete.
+ * @returns On success, `didDelete` is `true` when one row was removed; `false` when no visible
+ * row matched (not found or blocked by RLS).
+ */
+export async function deleteEpisodeById(
+  client: AbstrackSupabaseClient,
+  episodeId: Uuid,
+): Promise<PresetDataResult<{ didDelete: boolean }>> {
+  try {
+    const { data, error } = await client
+      .from('episodes')
+      .delete()
+      .eq('id', episodeId)
+      .select('id')
+      .maybeSingle();
+    if (error) {
+      return { ok: false, error: toPresetDataError(error) };
+    }
+    return { ok: true, data: { didDelete: data != null } };
   } catch (caught) {
     return { ok: false, error: toPresetDataError(caught) };
   }


### PR DESCRIPTION
Closes #105

## Summary

- allow patients/caretakers to permanently delete both active and completed episodes under existing RLS rules
- add a general `deleteEpisodeById` helper while keeping `cancelActiveEpisodeById` for active-episode cancel UX
- add/refresh web + mobile destructive confirmations to clearly explain cascade impact: symptom answers, health markers, and media metadata are removed; food diary entries are retained but unlinked
- add completed-episode delete actions in episode history surfaces (web and mobile)
- update tests and policy docs to reflect full user control and verify allowed/blocked delete behavior

## Test plan

- [x] `pnpm vitest run packages/supabase/src/lib/episode-data.spec.ts packages/supabase/src/episode-foundation.integration.spec.ts`
- [x] `pnpm nx test mobile --runInBand -- --testPathPatterns EpisodesScreen.spec.tsx SymptomPromptScreen.spec.tsx`
- [x] verify changed-file lint diagnostics are clean
- [ ] manually verify web Episodes page: delete completed episode flow + confirmation copy + refresh behavior
- [ ] manually verify mobile Episodes screen: delete completed episode flow + confirmation copy + list refresh behavior
- [ ] (env-gated) run Supabase cloud integration tests with required env to exercise non-skipped integration cases