### PR TITLE
feat(episode): add explicit end flow with confirmation, duration display, and end-step resume routing

### DIFF
--- a/apps/mobile/src/app/components/episode-flow/EpisodeStartHomeCta.tsx
+++ b/apps/mobile/src/app/components/episode-flow/EpisodeStartHomeCta.tsx
@@ -3,15 +3,24 @@ import { Platform, Pressable, Text, View } from 'react-native';
 import { announce } from '@abstrack/ui/native';
 import { nw } from '../../theme/app-nativewind-classes';
 
-/** Active episode with the symptom preset needed to resume the prompt flow. */
-export type ActiveEpisodeHomeSummary = {
-  episodeId: string;
-  symptomPresetId: string;
-  /**
-   * When true, resume should open health markers directly (episode is at explicit end step).
-   */
-  resumeAtHealthMarkers?: boolean;
-};
+/**
+ * Active episode resume summary for the home CTA.
+ *
+ * - `resumeAtHealthMarkers: true` means the episode is at the explicit end step; symptom preset is
+ *   optional/irrelevant for this resume path.
+ * - Otherwise, resume enters symptom prompts and requires `symptomPresetId`.
+ */
+export type ActiveEpisodeHomeSummary =
+  | {
+      episodeId: string;
+      resumeAtHealthMarkers: true;
+      symptomPresetId?: string | null;
+    }
+  | {
+      episodeId: string;
+      resumeAtHealthMarkers?: false;
+      symptomPresetId: string;
+    };
 
 export type EpisodeStartHomeCtaProps = {
   /** Invoked when the user starts the episode flow (no active episode). */
@@ -116,7 +125,7 @@ export function EpisodeStartHomeCta({
         <Pressable
           accessibilityRole="button"
           accessibilityLabel="Continue this episode"
-          accessibilityHint="Opens your in-progress episode at the next symptom step"
+          accessibilityHint="Opens your in-progress episode at the next step"
           accessibilityState={{ disabled: false }}
           onPress={() => onResumeEpisode(activeEpisode)}
           className="min-h-[56px] items-center justify-center rounded-xl bg-red-700 px-4 py-4 active:opacity-90 dark:bg-red-600"

--- a/apps/mobile/src/app/components/episode-flow/EpisodeStartHomeCta.tsx
+++ b/apps/mobile/src/app/components/episode-flow/EpisodeStartHomeCta.tsx
@@ -7,6 +7,10 @@ import { nw } from '../../theme/app-nativewind-classes';
 export type ActiveEpisodeHomeSummary = {
   episodeId: string;
   symptomPresetId: string;
+  /**
+   * When true, resume should open health markers directly (episode is at explicit end step).
+   */
+  resumeAtHealthMarkers?: boolean;
 };
 
 export type EpisodeStartHomeCtaProps = {

--- a/apps/mobile/src/app/navigation/MainTabNavigator.tsx
+++ b/apps/mobile/src/app/navigation/MainTabNavigator.tsx
@@ -60,6 +60,13 @@ function navigateFromHomeTabToSymptomPromptResume(
       'MainTabNavigator: expected native stack parent (MainStack) to open SymptomPrompt.',
     );
   }
+  if (episode.resumeAtHealthMarkers) {
+    stackNavigation.navigate('HealthMarkerPrompt', {
+      episodeId: episode.episodeId,
+      resume: true,
+    });
+    return;
+  }
   stackNavigation.navigate('SymptomPrompt', {
     episodeId: episode.episodeId,
     symptomPresetId: episode.symptomPresetId,

--- a/apps/mobile/src/app/navigation/MainTabNavigator.tsx
+++ b/apps/mobile/src/app/navigation/MainTabNavigator.tsx
@@ -67,6 +67,11 @@ function navigateFromHomeTabToSymptomPromptResume(
     });
     return;
   }
+  if (!episode.symptomPresetId) {
+    throw new Error(
+      'MainTabNavigator: expected symptom preset id for symptom resume.',
+    );
+  }
   stackNavigation.navigate('SymptomPrompt', {
     episodeId: episode.episodeId,
     symptomPresetId: episode.symptomPresetId,

--- a/apps/mobile/src/app/navigation/MainTabNavigator.tsx
+++ b/apps/mobile/src/app/navigation/MainTabNavigator.tsx
@@ -49,7 +49,7 @@ function navigateFromHomeTabToEpisodeStart(
   stackNavigation.navigate('EpisodeStart');
 }
 
-function navigateFromHomeTabToSymptomPromptResume(
+function navigateFromHomeTabToEpisodeResume(
   navigation: BottomTabNavigationProp<MainTabParamList, 'Home'>,
   episode: ActiveEpisodeHomeSummary,
 ) {
@@ -57,7 +57,7 @@ function navigateFromHomeTabToSymptomPromptResume(
     navigation.getParent<NativeStackNavigationProp<MainStackParamList>>();
   if (stackNavigation == null) {
     throw new Error(
-      'MainTabNavigator: expected native stack parent (MainStack) to open SymptomPrompt.',
+      'MainTabNavigator: expected native stack parent (MainStack) to open episode resume flow.',
     );
   }
   if (episode.resumeAtHealthMarkers) {
@@ -161,7 +161,7 @@ export function MainTabNavigator() {
                 navigateFromHomeTabToEpisodeStart(navigation);
               }}
               onResumeEpisode={(episode) => {
-                navigateFromHomeTabToSymptomPromptResume(navigation, episode);
+                navigateFromHomeTabToEpisodeResume(navigation, episode);
               }}
             />
           )}

--- a/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
@@ -15,6 +15,7 @@ import {
   fetchEpisodeTemplates,
   getCurrentUserId,
 } from '../../lib/episode-templates/episode-template-service';
+import { clearSymptomPromptSession } from '../../lib/episodes/symptom-prompt-session-store';
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { saveEpisodeWithTemplatePresets } from '../../lib/episodes/episode-start-service';
 import { AsyncScreenContainer } from '../components/AsyncScreenContainer';
@@ -267,12 +268,18 @@ export function EpisodeStartScreen() {
     setEpisodeStartError(null);
     try {
       const supabase = getMobileSupabaseClient();
-      const end = await endEpisodeIfStillActive(supabase, row.id);
+      const end = await endEpisodeIfStillActive(
+        supabase,
+        row.id,
+        new Date().toISOString(),
+        row.started_at,
+      );
       if (!end.ok) {
         setEpisodeStartError(end.error.message);
         announce(end.error.message);
         return;
       }
+      clearSymptomPromptSession(row.id);
       // Reload start flow before any success announcement so UI matches server state; always await
       // `load` (fallback cancel token if focus ref is unset).
       await load(

--- a/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
@@ -248,8 +248,18 @@ export function EpisodeStartScreen() {
 
   const onResumeActiveEpisode = useCallback(() => {
     const row = blockingActiveEpisode;
-    const presetId = row?.symptom_preset_id;
-    if (!row || typeof presetId !== 'string' || !presetId) {
+    if (!row) {
+      return;
+    }
+    if (row.post_marker_step_completed_at) {
+      navigation.replace('HealthMarkerPrompt', {
+        episodeId: row.id,
+        resume: true,
+      });
+      return;
+    }
+    const presetId = row.symptom_preset_id;
+    if (typeof presetId !== 'string' || !presetId) {
       return;
     }
     navigation.replace('SymptomPrompt', {
@@ -307,8 +317,11 @@ export function EpisodeStartScreen() {
   }, [blockingActiveEpisode, load, resolvingActiveGate]);
 
   const gatePresetId = blockingActiveEpisode?.symptom_preset_id;
+  const gateAtEndStep =
+    blockingActiveEpisode?.post_marker_step_completed_at != null;
   const canResumeFromGate =
-    typeof gatePresetId === 'string' && gatePresetId.length > 0;
+    gateAtEndStep ||
+    (typeof gatePresetId === 'string' && gatePresetId.length > 0);
 
   return (
     <ScreenShell contentAlign="stretch">
@@ -356,7 +369,7 @@ export function EpisodeStartScreen() {
               <Pressable
                 accessibilityRole="button"
                 accessibilityLabel="Continue this episode"
-                accessibilityHint="Opens your in-progress episode at the next symptom step"
+                accessibilityHint="Opens your in-progress episode at the next step"
                 accessibilityState={{ disabled: resolvingActiveGate }}
                 disabled={resolvingActiveGate}
                 onPress={onResumeActiveEpisode}

--- a/apps/mobile/src/app/screens/EpisodesScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/EpisodesScreen.spec.tsx
@@ -195,7 +195,7 @@ describe('EpisodesScreen', () => {
   it('navigates to HealthMarkerPrompt when episode is at end step', async () => {
     const active = makeEpisodeRow({
       id: 'ep-end-step',
-      symptom_preset_id: 'preset-12',
+      symptom_preset_id: null,
       post_marker_step_completed_at: '2026-04-20T12:00:00.000Z',
     });
     jest.mocked(getActiveEpisodeForUser).mockResolvedValue({

--- a/apps/mobile/src/app/screens/EpisodesScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/EpisodesScreen.spec.tsx
@@ -192,6 +192,28 @@ describe('EpisodesScreen', () => {
     });
   });
 
+  it('navigates to HealthMarkerPrompt when episode is at end step', async () => {
+    const active = makeEpisodeRow({
+      id: 'ep-end-step',
+      symptom_preset_id: 'preset-12',
+      post_marker_step_completed_at: '2026-04-20T12:00:00.000Z',
+    });
+    jest.mocked(getActiveEpisodeForUser).mockResolvedValue({
+      ok: true,
+      data: active,
+    });
+
+    render(<EpisodesScreen />);
+
+    expect(await screen.findByLabelText('Resume this episode')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Resume this episode'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('HealthMarkerPrompt', {
+      episodeId: 'ep-end-step',
+      resume: true,
+    });
+  });
+
   it('renders recent ended episodes when list returns rows', async () => {
     const ended = makeEpisodeRow({
       id: 'ep-ended',

--- a/apps/mobile/src/app/screens/EpisodesScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodesScreen.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useRef, useState } from 'react';
 import { Alert, Pressable, ScrollView, Text, View } from 'react-native';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import type { EpisodeRow } from '@abstrack/types';
+import { formatEpisodeDurationSimple, type EpisodeRow } from '@abstrack/types';
 import { announce } from '@abstrack/ui/native';
 import {
   cancelActiveEpisodeById,
@@ -14,7 +14,6 @@ import { clearSymptomPromptSession } from '../../lib/episodes/symptom-prompt-ses
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { ScreenShell } from '../components/ScreenShell';
 import type { MainStackParamList } from '../navigation/types';
-import type { ActiveEpisodeHomeSummary } from '../components/episode-flow/EpisodeStartHomeCta';
 import { nw } from '../theme/app-nativewind-classes';
 
 type EpisodesNav = NativeStackNavigationProp<MainStackParamList, 'Episodes'>;
@@ -128,10 +127,20 @@ export function EpisodesScreen() {
     }, [load]),
   );
 
-  const onResume = (episode: ActiveEpisodeHomeSummary) => {
+  const onResume = (episode: EpisodeRow) => {
+    if (episode.post_marker_step_completed_at) {
+      navigation.navigate('HealthMarkerPrompt', {
+        episodeId: episode.id,
+        resume: true,
+      });
+      return;
+    }
+    if (!episode.symptom_preset_id) {
+      return;
+    }
     navigation.navigate('SymptomPrompt', {
-      episodeId: episode.episodeId,
-      symptomPresetId: episode.symptomPresetId,
+      episodeId: episode.id,
+      symptomPresetId: episode.symptom_preset_id,
       resume: true,
     });
   };
@@ -231,14 +240,6 @@ export function EpisodesScreen() {
     [deletingEpisodeId, load],
   );
 
-  const resumeSummary: ActiveEpisodeHomeSummary | null =
-    active && active.symptom_preset_id
-      ? {
-          episodeId: active.id,
-          symptomPresetId: active.symptom_preset_id,
-        }
-      : null;
-
   return (
     <ScreenShell contentAlign="stretch">
       <ScrollView
@@ -311,11 +312,11 @@ export function EpisodesScreen() {
               >
                 Ended —
               </Text>
-              {resumeSummary ? (
+              {active.symptom_preset_id ? (
                 <Pressable
                   accessibilityRole="button"
                   accessibilityLabel="Resume this episode"
-                  onPress={() => onResume(resumeSummary)}
+                  onPress={() => onResume(active)}
                   className={`mt-2 min-h-[52px] items-center justify-center rounded-xl bg-emerald-700 px-4 py-3 dark:bg-emerald-600`}
                 >
                   <Text className="text-center text-[17px] font-semibold text-white">
@@ -397,6 +398,11 @@ export function EpisodesScreen() {
                   </Text>
                   <Text className={`text-sm ${nw.textMuted}`}>
                     Ended {ep.ended_at ? formatInstant(ep.ended_at) : '—'}
+                  </Text>
+                  <Text className={`text-sm ${nw.textMuted}`}>
+                    Duration{' '}
+                    {formatEpisodeDurationSimple(ep.started_at, ep.ended_at) ??
+                      '—'}
                   </Text>
                   <Pressable
                     accessibilityRole="button"

--- a/apps/mobile/src/app/screens/EpisodesScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodesScreen.tsx
@@ -312,7 +312,8 @@ export function EpisodesScreen() {
               >
                 Ended —
               </Text>
-              {active.symptom_preset_id ? (
+              {active.post_marker_step_completed_at ||
+              active.symptom_preset_id ? (
                 <Pressable
                   accessibilityRole="button"
                   accessibilityLabel="Resume this episode"

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.spec.tsx
@@ -5,6 +5,7 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 import {
   cancelActiveEpisodeById,
   completeEpisodePostMarkerStep,
+  endEpisodeIfStillActive,
   getEpisodeById,
   listEpisodeHealthMarkersForEpisode,
   listPresetHealthMarkersForPreset,
@@ -32,6 +33,7 @@ jest.mock('@abstrack/supabase', () => {
     ...actual,
     cancelActiveEpisodeById: jest.fn(),
     completeEpisodePostMarkerStep: jest.fn(),
+    endEpisodeIfStillActive: jest.fn(),
     getEpisodeById: jest.fn(),
     listEpisodeHealthMarkersForEpisode: jest.fn(),
     listPresetHealthMarkersForPreset: jest.fn(),
@@ -184,6 +186,10 @@ describe('HealthMarkerPromptScreen', () => {
         created_at: '2020-01-01T00:00:00Z',
         updated_at: '2020-01-01T01:00:00Z',
       },
+    });
+    jest.mocked(endEpisodeIfStillActive).mockResolvedValue({
+      ok: true,
+      data: { didEnd: true },
     });
   });
 
@@ -348,11 +354,11 @@ describe('HealthMarkerPromptScreen', () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          /Preset prompts and episode details for this episode are saved/,
+          /Preset prompts and episode details are saved\. End this episode to prevent stale resume state\./,
         ),
       ).toBeTruthy();
     });
-    expect(screen.getByLabelText('Return to home')).toBeTruthy();
+    expect(screen.getByLabelText('End episode')).toBeTruthy();
   });
 
   test('post-marker save failure shows postFeedback', async () => {

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -28,18 +28,21 @@ import type {
 } from '@abstrack/types';
 import {
   bacReadingSuggestsAbsEpisode,
+  formatEpisodeDurationSimple,
   PRESET_HEALTH_MARKER_KIND_LABELS,
   validatePresetHealthMarkerCustomFields,
 } from '@abstrack/types';
 import {
   cancelActiveEpisodeById,
   completeEpisodePostMarkerStep,
+  endEpisodeIfStillActive,
   getEpisodeById,
   listEpisodeHealthMarkersForEpisode,
   listPresetHealthMarkersForPreset,
   upsertEpisodeHealthMarkerForLine,
 } from '@abstrack/supabase';
 import { announce, COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
+import { clearSymptomPromptSession } from '../../lib/episodes/symptom-prompt-session-store';
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { AsyncScreenContainer } from '../components/AsyncScreenContainer';
 import { ScreenShell } from '../components/ScreenShell';
@@ -201,6 +204,12 @@ export function HealthMarkerPromptScreen() {
   const [postNote, setPostNote] = useState('');
   const [savingPost, setSavingPost] = useState(false);
   const [postFeedback, setPostFeedback] = useState<string | null>(null);
+  const [endingEpisode, setEndingEpisode] = useState(false);
+  const [endFeedback, setEndFeedback] = useState<string | null>(null);
+  const [endedSummary, setEndedSummary] = useState<{
+    endedAt: string;
+    durationText: string | null;
+  } | null>(null);
   const postFormInitRef = useRef(false);
   const [cancelingEpisode, setCancelingEpisode] = useState(false);
 
@@ -236,6 +245,8 @@ export function HealthMarkerPromptScreen() {
     setPhase('prompting');
     postFormInitRef.current = false;
     setPostFeedback(null);
+    setEndFeedback(null);
+    setEndedSummary(null);
 
     const {
       data: { user },
@@ -270,6 +281,15 @@ export function HealthMarkerPromptScreen() {
       return;
     }
     setEpisodeRow(episode.data);
+    if (episode.data?.ended_at) {
+      setEndedSummary({
+        endedAt: episode.data.ended_at,
+        durationText: formatEpisodeDurationSimple(
+          episode.data.started_at,
+          episode.data.ended_at,
+        ),
+      });
+    }
 
     const [presetLines, markerRows] = await Promise.all([
       listPresetHealthMarkersForPreset(supabase, markerPresetId),
@@ -483,6 +503,8 @@ export function HealthMarkerPromptScreen() {
       return;
     }
     setEpisodeRow(result.data);
+    setEndFeedback(null);
+    setEndedSummary(null);
     setPhase('complete');
     await announce('Episode details saved.', { politeness: 'polite' });
   };
@@ -495,6 +517,97 @@ export function HealthMarkerPromptScreen() {
       }),
     );
   };
+
+  const onEndEpisode = useCallback(async () => {
+    if (endingEpisode) {
+      return;
+    }
+    if (!episodeRow) {
+      const message = 'Could not find this episode. Please try again.';
+      setEndFeedback(message);
+      await announce(message, { politeness: 'assertive' });
+      return;
+    }
+    setEndingEpisode(true);
+    setEndFeedback(null);
+    try {
+      const nowIso = new Date().toISOString();
+      const startedAtMs = Date.parse(episodeRow.started_at);
+      const nowMs = Date.parse(nowIso);
+      const endedAt =
+        Number.isFinite(startedAtMs) &&
+        Number.isFinite(nowMs) &&
+        nowMs < startedAtMs
+          ? episodeRow.started_at
+          : nowIso;
+      const result = await endEpisodeIfStillActive(
+        supabase,
+        episodeId,
+        endedAt,
+        episodeRow.started_at,
+      );
+      if (!result.ok) {
+        setEndFeedback(result.error.message);
+        await announce(result.error.message, { politeness: 'assertive' });
+        return;
+      }
+      clearSymptomPromptSession(episodeId);
+      if (result.data.didEnd) {
+        const durationText = formatEpisodeDurationSimple(
+          episodeRow.started_at,
+          endedAt,
+        );
+        setEpisodeRow((prev) => (prev ? { ...prev, ended_at: endedAt } : prev));
+        setEndedSummary({ endedAt, durationText });
+        await announce(
+          durationText
+            ? `Episode ended. Duration ${durationText}.`
+            : 'Episode ended.',
+          { politeness: 'polite' },
+        );
+        return;
+      }
+      const latest = await getEpisodeById(supabase, episodeId);
+      if (latest.ok && latest.data?.ended_at) {
+        const durationText = formatEpisodeDurationSimple(
+          latest.data.started_at,
+          latest.data.ended_at,
+        );
+        setEpisodeRow(latest.data);
+        setEndedSummary({ endedAt: latest.data.ended_at, durationText });
+        await announce('This episode was already ended.', {
+          politeness: 'polite',
+        });
+        return;
+      }
+      const message =
+        'This episode is no longer active. Return home and refresh episodes.';
+      setEndFeedback(message);
+      await announce(message, { politeness: 'assertive' });
+    } finally {
+      setEndingEpisode(false);
+    }
+  }, [endingEpisode, episodeId, episodeRow, supabase]);
+
+  const onRequestEndEpisode = useCallback(() => {
+    if (endingEpisode || endedSummary) {
+      return;
+    }
+    Alert.alert(
+      'End this episode now?',
+      'Ending sets this episode as complete and removes resume progress from this device. You can still view it in history.',
+      [
+        { text: 'Not yet', style: 'cancel' },
+        {
+          text: 'End episode',
+          style: 'destructive',
+          onPress: () => {
+            void onEndEpisode();
+          },
+        },
+      ],
+    );
+  }, [endedSummary, endingEpisode, onEndEpisode]);
 
   const onCancelEpisodePress = () => {
     if (cancelingEpisode) {
@@ -576,24 +689,74 @@ export function HealthMarkerPromptScreen() {
 
         {phase === 'complete' ? (
           <View className="gap-4" accessibilityLiveRegion="polite">
-            <Text
-              className={`text-base leading-relaxed ${nw.textInk}`}
-              maxFontSizeMultiplier={2}
-            >
-              Preset prompts and episode details for this episode are saved. You
-              can return home when you are ready.
-            </Text>
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Return to home"
-              onPress={onFinishToHome}
-              style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-              className="items-center justify-center rounded-xl bg-red-700 px-4 py-4 active:opacity-90 dark:bg-red-600"
-            >
-              <Text className="text-center text-[17px] font-semibold text-white">
-                Return home
+            {endedSummary ? (
+              <>
+                <Text
+                  className={`text-base leading-relaxed ${nw.textInk}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  This episode is ended and saved.
+                </Text>
+                <Text
+                  className={`text-sm ${nw.textMuted}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  Ended {new Date(endedSummary.endedAt).toLocaleString()}
+                </Text>
+                <Text
+                  className={`text-sm ${nw.textMuted}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  Duration {endedSummary.durationText ?? '—'}
+                </Text>
+              </>
+            ) : (
+              <Text
+                className={`text-base leading-relaxed ${nw.textInk}`}
+                maxFontSizeMultiplier={2}
+              >
+                Preset prompts and episode details are saved. End this episode
+                to prevent stale resume state.
               </Text>
-            </Pressable>
+            )}
+            {endFeedback ? (
+              <Text
+                className={`text-sm ${nw.textError}`}
+                accessibilityLiveRegion="assertive"
+                maxFontSizeMultiplier={2}
+              >
+                {endFeedback}
+              </Text>
+            ) : null}
+            {endedSummary ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Return to home"
+                onPress={onFinishToHome}
+                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                className="items-center justify-center rounded-xl bg-red-700 px-4 py-4 active:opacity-90 dark:bg-red-600"
+              >
+                <Text className="text-center text-[17px] font-semibold text-white">
+                  Return home
+                </Text>
+              </Pressable>
+            ) : (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={
+                  endingEpisode ? 'Ending episode' : 'End episode'
+                }
+                accessibilityState={{ disabled: endingEpisode }}
+                disabled={endingEpisode}
+                onPress={onRequestEndEpisode}
+                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                className="items-center justify-center rounded-xl bg-red-700 px-4 py-4 active:opacity-90 disabled:opacity-60 dark:bg-red-600"
+              >
+                <Text className="text-center text-[17px] font-semibold text-white">
+                  {endingEpisode ? 'Ending episode…' : 'End episode'}
+                </Text>
+              </Pressable>
+            )}
           </View>
         ) : phase === 'postMarkers' ? (
           <>

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -635,6 +635,7 @@ export function HealthMarkerPromptScreen() {
                   });
                   return;
                 }
+                clearSymptomPromptSession(episodeId);
                 if (result.data.didCancel) {
                   await announce(
                     'Episode canceled. Resume is no longer available.',

--- a/apps/mobile/src/app/screens/HomeScreen.tsx
+++ b/apps/mobile/src/app/screens/HomeScreen.tsx
@@ -81,6 +81,8 @@ export function HomeScreen({
         setActiveEpisode({
           episodeId: result.data.id,
           symptomPresetId: result.data.symptom_preset_id,
+          resumeAtHealthMarkers:
+            result.data.post_marker_step_completed_at != null,
         });
       } catch {
         if (!stale()) {

--- a/apps/mobile/src/app/screens/HomeScreen.tsx
+++ b/apps/mobile/src/app/screens/HomeScreen.tsx
@@ -74,15 +74,29 @@ export function HomeScreen({
         if (stale()) {
           return;
         }
-        if (!result.ok || !result.data?.symptom_preset_id) {
+        if (!result.ok || !result.data) {
           setActiveEpisode(null);
+          return;
+        }
+        const hasSymptomResumePath = !!result.data.symptom_preset_id;
+        const hasEndStepResumePath =
+          result.data.post_marker_step_completed_at != null;
+        if (!hasSymptomResumePath && !hasEndStepResumePath) {
+          setActiveEpisode(null);
+          return;
+        }
+        if (hasEndStepResumePath) {
+          setActiveEpisode({
+            episodeId: result.data.id,
+            resumeAtHealthMarkers: true,
+            symptomPresetId: result.data.symptom_preset_id,
+          });
           return;
         }
         setActiveEpisode({
           episodeId: result.data.id,
-          symptomPresetId: result.data.symptom_preset_id,
-          resumeAtHealthMarkers:
-            result.data.post_marker_step_completed_at != null,
+          symptomPresetId: result.data.symptom_preset_id as string,
+          resumeAtHealthMarkers: false,
         });
       } catch {
         if (!stale()) {

--- a/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
@@ -250,7 +250,10 @@ export function EpisodeStartFlow() {
 
   if (blockingActiveEpisode) {
     const presetId = blockingActiveEpisode.symptom_preset_id;
-    const canResume = typeof presetId === 'string' && presetId.length > 0;
+    const isAtEndStep =
+      blockingActiveEpisode.post_marker_step_completed_at != null;
+    const canResume =
+      isAtEndStep || (typeof presetId === 'string' && presetId.length > 0);
     const gateStatusId = `episode-start-active-gate-status${groupLegendId}`;
     const primaryLinkClass =
       'inline-flex min-h-[56px] w-full items-center justify-center rounded-xl bg-red-700 px-5 py-4 text-center text-base font-semibold leading-snug text-white shadow-md outline-none ring-2 ring-transparent transition hover:bg-red-800 focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-red-50 dark:bg-red-600 dark:hover:bg-red-500 dark:focus-visible:ring-offset-red-950';
@@ -293,8 +296,7 @@ export function EpisodeStartFlow() {
           {canResume ? (
             <Link
               href={buildResumeEpisodeHref(blockingActiveEpisode.id, presetId, {
-                toHealthMarkers:
-                  blockingActiveEpisode.post_marker_step_completed_at != null,
+                toHealthMarkers: isAtEndStep,
               })}
               className={primaryLinkClass}
               aria-describedby={gateStatusId}

--- a/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
@@ -15,6 +15,7 @@ import {
 } from '@abstrack/supabase';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { buildResumeEpisodeHref } from '@/lib/episode-flow/resume-episode-href';
+import { clearSymptomPromptSession } from '@/lib/episode-flow/symptom-prompt-session-store';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { useAuth } from '@/lib/auth-provider';
 import { PageLoading } from '@/components/page-states/PageLoading';
@@ -150,12 +151,15 @@ export function EpisodeStartFlow() {
       const end = await endEpisodeIfStillActive(
         supabase,
         blockingActiveEpisode.id,
+        new Date().toISOString(),
+        blockingActiveEpisode.started_at,
       );
       if (!end.ok) {
         setSubmitError(end.error.message);
         announce(end.error.message, { politeness: 'assertive' });
         return;
       }
+      clearSymptomPromptSession(blockingActiveEpisode.id);
       await refresh();
       if (!end.data.didEnd) {
         return;
@@ -288,7 +292,10 @@ export function EpisodeStartFlow() {
         <div className="flex flex-col gap-3 sm:max-w-md">
           {canResume ? (
             <Link
-              href={buildResumeEpisodeHref(blockingActiveEpisode.id, presetId)}
+              href={buildResumeEpisodeHref(blockingActiveEpisode.id, presetId, {
+                toHealthMarkers:
+                  blockingActiveEpisode.post_marker_step_completed_at != null,
+              })}
               className={primaryLinkClass}
               aria-describedby={gateStatusId}
             >

--- a/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
@@ -65,7 +65,11 @@ export function EpisodeStartHomeCta({
       const row = result.data;
       const presetId = row?.symptom_preset_id ?? null;
       if (row && presetId) {
-        setResumeHref(buildResumeEpisodeHref(row.id, presetId));
+        setResumeHref(
+          buildResumeEpisodeHref(row.id, presetId, {
+            toHealthMarkers: row.post_marker_step_completed_at != null,
+          }),
+        );
         setCtaMode('resume');
         return;
       }

--- a/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
@@ -64,7 +64,7 @@ export function EpisodeStartHomeCta({
       }
       const row = result.data;
       const presetId = row?.symptom_preset_id ?? null;
-      if (row && presetId) {
+      if (row && (row.post_marker_step_completed_at != null || presetId)) {
         setResumeHref(
           buildResumeEpisodeHref(row.id, presetId, {
             toHealthMarkers: row.post_marker_step_completed_at != null,

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -581,6 +581,7 @@ export function HealthMarkerPromptFlow({
         announce(result.error.message, { politeness: 'assertive' });
         return false;
       }
+      clearSymptomPromptSession(episodeId);
       if (result.data.didCancel) {
         announce('Episode canceled. Resume is no longer available.', {
           politeness: 'polite',

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -11,12 +11,14 @@ import type {
 } from '@abstrack/types';
 import {
   bacReadingSuggestsAbsEpisode,
+  formatEpisodeDurationSimple,
   PRESET_HEALTH_MARKER_KIND_LABELS,
   validatePresetHealthMarkerCustomFields,
 } from '@abstrack/types';
 import {
   cancelActiveEpisodeById,
   completeEpisodePostMarkerStep,
+  endEpisodeIfStillActive,
   getEpisodeById,
   listEpisodeHealthMarkersForEpisode,
   listPresetHealthMarkersForPreset,
@@ -24,6 +26,8 @@ import {
 } from '@abstrack/supabase';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
+import { clearSymptomPromptSession } from '@/lib/episode-flow/symptom-prompt-session-store';
+import { EpisodeLocaleInstant } from '@/components/episodes/EpisodeLocaleInstant';
 import { ConfirmDialog } from '../symptom-presets/ConfirmDialog';
 
 type MarkerDraft = {
@@ -188,6 +192,13 @@ export function HealthMarkerPromptFlow({
   const [postNote, setPostNote] = useState('');
   const [savingPost, setSavingPost] = useState(false);
   const [postFeedback, setPostFeedback] = useState<string | null>(null);
+  const [endingEpisode, setEndingEpisode] = useState(false);
+  const [endDialogOpen, setEndDialogOpen] = useState(false);
+  const [endFeedback, setEndFeedback] = useState<string | null>(null);
+  const [endedSummary, setEndedSummary] = useState<{
+    endedAt: string;
+    durationText: string | null;
+  } | null>(null);
   const postFormInitRef = useRef(false);
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
   const [cancelingEpisode, setCancelingEpisode] = useState(false);
@@ -222,6 +233,8 @@ export function HealthMarkerPromptFlow({
     setPhase('prompting');
     postFormInitRef.current = false;
     setPostFeedback(null);
+    setEndFeedback(null);
+    setEndedSummary(null);
     const {
       data: { user },
     } = await supabase.auth.getUser();
@@ -255,6 +268,15 @@ export function HealthMarkerPromptFlow({
       return;
     }
     setEpisodeRow(episode.data);
+    if (episode.data?.ended_at) {
+      setEndedSummary({
+        endedAt: episode.data.ended_at,
+        durationText: formatEpisodeDurationSimple(
+          episode.data.started_at,
+          episode.data.ended_at,
+        ),
+      });
+    }
 
     const [presetLines, markerRows] = await Promise.all([
       listPresetHealthMarkersForPreset(supabase, markerPresetId),
@@ -465,6 +487,8 @@ export function HealthMarkerPromptFlow({
       return;
     }
     setEpisodeRow(result.data);
+    setEndFeedback(null);
+    setEndedSummary(null);
     setPhase('complete');
     announce('Episode details saved.', { politeness: 'polite' });
   };
@@ -472,6 +496,76 @@ export function HealthMarkerPromptFlow({
   const onFinishToDashboard = () => {
     router.push('/dashboard');
   };
+
+  const onEndEpisode = useCallback(async (): Promise<void | false> => {
+    if (endingEpisode) {
+      return false;
+    }
+    if (!episodeRow) {
+      const message = 'Could not find this episode. Please try again.';
+      setEndFeedback(message);
+      announce(message, { politeness: 'assertive' });
+      return false;
+    }
+    setEndingEpisode(true);
+    setEndFeedback(null);
+    try {
+      const nowIso = new Date().toISOString();
+      const startedAtMs = Date.parse(episodeRow.started_at);
+      const nowMs = Date.parse(nowIso);
+      const endedAt =
+        Number.isFinite(startedAtMs) &&
+        Number.isFinite(nowMs) &&
+        nowMs < startedAtMs
+          ? episodeRow.started_at
+          : nowIso;
+      const result = await endEpisodeIfStillActive(
+        supabase,
+        episodeId,
+        endedAt,
+        episodeRow.started_at,
+      );
+      if (!result.ok) {
+        setEndFeedback(result.error.message);
+        announce(result.error.message, { politeness: 'assertive' });
+        return false;
+      }
+      clearSymptomPromptSession(episodeId);
+      if (result.data.didEnd) {
+        const durationText = formatEpisodeDurationSimple(
+          episodeRow.started_at,
+          endedAt,
+        );
+        setEpisodeRow((prev) => (prev ? { ...prev, ended_at: endedAt } : prev));
+        setEndedSummary({ endedAt, durationText });
+        announce(
+          durationText
+            ? `Episode ended. Duration ${durationText}.`
+            : 'Episode ended.',
+          { politeness: 'polite' },
+        );
+        return;
+      }
+      const latest = await getEpisodeById(supabase, episodeId);
+      if (latest.ok && latest.data?.ended_at) {
+        const durationText = formatEpisodeDurationSimple(
+          latest.data.started_at,
+          latest.data.ended_at,
+        );
+        setEpisodeRow(latest.data);
+        setEndedSummary({ endedAt: latest.data.ended_at, durationText });
+        announce('This episode was already ended.', { politeness: 'polite' });
+        return;
+      }
+      const message =
+        'This episode is no longer active. Return to dashboard and refresh episodes.';
+      setEndFeedback(message);
+      announce(message, { politeness: 'assertive' });
+      return false;
+    } finally {
+      setEndingEpisode(false);
+    }
+  }, [announce, endingEpisode, episodeId, episodeRow, supabase]);
 
   const onCancelEpisodeConfirm = async (): Promise<void | false> => {
     if (cancelingEpisode) {
@@ -693,28 +787,74 @@ export function HealthMarkerPromptFlow({
 
   if (phase === 'complete') {
     return (
-      <div className="space-y-4">
-        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
-          Episode health markers
-        </h1>
-        <div
-          className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
-          role="status"
-          aria-live="polite"
-        >
-          <p className="text-sm leading-relaxed text-app-ink">
-            Preset prompts and episode details for this episode are saved. You
-            can return to the dashboard when you are ready.
-          </p>
+      <>
+        <div className="space-y-4">
+          <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+            Episode health markers
+          </h1>
+          <div
+            className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
+            role="status"
+            aria-live="polite"
+          >
+            {endedSummary ? (
+              <div className="space-y-2">
+                <p className="text-sm leading-relaxed text-app-ink">
+                  This episode is ended and saved.
+                </p>
+                <p className="text-sm text-app-muted">
+                  Ended <EpisodeLocaleInstant iso={endedSummary.endedAt} />
+                </p>
+                <p className="text-sm text-app-muted">
+                  Duration {endedSummary.durationText ?? '—'}
+                </p>
+              </div>
+            ) : (
+              <p className="text-sm leading-relaxed text-app-ink">
+                Preset prompts and episode details are saved. End this episode
+                to prevent stale resume state.
+              </p>
+            )}
+          </div>
+          {endFeedback ? (
+            <p className="text-sm text-red-700 dark:text-red-300" role="alert">
+              {endFeedback}
+            </p>
+          ) : null}
+          {endedSummary ? (
+            <button
+              type="button"
+              className="inline-flex min-h-[56px] items-center justify-center rounded-xl bg-red-700 px-5 text-base font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:bg-red-600 dark:hover:bg-red-500"
+              onClick={onFinishToDashboard}
+            >
+              Back to dashboard
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="inline-flex min-h-[56px] items-center justify-center rounded-xl bg-red-700 px-5 text-base font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60 dark:bg-red-600 dark:hover:bg-red-500"
+              onClick={() => {
+                setEndDialogOpen(true);
+              }}
+              disabled={endingEpisode}
+            >
+              {endingEpisode ? 'Ending episode…' : 'End episode'}
+            </button>
+          )}
         </div>
-        <button
-          type="button"
-          className="inline-flex min-h-[56px] items-center justify-center rounded-xl bg-red-700 px-5 text-base font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:bg-red-600 dark:hover:bg-red-500"
-          onClick={onFinishToDashboard}
-        >
-          Back to dashboard
-        </button>
-      </div>
+        <ConfirmDialog
+          open={endDialogOpen}
+          title="End this episode now?"
+          description="Ending sets this episode as complete and removes resume progress from this device. You can still view it in history."
+          confirmLabel="End episode"
+          confirmBusyLabel="Ending episode…"
+          cancelLabel="Not yet"
+          onConfirm={onEndEpisode}
+          onClose={() => {
+            setEndDialogOpen(false);
+          }}
+        />
+      </>
     );
   }
 

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -497,15 +497,16 @@ export function HealthMarkerPromptFlow({
     router.push('/dashboard');
   };
 
-  const onEndEpisode = useCallback(async (): Promise<void | false> => {
+  const onEndEpisode = useCallback(async (): Promise<void> => {
     if (endingEpisode) {
-      return false;
+      return;
     }
     if (!episodeRow) {
       const message = 'Could not find this episode. Please try again.';
+      setEndDialogOpen(false);
       setEndFeedback(message);
       announce(message, { politeness: 'assertive' });
-      return false;
+      return;
     }
     setEndingEpisode(true);
     setEndFeedback(null);
@@ -526,9 +527,10 @@ export function HealthMarkerPromptFlow({
         episodeRow.started_at,
       );
       if (!result.ok) {
+        setEndDialogOpen(false);
         setEndFeedback(result.error.message);
         announce(result.error.message, { politeness: 'assertive' });
-        return false;
+        return;
       }
       clearSymptomPromptSession(episodeId);
       if (result.data.didEnd) {
@@ -559,9 +561,10 @@ export function HealthMarkerPromptFlow({
       }
       const message =
         'This episode is no longer active. Return to dashboard and refresh episodes.';
+      setEndDialogOpen(false);
       setEndFeedback(message);
       announce(message, { politeness: 'assertive' });
-      return false;
+      return;
     } finally {
       setEndingEpisode(false);
     }

--- a/apps/web/src/components/episodes/ActiveEpisodeCard.tsx
+++ b/apps/web/src/components/episodes/ActiveEpisodeCard.tsx
@@ -80,7 +80,8 @@ export function ActiveEpisodeCard({ episode }: { episode: EpisodeRow }) {
           </div>
         </dl>
         <div className="mt-5 space-y-3">
-          {episode.symptom_preset_id ? (
+          {episode.post_marker_step_completed_at ||
+          episode.symptom_preset_id ? (
             <Link
               href={buildResumeEpisodeHref(
                 episode.id,

--- a/apps/web/src/components/episodes/ActiveEpisodeCard.tsx
+++ b/apps/web/src/components/episodes/ActiveEpisodeCard.tsx
@@ -85,6 +85,10 @@ export function ActiveEpisodeCard({ episode }: { episode: EpisodeRow }) {
               href={buildResumeEpisodeHref(
                 episode.id,
                 episode.symptom_preset_id,
+                {
+                  toHealthMarkers:
+                    episode.post_marker_step_completed_at != null,
+                },
               )}
               className={resumeLinkClass}
             >

--- a/apps/web/src/components/episodes/RecentEpisodesList.tsx
+++ b/apps/web/src/components/episodes/RecentEpisodesList.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { deleteEpisodeById } from '@abstrack/supabase';
-import type { EpisodeRow } from '@abstrack/types';
+import { formatEpisodeDurationSimple, type EpisodeRow } from '@abstrack/types';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { formatEpisodeTypeSummary } from '@/lib/episodes/format-episode-meta';
@@ -87,6 +87,13 @@ export function RecentEpisodesList({ episodes }: RecentEpisodesListProps) {
                     ) : (
                       '—'
                     )}
+                  </dd>
+                </div>
+                <div className="flex flex-wrap gap-x-2">
+                  <dt className="font-medium text-app-ink/80">Duration</dt>
+                  <dd>
+                    {formatEpisodeDurationSimple(ep.started_at, ep.ended_at) ??
+                      '—'}
                   </dd>
                 </div>
               </dl>

--- a/apps/web/src/lib/episode-flow/resume-episode-href.spec.ts
+++ b/apps/web/src/lib/episode-flow/resume-episode-href.spec.ts
@@ -10,9 +10,15 @@ describe('buildResumeEpisodeHref', () => {
   });
 
   it('builds direct health-marker resume link when requested', () => {
-    const href = buildResumeEpisodeHref('ep-uuid', 'sym-uuid', {
+    const href = buildResumeEpisodeHref('ep-uuid', null, {
       toHealthMarkers: true,
     });
     expect(href).toBe('/episode/ep-uuid/health-markers?resume=1');
+  });
+
+  it('throws when symptom resume has no symptomPresetId', () => {
+    expect(() => buildResumeEpisodeHref('ep-uuid', null)).toThrow(
+      'buildResumeEpisodeHref requires symptomPresetId when resuming to symptoms.',
+    );
   });
 });

--- a/apps/web/src/lib/episode-flow/resume-episode-href.spec.ts
+++ b/apps/web/src/lib/episode-flow/resume-episode-href.spec.ts
@@ -3,8 +3,16 @@ import { buildResumeEpisodeHref } from './resume-episode-href';
 describe('buildResumeEpisodeHref', () => {
   it('includes episode id, symptomPresetId, and resume=1', () => {
     const href = buildResumeEpisodeHref('ep-uuid', 'sym-uuid');
-    expect(href).toBe(
-      '/episode/ep-uuid/symptoms?symptomPresetId=sym-uuid&resume=1',
-    );
+    const url = new URL(`https://example.test${href}`);
+    expect(url.pathname).toBe('/episode/ep-uuid/symptoms');
+    expect(url.searchParams.get('symptomPresetId')).toBe('sym-uuid');
+    expect(url.searchParams.get('resume')).toBe('1');
+  });
+
+  it('builds direct health-marker resume link when requested', () => {
+    const href = buildResumeEpisodeHref('ep-uuid', 'sym-uuid', {
+      toHealthMarkers: true,
+    });
+    expect(href).toBe('/episode/ep-uuid/health-markers?resume=1');
   });
 });

--- a/apps/web/src/lib/episode-flow/resume-episode-href.ts
+++ b/apps/web/src/lib/episode-flow/resume-episode-href.ts
@@ -19,13 +19,18 @@ export type BuildResumeEpisodeHrefOptions = {
  */
 export function buildResumeEpisodeHref(
   episodeId: string,
-  symptomPresetId: string,
+  symptomPresetId: string | null,
   options: BuildResumeEpisodeHrefOptions = {},
 ): string {
   const q = new URLSearchParams();
   q.set('resume', '1');
   if (options.toHealthMarkers) {
     return `/episode/${episodeId}/health-markers?${q.toString()}`;
+  }
+  if (!symptomPresetId) {
+    throw new Error(
+      'buildResumeEpisodeHref requires symptomPresetId when resuming to symptoms.',
+    );
   }
   q.set('symptomPresetId', symptomPresetId);
   return `/episode/${episodeId}/symptoms?${q.toString()}`;

--- a/apps/web/src/lib/episode-flow/resume-episode-href.ts
+++ b/apps/web/src/lib/episode-flow/resume-episode-href.ts
@@ -1,19 +1,32 @@
+export type BuildResumeEpisodeHrefOptions = {
+  /**
+   * When true, resume enters `/health-markers` directly. Use this for episodes that already
+   * completed post-marker details and only need explicit ending.
+   */
+  toHealthMarkers?: boolean;
+};
+
 /**
- * Builds the `/episode/[id]/symptoms` URL for continuing an active episode: `symptomPresetId`
- * selects the preset, and `resume=1` tells the symptom prompt flow to hydrate with resume logic.
- * The step index is **not** in the query string; it is computed in the flow from merged server +
- * session answers (and related resume handling).
+ * Builds a resume URL for an active episode.
+ *
+ * `resume=1` tells flows to hydrate with resume logic. The symptom step index is not encoded in the
+ * URL; the symptom flow computes it from merged server + session answers.
  *
  * @param episodeId - `episodes.id`.
- * @param symptomPresetId - `symptom_presets.id` on the episode row.
- * @returns Path under `/episode/[id]/symptoms`.
+ * @param symptomPresetId - `symptom_presets.id` on the episode row (ignored for health-marker resumes).
+ * @param options - Optional destination override.
+ * @returns Path under `/episode/[id]/symptoms` or `/episode/[id]/health-markers`.
  */
 export function buildResumeEpisodeHref(
   episodeId: string,
   symptomPresetId: string,
+  options: BuildResumeEpisodeHrefOptions = {},
 ): string {
   const q = new URLSearchParams();
-  q.set('symptomPresetId', symptomPresetId);
   q.set('resume', '1');
+  if (options.toHealthMarkers) {
+    return `/episode/${episodeId}/health-markers?${q.toString()}`;
+  }
+  q.set('symptomPresetId', symptomPresetId);
   return `/episode/${episodeId}/symptoms?${q.toString()}`;
 }

--- a/packages/supabase/src/lib/episode-data.spec.ts
+++ b/packages/supabase/src/lib/episode-data.spec.ts
@@ -294,6 +294,38 @@ describe('endEpisodeIfStillActive', () => {
       expect(result.data.didEnd).toBe(false);
     }
   });
+
+  it('clamps ended_at to started_at when ended_at would be earlier', async () => {
+    const update = vi.fn(() => ({
+      eq: vi.fn(() => ({
+        is: vi.fn(() => ({
+          select: vi.fn(() => ({
+            maybeSingle: vi.fn(async () => ({
+              data: { id: 'ep-1' },
+              error: null,
+            })),
+          })),
+        })),
+      })),
+    }));
+    const client = {
+      from: vi.fn(() => ({
+        update,
+      })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const startedAt = '2026-04-20T12:00:00.000Z';
+    const endedAt = '2026-04-20T11:00:00.000Z';
+    const result = await endEpisodeIfStillActive(
+      client,
+      'ep-1',
+      endedAt,
+      startedAt,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(update).toHaveBeenCalledWith({ ended_at: startedAt });
+  });
 });
 
 describe('cancelActiveEpisodeById', () => {

--- a/packages/supabase/src/lib/episode-data.ts
+++ b/packages/supabase/src/lib/episode-data.ts
@@ -162,11 +162,14 @@ export async function endEpisodeIfStillActive(
   startedAt?: string,
 ): Promise<PresetDataResult<{ didEnd: boolean }>> {
   try {
+    const startedAtMs =
+      typeof startedAt === 'string' ? Date.parse(startedAt) : Number.NaN;
+    const endedAtMs = Date.parse(endedAt);
     const safeEndedAt =
       typeof startedAt === 'string' &&
-      Number.isFinite(Date.parse(startedAt)) &&
-      Number.isFinite(Date.parse(endedAt)) &&
-      Date.parse(endedAt) < Date.parse(startedAt)
+      Number.isFinite(startedAtMs) &&
+      Number.isFinite(endedAtMs) &&
+      endedAtMs < startedAtMs
         ? startedAt
         : endedAt;
     const { data, error } = await client

--- a/packages/supabase/src/lib/episode-data.ts
+++ b/packages/supabase/src/lib/episode-data.ts
@@ -149,6 +149,7 @@ export async function listCompletedEpisodesForUser(
  * @param client - Supabase client (RLS applies).
  * @param episodeId - `episodes.id` to close.
  * @param endedAt - Timestamp for `ended_at` (defaults to now, ISO string).
+ * @param startedAt - Optional `started_at` floor; when provided and parseable, `ended_at` is clamped so it is not earlier.
  * @returns On success, `didEnd` is `true` if exactly one active row was updated. `didEnd` is
  * `false` when the update matched no rows: e.g. the episode was already ended, `episodeId` does
  * not exist, or RLS hid the row from the update. Callers must not treat `didEnd: false` as proof
@@ -158,11 +159,19 @@ export async function endEpisodeIfStillActive(
   client: AbstrackSupabaseClient,
   episodeId: Uuid,
   endedAt: string = new Date().toISOString(),
+  startedAt?: string,
 ): Promise<PresetDataResult<{ didEnd: boolean }>> {
   try {
+    const safeEndedAt =
+      typeof startedAt === 'string' &&
+      Number.isFinite(Date.parse(startedAt)) &&
+      Number.isFinite(Date.parse(endedAt)) &&
+      Date.parse(endedAt) < Date.parse(startedAt)
+        ? startedAt
+        : endedAt;
     const { data, error } = await client
       .from('episodes')
-      .update({ ended_at: endedAt })
+      .update({ ended_at: safeEndedAt })
       .eq('id', episodeId)
       .is('ended_at', null)
       .select('id')

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/abs-symptom-suggestions.js';
+export * from './lib/episode-duration.js';
 export * from './lib/episode-template.js';
 export * from './lib/symptom-prompt-session.js';
 export * from './lib/symptom-prompt-session-sanitize.js';

--- a/packages/types/src/lib/episode-duration.spec.ts
+++ b/packages/types/src/lib/episode-duration.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { formatEpisodeDurationSimple } from './episode-duration.js';
+
+describe('formatEpisodeDurationSimple', () => {
+  it('returns null when ended_at is missing', () => {
+    expect(
+      formatEpisodeDurationSimple('2026-04-22T10:00:00.000Z', null),
+    ).toBeNull();
+  });
+
+  it('returns null for invalid timestamps', () => {
+    expect(formatEpisodeDurationSimple('bad', '2026-04-22T11:00:00.000Z')).toBe(
+      null,
+    );
+    expect(formatEpisodeDurationSimple('2026-04-22T10:00:00.000Z', 'bad')).toBe(
+      null,
+    );
+  });
+
+  it('returns null when ended_at is before started_at', () => {
+    expect(
+      formatEpisodeDurationSimple(
+        '2026-04-22T11:00:00.000Z',
+        '2026-04-22T10:59:00.000Z',
+      ),
+    ).toBeNull();
+  });
+
+  it('formats minutes, hours, and days with simple wording', () => {
+    expect(
+      formatEpisodeDurationSimple(
+        '2026-04-22T10:00:00.000Z',
+        '2026-04-22T10:05:00.000Z',
+      ),
+    ).toBe('5 minutes');
+    expect(
+      formatEpisodeDurationSimple(
+        '2026-04-22T10:00:00.000Z',
+        '2026-04-22T11:05:00.000Z',
+      ),
+    ).toBe('1 hour 5 minutes');
+    expect(
+      formatEpisodeDurationSimple(
+        '2026-04-22T10:00:00.000Z',
+        '2026-04-23T12:01:00.000Z',
+      ),
+    ).toBe('1 day 2 hours 1 minute');
+  });
+
+  it('returns less than one minute for short spans', () => {
+    expect(
+      formatEpisodeDurationSimple(
+        '2026-04-22T10:00:00.000Z',
+        '2026-04-22T10:00:40.000Z',
+      ),
+    ).toBe('Less than 1 minute');
+  });
+});

--- a/packages/types/src/lib/episode-duration.ts
+++ b/packages/types/src/lib/episode-duration.ts
@@ -1,0 +1,42 @@
+/**
+ * Formats an episode span in a simple spoken-friendly form.
+ *
+ * @param startedAt - Episode start timestamp (`episodes.started_at`).
+ * @param endedAt - Episode end timestamp (`episodes.ended_at`).
+ * @returns Duration text such as `1 hour 12 minutes`, or `null` for invalid data.
+ */
+export function formatEpisodeDurationSimple(
+  startedAt: string,
+  endedAt: string | null | undefined,
+): string | null {
+  if (!endedAt) {
+    return null;
+  }
+  const startMs = Date.parse(startedAt);
+  const endMs = Date.parse(endedAt);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) {
+    return null;
+  }
+  const diffMs = endMs - startMs;
+  if (diffMs < 0) {
+    return null;
+  }
+  const totalMinutes = Math.floor(diffMs / 60000);
+  if (totalMinutes <= 0) {
+    return 'Less than 1 minute';
+  }
+  const days = Math.floor(totalMinutes / (24 * 60));
+  const hours = Math.floor((totalMinutes % (24 * 60)) / 60);
+  const minutes = totalMinutes % 60;
+  const parts: string[] = [];
+  if (days > 0) {
+    parts.push(days === 1 ? '1 day' : `${days} days`);
+  }
+  if (hours > 0) {
+    parts.push(hours === 1 ? '1 hour' : `${hours} hours`);
+  }
+  if (minutes > 0) {
+    parts.push(minutes === 1 ? '1 minute' : `${minutes} minutes`);
+  }
+  return parts.join(' ');
+}


### PR DESCRIPTION
Closes #95

## Summary

- Add an explicit **End episode** step after post-marker details on web and mobile, including confirmation to reduce accidental endings.
- Persist `ended_at` with safety clamping (`ended_at >= started_at`), and show a simple, impaired-friendly duration derived from `started_at`/`ended_at`.
- Ensure stale episode prompt/session state is cleared on end-related flows and improve resume routing so episodes already at the end step reopen directly there.

## What Changed

- **Explicit end action**
  - Web: updated `HealthMarkerPromptFlow` completion phase to require explicit end before returning to dashboard.
  - Mobile: updated `HealthMarkerPromptScreen` completion phase to require explicit end before returning home.

- **Accidental-end protection**
  - Web: added `ConfirmDialog` before executing end.
  - Mobile: added native `Alert` confirmation before executing end.

- **Timestamp persistence and safety**
  - Extended `endEpisodeIfStillActive` to accept optional `startedAt` floor and clamp `ended_at` when needed.
  - Added/updated call sites to pass `started_at` where available.

- **Duration display**
  - Added `formatEpisodeDurationSimple` utility in `@abstrack/types`.
  - Display duration in recent episode history (web + mobile) and in post-end completion summaries.

- **Ephemeral state cleanup**
  - Clear symptom prompt session state when ending/canceling in all relevant paths (web sessionStorage + mobile in-memory store).

- **Resume behavior improvements**
  - Added resume URL option to route directly to `/health-markers?resume=1` when episode is already at end step.
  - Updated web/mobile “Continue this episode” entry points to use health-marker resume when `post_marker_step_completed_at` is set.

- **Tests**
  - Added tests for duration formatting.
  - Added tests for `ended_at` clamping behavior.
  - Updated/extended web/mobile resume and flow tests to match explicit end step and routing behavior.

## Acceptance Criteria Mapping

- [x] `ended_at` persisted on the episode row when user completes end action.
- [x] Duration shown in a simple, impaired-friendly format.
- [x] Prompt session keys/state removed or invalidated per app patterns.

## Notes

- This implementation keeps post-marker detail save and end-episode responsibilities ordered and separate: save details first, then explicit end.
- No changes were made to episode type/notes ownership beyond existing post-marker detail save behavior.